### PR TITLE
Hero: remove "The Gaffer" signature overlay

### DIFF
--- a/src/components/homepage/HeroBanner.tsx
+++ b/src/components/homepage/HeroBanner.tsx
@@ -40,14 +40,6 @@ export function HeroBanner() {
         />
         <div aria-hidden className="absolute inset-x-0 bottom-0 hidden h-2/5 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/40 to-transparent md:block" />
 
-        {/* DESKTOP — The Gaffer's handwritten signature across the scene */}
-        <span
-          aria-hidden
-          className="pointer-events-none absolute right-[6%] top-[56%] z-[1] hidden -rotate-[8deg] font-['Dancing_Script'] text-[5.5rem] font-semibold leading-none text-white/95 [text-shadow:0_2px_10px_rgba(0,0,0,0.55)] md:block lg:text-[7rem]"
-        >
-          The Gaffer
-        </span>
-
         <div className="relative flex flex-col md:min-h-[660px] md:justify-between md:gap-8">
           {/* MOBILE scene banner — the Gaffer shown clearly up top, fading into the copy */}
           <div
@@ -56,13 +48,6 @@ export function HeroBanner() {
             style={{ backgroundImage: `url(${HERO_SCENE})` }}
           >
             <div className="absolute inset-0 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/25 to-transparent" />
-            {/* MOBILE — The Gaffer's handwritten signature across the scene */}
-            <span
-              aria-hidden
-              className="pointer-events-none absolute bottom-3 left-4 -rotate-[8deg] font-['Dancing_Script'] text-6xl font-semibold leading-none text-white/95 [text-shadow:0_2px_10px_rgba(0,0,0,0.6)] sm:text-7xl"
-            >
-              The Gaffer
-            </span>
           </div>
 
           {/* copy */}


### PR DESCRIPTION
Removes the "The Gaffer" signature overlay from the hero (desktop + mobile). Only `HeroBanner.tsx` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_