### PR TITLE
Pipeline: auto-target leagues playing next 3 days + fix league names

### DIFF
--- a/supabase/functions/_shared/footystats.ts
+++ b/supabase/functions/_shared/footystats.ts
@@ -96,7 +96,9 @@ export async function fetchChosenLeagues(key: string): Promise<{ id: number; nam
   const rows: any[] = Array.isArray(json?.data) ? json.data : [];
   const out: { id: number; name: string }[] = [];
   for (const lg of rows) {
-    const name = String(lg?.league_name ?? lg?.name ?? "").trim();
+    // NB: `league_name` comes back as "" for chosen leagues; the real label is `name`
+    // ("Iceland Úrvalsdeild"). Use || (not ??) so an empty string falls through.
+    const name = String(lg?.name || lg?.league_name || "").trim();
     // deno-lint-ignore no-explicit-any
     const seasons: any[] = Array.isArray(lg?.season) ? lg.season : [];
     if (!seasons.length) continue;
@@ -104,6 +106,59 @@ export async function fetchChosenLeagues(key: string): Promise<{ id: number; nam
     if (latest?.id) out.push({ id: Number(latest.id), name: name || `League ${latest.id}` });
   }
   return out;
+}
+
+/**
+ * Every season id → its league label ("Iceland Úrvalsdeild"), across all the
+ * account's chosen leagues. Used to resolve a fixture's league name from any
+ * season/competition id the API hands back — no per-league season guessing.
+ */
+export async function fetchSeasonNames(key: string): Promise<Record<number, string>> {
+  const json = await getJson(`/league-list?key=${key}&chosen_leagues_only=true`);
+  // deno-lint-ignore no-explicit-any
+  const rows: any[] = Array.isArray(json?.data) ? json.data : [];
+  const out: Record<number, string> = {};
+  for (const lg of rows) {
+    const name = String(lg?.name || lg?.league_name || "").trim();
+    if (!name) continue;
+    // deno-lint-ignore no-explicit-any
+    for (const s of (Array.isArray(lg?.season) ? lg.season : []) as any[]) {
+      if (s?.id != null) out[Number(s.id)] = name;
+    }
+  }
+  return out;
+}
+
+/** Matches scheduled on a given date (YYYY-MM-DD), across the chosen leagues. */
+export async function fetchMatchesOnDate(key: string, date: string): Promise<Record<string, unknown>[]> {
+  const json = await getJson(`/todays-matches?key=${key}&date=${date}`);
+  return Array.isArray(json?.data) ? json.data : [];
+}
+
+/** YYYY-MM-DD, n days from now (UTC). */
+function isoDatePlus(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * The leagues (season/competition ids) that actually have fixtures in the next
+ * `days` days — auto-discovered each run from today's-matches, so the pipeline
+ * only touches leagues in play (fast, and always current as seasons come/go).
+ */
+export async function fetchActiveLeagues(key: string, days = 3): Promise<{ id: number; name: string }[]> {
+  const names = await fetchSeasonNames(key);
+  const ids = new Set<number>();
+  for (let n = 0; n < days; n++) {
+    try {
+      for (const m of await fetchMatchesOnDate(key, isoDatePlus(n))) {
+        const id = Number((m as Record<string, unknown>).competition_id ?? (m as Record<string, unknown>).season_id);
+        if (Number.isFinite(id) && id > 0) ids.add(id);
+      }
+    } catch { /* skip a bad date, keep the rest */ }
+  }
+  return [...ids].map((id) => ({ id, name: names[id] ?? `League ${id}` }));
 }
 
 // ── Market <-> FootyStats field maps (verified against the API) ─────────────
@@ -265,8 +320,12 @@ export interface DetailedMatch {
 export async function fetchUpcomingMatches(seasonId: number, key: string): Promise<TodayFixture[]> {
   const json = await getJson(`/league-matches?key=${key}&season_id=${seasonId}`);
   const data: any[] = Array.isArray(json?.data) ? json.data : [];
+  // Upcoming fixtures — priced OR not. FootyStats usually only prices imminent
+  // games, so requiring odds would hide the next 2 days. Form tables rank by the
+  // teams' combined average (not odds), so unpriced games still belong; their
+  // odds columns simply render "—" until the book prices them.
   return data
-    .filter((m) => m.status !== "complete" && Object.keys(normalizeOdds(m)).length > 0)
+    .filter((m) => m.status !== "complete")
     .sort((a, b) => (a.date_unix ?? 0) - (b.date_unix ?? 0))
     .map((m) => ({
       fixtureId: m.id,

--- a/supabase/functions/build-form-tables/index.ts
+++ b/supabase/functions/build-form-tables/index.ts
@@ -7,7 +7,7 @@
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchUpcomingMatches, fetchLeagueMatchesDetailed, fetchChosenLeagues, type TodayFixture, type DetailedMatch } from "../_shared/footystats.ts";
+import { fetchUpcomingMatches, fetchLeagueMatchesDetailed, fetchActiveLeagues, fetchSeasonNames, type TodayFixture, type DetailedMatch } from "../_shared/footystats.ts";
 import { buildFormTables, buildHistory, type TeamFormStats } from "../_shared/formTableRows.ts";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, content-type" };
@@ -42,15 +42,18 @@ serve(async (req) => {
   const formFor = (id: number, name: string) => byId.get(id) ?? byName.get(name) ?? null;
 
   const names = leagueNames();
-  // Fallback: no FOOTYSTATS_SEASON_IDS -> discover the account's chosen leagues from the key.
-  if (!Object.keys(names).length) {
-    for (const lg of await fetchChosenLeagues(fsKey)) names[lg.id] = lg.name;
-  }
-  const today = new Date().toISOString().slice(0, 10);
-  const leagueIds = Object.keys(names).map(Number).filter(Boolean);
+  // No FOOTYSTATS_SEASON_IDS -> resolve every season id to its league label from
+  // the key (fixes "League 16696" showing instead of "Iceland Úrvalsdeild").
+  if (!Object.keys(names).length) Object.assign(names, await fetchSeasonNames(fsKey));
 
-  // 3-DAY WINDOW — today + next 2 days, priced fixtures across the leagues.
-  // The page ranks by combined average, caps top-20/league, tags today's games.
+  const today = new Date().toISOString().slice(0, 10);
+  // Only the leagues actually playing in the next 3 days (auto-discovered daily).
+  const active = await fetchActiveLeagues(fsKey, 3);
+  const leagueIds = active.map((l) => l.id);
+  for (const l of active) if (!names[l.id]) names[l.id] = l.name;
+
+  // 3-DAY WINDOW — today + next 2 days across the active leagues (priced or not;
+  // the page ranks by combined average, caps top-20/league, tags today's games).
   const windowEnd = new Date(new Date(today + "T12:00:00Z").getTime() + 2 * 86400000).toISOString().slice(0, 10);
   const upcoming = (await Promise.all(
     leagueIds.map((id) => fetchUpcomingMatches(id, fsKey).catch(() => [] as TodayFixture[])),

--- a/supabase/functions/gaffer-daily-pick/index.ts
+++ b/supabase/functions/gaffer-daily-pick/index.ts
@@ -7,7 +7,7 @@
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchTodaysMatches, fetchChosenLeagues, type TodayFixture } from "../_shared/footystats.ts";
+import { fetchTodaysMatches, fetchSeasonNames, type TodayFixture } from "../_shared/footystats.ts";
 import { selectDailyPicks, type Fixture, type TeamForm, type Candidate } from "../_shared/gafferEngine.ts";
 import { gafferReason, gafferPickLine, gafferNoBetLine, type Market, type PickSignals } from "../_shared/gafferVoice.ts";
 
@@ -87,10 +87,9 @@ serve(async (req) => {
   }
 
   const names = leagueNames();
-  // Fallback: no FOOTYSTATS_SEASON_IDS -> discover the account's chosen leagues from the key (for labels).
-  if (!Object.keys(names).length) {
-    for (const lg of await fetchChosenLeagues(fsKey)) names[lg.id] = lg.name;
-  }
+  // No FOOTYSTATS_SEASON_IDS -> resolve every season/competition id to its league
+  // label from the key, so today's picks show real names, not "League 16696".
+  if (!Object.keys(names).length) Object.assign(names, await fetchSeasonNames(fsKey));
   const fixtures = await fetchTodaysMatches(fsKey);
   const fxById = new Map<number | string, TodayFixture>();
   const engineFixtures: Fixture[] = [];

--- a/supabase/functions/ingest-form-stats/index.ts
+++ b/supabase/functions/ingest-form-stats/index.ts
@@ -1,12 +1,12 @@
 // ============================================================================
 // Footy Oracle — ingest-form-stats
-// Pulls last-10 form for every team in the configured leagues from FootyStats
-// and upserts it into form_tables (powers the form tables + the Gaffer engine).
-// Schedule daily. Needs FOOTYSTATS_KEY + the league season_ids configured.
+// Pulls last-10 form for every team in the leagues that actually have fixtures in
+// the next 3 days (auto-discovered) and upserts it into form_tables (powers the
+// form tables + the Gaffer engine). Schedule daily. Needs FOOTYSTATS_KEY.
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
-import { fetchLeagueTeams, fetchLast10, fetchChosenLeagues } from "../_shared/footystats.ts";
+import { fetchLeagueTeams, fetchLast10, fetchActiveLeagues } from "../_shared/footystats.ts";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, content-type" };
 const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { ...corsHeaders, "Content-Type": "application/json" } });
@@ -28,9 +28,10 @@ serve(async (req) => {
   let body: { leagues?: { id: number; name: string }[] } = {};
   try { body = await req.json(); } catch { /* no body */ }
   let leagues = body.leagues?.length ? body.leagues : configuredLeagues();
-  // Fallback: no FOOTYSTATS_SEASON_IDS configured -> discover the account's chosen leagues from the key.
-  if (!leagues.length) leagues = await fetchChosenLeagues(fsKey);
-  if (!leagues.length) return json({ ok: false, error: "no leagues configured" }, 400);
+  // Default: only the leagues with fixtures in the next 3 days (auto-discovered,
+  // so the daily run stays fast and always matches what's actually on).
+  if (!leagues.length) leagues = await fetchActiveLeagues(fsKey, 3);
+  if (!leagues.length) return json({ ok: false, error: "no active leagues in the next 3 days" }, 200);
 
   let upserts = 0; const errors: string[] = [];
   for (const lg of leagues) {


### PR DESCRIPTION
Makes the daily data pipeline auto-follow the live slate and fixes the two form-table issues.

**Auto-league detection (new feature)**
- `fetchActiveLeagues()` asks FootyStats `todays-matches` for today / +1 / +2 and collects the leagues that actually have fixtures, so `ingest-form-stats` and `build-form-tables` only touch leagues in play. No hardcoded league list — it updates itself daily and scales up as the European season starts.

**Fix "League 16696"**
- Chosen-leagues returns the label in `name` ("Iceland Úrvalsdeild") while `league_name` is `""`; the old `league_name ?? name` kept the empty string. Now uses `name`, plus a `fetchSeasonNames()` map (every season id → label) used by build + gaffer-pick.

**Show all 3 days**
- `fetchUpcomingMatches` no longer requires odds, so the next 2 days appear even before they're priced (odds render "—"). Form tables rank by combined average, not odds.

Verified against the live API: **12 active leagues** (all real names), **52 fixtures across 3 days** (5 / 15 / 32). Runs on the existing 02:00 UTC cron (ingest → build → pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_