### PR TITLE
Nav: make the logo link to the homepage

### DIFF
--- a/src/components/homepage/HomepageNav.tsx
+++ b/src/components/homepage/HomepageNav.tsx
@@ -29,7 +29,7 @@ export function HomepageNav() {
 
       <div className="border-b border-[#f5c542]/25 bg-[#130321]">
         <div className="mx-auto grid min-h-[82px] w-full max-w-[1480px] grid-cols-[auto_1fr_auto] items-center gap-3 px-3 py-2.5 md:min-h-[104px] md:px-6 md:py-4">
-          <a href="#top" aria-label="Footy Oracle home" className="group flex min-w-0 items-center gap-2.5 md:gap-4">
+          <a href="/" aria-label="Footy Oracle home" className="group flex min-w-0 items-center gap-2.5 md:gap-4">
             <span className="grid h-14 w-14 shrink-0 place-items-center overflow-hidden rounded-full border-2 border-[#f5c542] bg-[#07000f] shadow-[0_0_28px_rgba(245,197,66,0.22)] md:h-20 md:w-20">
               <img
                 src="/images/brand/footy-oracle-mark.png"


### PR DESCRIPTION
The header logo linked to `#top`, which does nothing on inner pages like `/form-tables`. Now it links to `/` so clicking it always returns to the homepage. Only `HomepageNav.tsx` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_