### PR TITLE
Hero: "The Gaffer" as a real handwritten signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,10 +117,10 @@
     <!-- Preload font to prevent FOUT layout shifts -->
     <link rel="preload" as="font" type="font/woff2" href="/fonts/outfit-latin.woff2" crossorigin />
 
-    <!-- Display fonts for the Club homepage headlines (Anton = condensed impact, Caveat = handwritten accent) -->
+    <!-- Display fonts for the Club homepage headlines (Anton = condensed impact, Caveat/Dancing Script = handwritten signature) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Dancing+Script:wght@600;700&display=swap" />
 
     <!-- Preload LCP image for faster Largest Contentful Paint -->
     <link rel="preload" as="image" href="/images/the-gaffer.webp" fetchpriority="high" />

--- a/src/components/homepage/HeroBanner.tsx
+++ b/src/components/homepage/HeroBanner.tsx
@@ -40,10 +40,10 @@ export function HeroBanner() {
         />
         <div aria-hidden className="absolute inset-x-0 bottom-0 hidden h-2/5 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/40 to-transparent md:block" />
 
-        {/* DESKTOP — The Gaffer's signature across the scene */}
+        {/* DESKTOP — The Gaffer's handwritten signature across the scene */}
         <span
           aria-hidden
-          className="pointer-events-none absolute right-[7%] top-[54%] z-[1] hidden -rotate-[7deg] font-['Caveat'] text-7xl font-bold text-[#f8e7a1] [text-shadow:0_3px_22px_rgba(245,197,66,0.5),0_1px_2px_rgba(0,0,0,0.7)] md:block lg:text-8xl"
+          className="pointer-events-none absolute right-[6%] top-[56%] z-[1] hidden -rotate-[8deg] font-['Dancing_Script'] text-[5.5rem] font-semibold leading-none text-white/95 [text-shadow:0_2px_10px_rgba(0,0,0,0.55)] md:block lg:text-[7rem]"
         >
           The Gaffer
         </span>
@@ -56,10 +56,10 @@ export function HeroBanner() {
             style={{ backgroundImage: `url(${HERO_SCENE})` }}
           >
             <div className="absolute inset-0 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/25 to-transparent" />
-            {/* MOBILE — The Gaffer's signature across the scene */}
+            {/* MOBILE — The Gaffer's handwritten signature across the scene */}
             <span
               aria-hidden
-              className="pointer-events-none absolute bottom-3 left-4 -rotate-[7deg] font-['Caveat'] text-5xl font-bold text-[#f8e7a1] [text-shadow:0_3px_18px_rgba(245,197,66,0.5),0_1px_2px_rgba(0,0,0,0.7)] sm:text-6xl"
+              className="pointer-events-none absolute bottom-3 left-4 -rotate-[8deg] font-['Dancing_Script'] text-6xl font-semibold leading-none text-white/95 [text-shadow:0_2px_10px_rgba(0,0,0,0.6)] sm:text-7xl"
             >
               The Gaffer
             </span>


### PR DESCRIPTION
Swaps the blocky gold Caveat for a flowing **Dancing Script** autograph in soft white ink with a marker shadow — reads like a genuine handwritten signature across the scene, desktop and mobile. Loads Dancing Script alongside the existing homepage fonts. Touches `HeroBanner.tsx` + `index.html` (font link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_