### PR TITLE
Pipeline runs on FOOTYSTATS_KEY alone (auto-discover chosen leagues)

### DIFF
--- a/supabase/functions/_shared/footystats.ts
+++ b/supabase/functions/_shared/footystats.ts
@@ -84,6 +84,28 @@ export async function fetchLeagueList(key: string): Promise<FootyStatsLeague[]> 
   return Array.isArray(json?.data) ? json.data : [];
 }
 
+/**
+ * The leagues chosen on the FootyStats account, each mapped to its latest season
+ * id. Used as a fallback when FOOTYSTATS_SEASON_IDS isn't configured, so the whole
+ * pipeline runs on FOOTYSTATS_KEY alone.
+ */
+export async function fetchChosenLeagues(key: string): Promise<{ id: number; name: string }[]> {
+  // deno-lint-ignore no-explicit-any
+  const json = await getJson(`/league-list?key=${key}&chosen_leagues_only=true`);
+  // deno-lint-ignore no-explicit-any
+  const rows: any[] = Array.isArray(json?.data) ? json.data : [];
+  const out: { id: number; name: string }[] = [];
+  for (const lg of rows) {
+    const name = String(lg?.league_name ?? lg?.name ?? "").trim();
+    // deno-lint-ignore no-explicit-any
+    const seasons: any[] = Array.isArray(lg?.season) ? lg.season : [];
+    if (!seasons.length) continue;
+    const latest = seasons.reduce((a, b) => (Number(b?.year) > Number(a?.year) ? b : a));
+    if (latest?.id) out.push({ id: Number(latest.id), name: name || `League ${latest.id}` });
+  }
+  return out;
+}
+
 // ── Market <-> FootyStats field maps (verified against the API) ─────────────
 /** over-% field per market label (works on lastx + league-teams stat objects). */
 const OVER_PCT_FIELD: Record<string, string> = {

--- a/supabase/functions/build-form-tables/index.ts
+++ b/supabase/functions/build-form-tables/index.ts
@@ -7,7 +7,7 @@
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchUpcomingMatches, fetchLeagueMatchesDetailed, type TodayFixture, type DetailedMatch } from "../_shared/footystats.ts";
+import { fetchUpcomingMatches, fetchLeagueMatchesDetailed, fetchChosenLeagues, type TodayFixture, type DetailedMatch } from "../_shared/footystats.ts";
 import { buildFormTables, buildHistory, type TeamFormStats } from "../_shared/formTableRows.ts";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, content-type" };
@@ -42,6 +42,10 @@ serve(async (req) => {
   const formFor = (id: number, name: string) => byId.get(id) ?? byName.get(name) ?? null;
 
   const names = leagueNames();
+  // Fallback: no FOOTYSTATS_SEASON_IDS -> discover the account's chosen leagues from the key.
+  if (!Object.keys(names).length) {
+    for (const lg of await fetchChosenLeagues(fsKey)) names[lg.id] = lg.name;
+  }
   const today = new Date().toISOString().slice(0, 10);
   const leagueIds = Object.keys(names).map(Number).filter(Boolean);
 

--- a/supabase/functions/gaffer-daily-pick/index.ts
+++ b/supabase/functions/gaffer-daily-pick/index.ts
@@ -7,7 +7,7 @@
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchTodaysMatches, type TodayFixture } from "../_shared/footystats.ts";
+import { fetchTodaysMatches, fetchChosenLeagues, type TodayFixture } from "../_shared/footystats.ts";
 import { selectDailyPicks, type Fixture, type TeamForm, type Candidate } from "../_shared/gafferEngine.ts";
 import { gafferReason, gafferPickLine, gafferNoBetLine, type Market, type PickSignals } from "../_shared/gafferVoice.ts";
 
@@ -87,6 +87,10 @@ serve(async (req) => {
   }
 
   const names = leagueNames();
+  // Fallback: no FOOTYSTATS_SEASON_IDS -> discover the account's chosen leagues from the key (for labels).
+  if (!Object.keys(names).length) {
+    for (const lg of await fetchChosenLeagues(fsKey)) names[lg.id] = lg.name;
+  }
   const fixtures = await fetchTodaysMatches(fsKey);
   const fxById = new Map<number | string, TodayFixture>();
   const engineFixtures: Fixture[] = [];

--- a/supabase/functions/ingest-form-stats/index.ts
+++ b/supabase/functions/ingest-form-stats/index.ts
@@ -6,7 +6,7 @@
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchLeagueTeams, fetchLast10 } from "../_shared/footystats.ts";
+import { fetchLeagueTeams, fetchLast10, fetchChosenLeagues } from "../_shared/footystats.ts";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, content-type" };
 const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { ...corsHeaders, "Content-Type": "application/json" } });
@@ -27,7 +27,9 @@ serve(async (req) => {
 
   let body: { leagues?: { id: number; name: string }[] } = {};
   try { body = await req.json(); } catch { /* no body */ }
-  const leagues = body.leagues?.length ? body.leagues : configuredLeagues();
+  let leagues = body.leagues?.length ? body.leagues : configuredLeagues();
+  // Fallback: no FOOTYSTATS_SEASON_IDS configured -> discover the account's chosen leagues from the key.
+  if (!leagues.length) leagues = await fetchChosenLeagues(fsKey);
   if (!leagues.length) return json({ ok: false, error: "no leagues configured" }, 400);
 
   let upserts = 0; const errors: string[] = [];


### PR DESCRIPTION
`ingest-form-stats`, `build-form-tables` and `gaffer-daily-pick` now fall back to FootyStats' **chosen-leagues** list (fetched with the API key) when `FOOTYSTATS_SEASON_IDS` isn't set. So the daily form tables + Gaffer picks work on **`FOOTYSTATS_KEY` alone** — no second secret needed, and the daily cron works too. New `_shared/fetchChosenLeagues()` helper. Transform-checked all three functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fallback that automatically loads your chosen leagues when league names aren’t configured, helping daily picks, form tables, and form stats continue to work.
  * Improved league selection so the latest season is used when available, with cleaner league names shown to users.

* **Bug Fixes**
  * Prevents empty league lists from blocking routine football data workflows.
  * Adds a more reliable backup path before returning an error when league data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->