### PR TITLE
Form tables: correct 3-day slate + reject broken live feed

### DIFF
--- a/src/data/formTablesData.json
+++ b/src/data/formTablesData.json
@@ -1,24 +1,1011 @@
 {
   "leagues": [
     {
+      "name": "First Division",
+      "region": "Norway"
+    },
+    {
+      "name": "Esiliiga",
+      "region": "Estonia"
+    },
+    {
+      "name": "Meistriliiga",
+      "region": "Estonia"
+    },
+    {
+      "name": "Úrvalsdeild",
+      "region": "Iceland"
+    },
+    {
+      "name": "Chinese Super League",
+      "region": "China"
+    },
+    {
+      "name": "Ykkösliiga",
+      "region": "Finland"
+    },
+    {
       "name": "Allsvenskan",
       "region": "Sweden"
     },
     {
-      "name": "Urvalsdeild",
-      "region": "Iceland"
+      "name": "Premier Division",
+      "region": "Republic of Ireland"
+    },
+    {
+      "name": "China League One",
+      "region": "China"
+    },
+    {
+      "name": "K League 1",
+      "region": "South Korea"
+    },
+    {
+      "name": "K League 2",
+      "region": "South Korea"
+    },
+    {
+      "name": "Veikkausliiga",
+      "region": "Finland"
     }
   ],
   "fixtures": [
     {
+      "id": "8412462",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-02",
+      "time": "17:00",
+      "home": {
+        "name": "Lyn",
+        "short": "LYN",
+        "logo": "https://cdn.footystats.org/img/teams/norway-fc-lyn-oslo.png"
+      },
+      "away": {
+        "name": "Åsane",
+        "short": "ÅSA",
+        "logo": "https://cdn.footystats.org/img/teams/norway-asane-fotball.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 10.7,
+      "cards_avg": 2,
+      "btts_pct": 34.5,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 81,
+        "2.5": 65.5,
+        "3.5": 31,
+        "4.5": 19
+      },
+      "corners_over": {
+        "8.5": 77,
+        "9.5": 69,
+        "10.5": 42.5,
+        "11.5": 31
+      },
+      "cards_over": {
+        "2.5": 65.5,
+        "3.5": 50,
+        "4.5": 38.5,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": 1.51,
+        "3.5": 2.24,
+        "4.5": 3.9
+      },
+      "corners_odds": {
+        "8.5": 1.23,
+        "9.5": 1.58,
+        "10.5": 1.77
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.47,
+      "goals_under_odds": {
+        "0.5": 15.0,
+        "1.5": 5.25,
+        "2.5": 2.55,
+        "3.5": 1.58
+      },
+      "corners_under_odds": {
+        "8.5": 3.42,
+        "9.5": 2.47,
+        "10.5": 1.93,
+        "11.5": 1.7
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.4,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 65.5,
+            "odds": 1.51,
+            "implied": 66.2,
+            "edge": -0.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 31,
+            "odds": 2.24,
+            "implied": 44.6,
+            "edge": -13.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 19,
+            "odds": 3.9,
+            "implied": 25.6,
+            "edge": -6.6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 77,
+            "odds": 1.23,
+            "implied": 81.3,
+            "edge": -4.3,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 69,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": 5.7,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 42.5,
+            "odds": 1.77,
+            "implied": 56.5,
+            "edge": -14,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 34.5,
+          "odds": 1.47,
+          "implied": 68,
+          "edge": -33.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Hødd",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Ranheim",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Bryne",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Odd",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Strømmen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Egersund",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Kongsvinger",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Raufoss",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Ranheim",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Bryne",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Odd",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Kongsvinger",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Raufoss",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Sandnes Ulf",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Haugesund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Strømsgodset",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8464277",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-02",
+      "time": "17:00",
+      "home": {
+        "name": "Tartu JK Welco",
+        "short": "TAR",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tartu-jk-welco.png"
+      },
+      "away": {
+        "name": "Viimsi",
+        "short": "VII",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-viimsi-jk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 9,
+      "cards_avg": 1.7,
+      "btts_pct": 48.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 84.5,
+        "2.5": 54.5,
+        "3.5": 42,
+        "4.5": 26.5
+      },
+      "corners_over": {
+        "8.5": 45,
+        "9.5": 33,
+        "10.5": 23.5,
+        "11.5": 20.5
+      },
+      "cards_over": {
+        "2.5": 69.5,
+        "3.5": 41.5,
+        "4.5": 24,
+        "5.5": 17
+      },
+      "goals_odds": {
+        "2.5": 1.48,
+        "3.5": 2.23,
+        "4.5": 3.68
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.44,
+      "goals_under_odds": {
+        "0.5": 15.0,
+        "1.5": 6.0,
+        "2.5": 2.33,
+        "3.5": 1.54
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.5,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 54.5,
+            "odds": 1.48,
+            "implied": 67.6,
+            "edge": -13.1,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 42,
+            "odds": 2.23,
+            "implied": 44.8,
+            "edge": -2.8,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 26.5,
+            "odds": 3.68,
+            "implied": 27.2,
+            "edge": -0.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": {
+          "prob": 48.5,
+          "odds": 1.44,
+          "implied": 69.4,
+          "edge": -20.9,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-21",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "FC Tallinn",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 16,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-22",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-23",
+          "home": "Viimsi",
+          "away": "Tartu JK Welco",
+          "hg": 2,
+          "ag": 0,
+          "corners": 10,
+          "cards": 8
+        }
+      ]
+    },
+    {
+      "id": "8465697",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-02",
+      "time": "17:00",
+      "home": {
+        "name": "Kuressaare",
+        "short": "KUR",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-kuressaare.png"
+      },
+      "away": {
+        "name": "Tallinna FC Flora",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-flora.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 11.5,
+      "cards_avg": 1.7,
+      "btts_pct": 47,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 79.5,
+        "2.5": 64.5,
+        "3.5": 29.5,
+        "4.5": 15
+      },
+      "corners_over": {
+        "8.5": 88,
+        "9.5": 76.5,
+        "10.5": 67.5,
+        "11.5": 59
+      },
+      "cards_over": {
+        "2.5": 70.5,
+        "3.5": 49.5,
+        "4.5": 34.5,
+        "5.5": 23
+      },
+      "goals_odds": {
+        "2.5": 1.44,
+        "3.5": 1.89,
+        "4.5": 3.58
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": 1.23,
+        "10.5": 1.4
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.76,
+      "goals_under_odds": {
+        "0.5": 17.0,
+        "1.5": 3.5,
+        "2.5": 2.55,
+        "3.5": 1.49
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": 3.5,
+        "10.5": 2.65,
+        "11.5": 2.1
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.75,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 64.5,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": -4.9,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 29.5,
+            "odds": 1.89,
+            "implied": 52.9,
+            "edge": -23.4,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 15,
+            "odds": 3.58,
+            "implied": 27.9,
+            "edge": -12.9,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": {
+            "prob": 76.5,
+            "odds": 1.23,
+            "implied": 81.3,
+            "edge": -4.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 67.5,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -3.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 47,
+          "odds": 1.76,
+          "implied": 56.8,
+          "edge": -9.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 16,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 16,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Tallinna FC Levadia",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Nõmme United",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Trans",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Nõmme Kalju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 18,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-30",
+          "opp": "Harju Jalgpallikool",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-07",
+          "home": "Tallinna FC Flora",
+          "away": "Kuressaare",
+          "hg": 2,
+          "ag": 1,
+          "corners": 11,
+          "cards": 2
+        }
+      ]
+    },
+    {
       "id": "8447231",
-      "league": "Urvalsdeild",
+      "league": "Úrvalsdeild",
       "region": "Iceland",
       "date": "2026-07-02",
       "time": "18:00",
       "home": {
-        "name": "Thor",
-        "short": "THO",
+        "name": "Thór",
+        "short": "THÓ",
         "logo": "https://cdn.footystats.org/img/teams/iceland-thor-akureyri.png"
       },
       "away": {
@@ -33,16 +1020,16 @@
         "cards": 0,
         "btts": false
       },
-      "goals_avg": 4.8,
-      "corners_avg": 13.4,
-      "cards_avg": 4.6,
+      "goals_avg": 4.7,
+      "corners_avg": 13.3,
+      "cards_avg": 2.1,
       "btts_pct": 75,
       "goals_over": {
         "0.5": 100,
-        "1.5": 85,
-        "2.5": 80,
-        "3.5": 70,
-        "4.5": 60
+        "1.5": 87.5,
+        "2.5": 79.5,
+        "3.5": 71,
+        "4.5": 55
       },
       "corners_over": {
         "8.5": 80,
@@ -51,97 +1038,97 @@
         "11.5": 80
       },
       "cards_over": {
-        "2.5": 90,
-        "3.5": 65,
-        "4.5": 40,
-        "5.5": 30
+        "2.5": 91.5,
+        "3.5": 71,
+        "4.5": 31.5,
+        "5.5": 24
       },
       "goals_odds": {
-        "2.5": 1.11,
-        "3.5": 1.38,
-        "4.5": 1.95
+        "2.5": 1.14,
+        "3.5": 1.4,
+        "4.5": 2.04
       },
       "corners_odds": {
-        "8.5": 1.09,
-        "9.5": 1.3,
-        "10.5": 1.46
+        "8.5": 1.07,
+        "9.5": 1.2,
+        "10.5": 1.34
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.3,
+      "btts_odds": 1.22,
       "goals_under_odds": {
-        "0.5": 27,
-        "1.5": 11,
-        "2.5": 5.26,
-        "3.5": 2.62
+        "0.5": 27.0,
+        "1.5": 11.0,
+        "2.5": 4.5,
+        "3.5": 2.7
       },
       "corners_under_odds": {
-        "8.5": 5,
-        "9.5": 3.34,
-        "10.5": 2.46,
-        "11.5": 1.94
+        "8.5": 5.75,
+        "9.5": 4.01,
+        "10.5": 2.83,
+        "11.5": 2.18
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 3.1,
+      "btts_no_odds": 3.14,
       "value": {
         "goals": {
           "2.5": {
-            "prob": 80,
-            "odds": 1.11,
-            "implied": 90.1,
-            "edge": -10.1,
+            "prob": 79.5,
+            "odds": 1.14,
+            "implied": 87.7,
+            "edge": -8.2,
             "flag": null
           },
           "3.5": {
-            "prob": 70,
-            "odds": 1.38,
-            "implied": 72.5,
-            "edge": -2.5,
+            "prob": 71,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -0.4,
             "flag": null
           },
           "4.5": {
-            "prob": 60,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": 8.7,
+            "prob": 55,
+            "odds": 2.04,
+            "implied": 49,
+            "edge": 6,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 80,
-            "odds": 1.09,
-            "implied": 91.7,
-            "edge": -11.7,
+            "odds": 1.07,
+            "implied": 93.5,
+            "edge": -13.5,
             "flag": null
           },
           "9.5": {
             "prob": 80,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": 3.1,
+            "odds": 1.2,
+            "implied": 83.3,
+            "edge": -3.3,
             "flag": null
           },
           "10.5": {
             "prob": 80,
-            "odds": 1.46,
-            "implied": 68.5,
-            "edge": 11.5,
+            "odds": 1.34,
+            "implied": 74.6,
+            "edge": 5.4,
             "flag": null
           }
         },
         "btts": {
           "prob": 75,
-          "odds": 1.3,
-          "implied": 76.9,
-          "edge": -1.9,
+          "odds": 1.22,
+          "implied": 82,
+          "edge": -7,
           "flag": null
         }
       },
@@ -170,7 +1157,7 @@
         },
         {
           "date": "2026-06-14",
-          "opp": "IBV",
+          "opp": "ÍBV",
           "ha": "H",
           "gf": 1,
           "ga": 4,
@@ -192,7 +1179,7 @@
         },
         {
           "date": "2026-05-22",
-          "opp": "Keflavik",
+          "opp": "Keflavík",
           "ha": "A",
           "gf": 0,
           "ga": 1,
@@ -203,7 +1190,7 @@
         },
         {
           "date": "2026-05-17",
-          "opp": "IA",
+          "opp": "ÍA",
           "ha": "H",
           "gf": 1,
           "ga": 2,
@@ -214,7 +1201,7 @@
         },
         {
           "date": "2026-05-08",
-          "opp": "Vikingur Reykjavik",
+          "opp": "Víkingur Reykjavík",
           "ha": "A",
           "gf": 0,
           "ga": 6,
@@ -238,7 +1225,7 @@
       "away_form": [
         {
           "date": "2026-06-28",
-          "opp": "Keflavik",
+          "opp": "Keflavík",
           "ha": "A",
           "gf": 2,
           "ga": 3,
@@ -249,7 +1236,7 @@
         },
         {
           "date": "2026-06-22",
-          "opp": "IA",
+          "opp": "ÍA",
           "ha": "H",
           "gf": 5,
           "ga": 3,
@@ -260,7 +1247,7 @@
         },
         {
           "date": "2026-06-16",
-          "opp": "Vikingur Reykjavik",
+          "opp": "Víkingur Reykjavík",
           "ha": "A",
           "gf": 0,
           "ga": 2,
@@ -329,7 +1316,7 @@
         {
           "date": "2026-04-17",
           "home": "KR",
-          "away": "Thor",
+          "away": "Thór",
           "hg": 5,
           "ag": 2,
           "corners": 12,
@@ -338,668 +1325,14 @@
       ]
     },
     {
-      "id": "8447218",
-      "league": "Urvalsdeild",
-      "region": "Iceland",
-      "date": "2026-07-04",
-      "time": "15:00",
-      "home": {
-        "name": "IA",
-        "short": "IA",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-ia-akranes.png"
-      },
-      "away": {
-        "name": "Breidablik",
-        "short": "BRE",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-breidablik-ubk.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.7,
-      "corners_avg": 12.6,
-      "cards_avg": 4.7,
-      "btts_pct": 70,
-      "goals_over": {
-        "0.5": 95,
-        "1.5": 75,
-        "2.5": 65,
-        "3.5": 50,
-        "4.5": 30
-      },
-      "corners_over": {
-        "8.5": 85,
-        "9.5": 75,
-        "10.5": 70,
-        "11.5": 65
-      },
-      "cards_over": {
-        "2.5": 85,
-        "3.5": 70,
-        "4.5": 55,
-        "5.5": 40
-      },
-      "goals_odds": {
-        "2.5": 1.28,
-        "3.5": 1.71,
-        "4.5": 2.15
-      },
-      "corners_odds": {
-        "8.5": 1.11,
-        "9.5": 1.33,
-        "10.5": 1.5
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.26,
-      "goals_under_odds": {
-        "0.5": 19.5,
-        "1.5": 7.7,
-        "2.5": 3.5,
-        "3.5": 2.08
-      },
-      "corners_under_odds": {
-        "8.5": 4.7,
-        "9.5": 3.18,
-        "10.5": 2.36,
-        "11.5": 1.88
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.48,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 65,
-            "odds": 1.28,
-            "implied": 78.1,
-            "edge": -13.1,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 50,
-            "odds": 1.71,
-            "implied": 58.5,
-            "edge": -8.5,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 30,
-            "odds": 2.15,
-            "implied": 46.5,
-            "edge": -16.5,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 85,
-            "odds": 1.11,
-            "implied": 90.1,
-            "edge": -5.1,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 75,
-            "odds": 1.33,
-            "implied": 75.2,
-            "edge": -0.2,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 70,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": 3.3,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 70,
-          "odds": 1.26,
-          "implied": 79.4,
-          "edge": -9.4,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-29",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "KR",
-          "ha": "A",
-          "gf": 3,
-          "ga": 5,
-          "res": "L",
-          "corners": 17,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Valur",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
-          "cards": 8,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "FH",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 14,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-21",
-          "opp": "IBV",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Thor",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 20,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Keflavik",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Stjarnan",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 16,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-25",
-          "opp": "Vikingur Reykjavik",
-          "ha": "H",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 7,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 15,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Stjarnan",
-          "ha": "A",
-          "gf": 4,
-          "ga": 4,
-          "res": "D",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Fram",
-          "ha": "A",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 6,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "KR",
-          "ha": "H",
-          "gf": 6,
-          "ga": 3,
-          "res": "W",
-          "corners": 14,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Valur",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 17,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "FH",
-          "ha": "H",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 21,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "IBV",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 7,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-17",
-          "home": "Breidablik",
-          "away": "IA",
-          "hg": 1,
-          "ag": 0,
-          "corners": 12,
-          "cards": 6
-        }
-      ]
-    },
-    {
-      "id": "8447230",
-      "league": "Urvalsdeild",
-      "region": "Iceland",
-      "date": "2026-07-03",
-      "time": "20:15",
-      "home": {
-        "name": "FH",
-        "short": "FH",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-fh-hafnarfjordur.png"
-      },
-      "away": {
-        "name": "Stjarnan",
-        "short": "STJ",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-umf-stjarnan.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 4.1,
-      "corners_avg": 11.9,
-      "cards_avg": 5,
-      "btts_pct": 85,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 90,
-        "2.5": 75,
-        "3.5": 55,
-        "4.5": 50
-      },
-      "corners_over": {
-        "8.5": 80,
-        "9.5": 80,
-        "10.5": 70,
-        "11.5": 60
-      },
-      "cards_over": {
-        "2.5": 85,
-        "3.5": 80,
-        "4.5": 55,
-        "5.5": 40
-      },
-      "goals_odds": {
-        "2.5": 1.3,
-        "3.5": 1.78,
-        "4.5": 2.59
-      },
-      "corners_odds": {
-        "8.5": 1.12,
-        "9.5": 1.27,
-        "10.5": 1.45
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.28,
-      "goals_under_odds": {
-        "0.5": 19.5,
-        "1.5": 6.7,
-        "2.5": 3,
-        "3.5": 1.98
-      },
-      "corners_under_odds": {
-        "8.5": 4.8,
-        "9.5": 3.16,
-        "10.5": 2.44,
-        "11.5": 1.92
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.34,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 75,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -1.9,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 55,
-            "odds": 1.78,
-            "implied": 56.2,
-            "edge": -1.2,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 50,
-            "odds": 2.59,
-            "implied": 38.6,
-            "edge": 11.4,
-            "flag": "value"
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 80,
-            "odds": 1.12,
-            "implied": 89.3,
-            "edge": -9.3,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 80,
-            "odds": 1.27,
-            "implied": 78.7,
-            "edge": 1.3,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 70,
-            "odds": 1.45,
-            "implied": 69,
-            "edge": 1,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 85,
-          "odds": 1.28,
-          "implied": 78.1,
-          "edge": 6.9,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "IBV",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Thor",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Keflavik",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "IA",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 14,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Vikingur Reykjavik",
-          "ha": "A",
-          "gf": 0,
-          "ga": 5,
-          "res": "L",
-          "corners": 12,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Breidablik",
-          "ha": "A",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 21,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 20,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "IBV",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Breidablik",
-          "ha": "H",
-          "gf": 4,
-          "ga": 4,
-          "res": "D",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Thor",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-26",
-          "opp": "Vikingur Reykjavik",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 6,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Keflavik",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "KR",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 14,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-17",
-          "home": "Stjarnan",
-          "away": "FH",
-          "hg": 3,
-          "ag": 2,
-          "corners": 13,
-          "cards": 6
-        }
-      ]
-    },
-    {
       "id": "8447228",
-      "league": "Urvalsdeild",
+      "league": "Úrvalsdeild",
       "region": "Iceland",
       "date": "2026-07-02",
       "time": "20:15",
       "home": {
-        "name": "Vikingur Reykjavik",
-        "short": "VIK",
+        "name": "Víkingur Reykjavík",
+        "short": "VÍK",
         "logo": "https://cdn.footystats.org/img/teams/iceland-vikingur-reykjavik.png"
       },
       "away": {
@@ -1014,115 +1347,115 @@
         "cards": 0,
         "btts": false
       },
-      "goals_avg": 3.7,
-      "corners_avg": 11.6,
-      "cards_avg": 3.7,
-      "btts_pct": 50,
+      "goals_avg": 3.8,
+      "corners_avg": 11.8,
+      "cards_avg": 1.8,
+      "btts_pct": 56.5,
       "goals_over": {
         "0.5": 100,
-        "1.5": 90,
-        "2.5": 60,
-        "3.5": 50,
-        "4.5": 35
+        "1.5": 91.5,
+        "2.5": 63.5,
+        "3.5": 55.5,
+        "4.5": 35.5
       },
       "corners_over": {
-        "8.5": 90,
-        "9.5": 80,
-        "10.5": 70,
-        "11.5": 40
+        "8.5": 88.5,
+        "9.5": 76,
+        "10.5": 68.5,
+        "11.5": 44
       },
       "cards_over": {
-        "2.5": 80,
-        "3.5": 65,
-        "4.5": 20,
-        "5.5": 15
+        "2.5": 80.5,
+        "3.5": 64.5,
+        "4.5": 28,
+        "5.5": 24
       },
       "goals_odds": {
-        "2.5": 1.18,
-        "3.5": 1.61,
-        "4.5": 2.39
+        "2.5": 1.25,
+        "3.5": 1.58,
+        "4.5": 1.99
       },
       "corners_odds": {
-        "8.5": 1.12,
-        "9.5": 1.28,
-        "10.5": 1.53
+        "8.5": 1.09,
+        "9.5": 1.24,
+        "10.5": 1.44
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.62,
+      "btts_odds": 1.53,
       "goals_under_odds": {
-        "0.5": 22,
-        "1.5": 9,
-        "2.5": 4,
-        "3.5": 2.25
+        "0.5": 23.0,
+        "1.5": 9.0,
+        "2.5": 3.75,
+        "3.5": 1.91
       },
       "corners_under_odds": {
-        "8.5": 4.45,
-        "9.5": 3.08,
-        "10.5": 2.31,
-        "11.5": 1.84
+        "8.5": 4.99,
+        "9.5": 3.34,
+        "10.5": 2.47,
+        "11.5": 1.94
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.02,
+      "btts_no_odds": 1.83,
       "value": {
         "goals": {
           "2.5": {
-            "prob": 60,
-            "odds": 1.18,
-            "implied": 84.7,
-            "edge": -24.7,
+            "prob": 63.5,
+            "odds": 1.25,
+            "implied": 80,
+            "edge": -16.5,
             "flag": null
           },
           "3.5": {
-            "prob": 50,
-            "odds": 1.61,
-            "implied": 62.1,
-            "edge": -12.1,
+            "prob": 55.5,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": -7.8,
             "flag": null
           },
           "4.5": {
-            "prob": 35,
-            "odds": 2.39,
-            "implied": 41.8,
-            "edge": -6.8,
+            "prob": 35.5,
+            "odds": 1.99,
+            "implied": 50.3,
+            "edge": -14.8,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
-            "prob": 90,
-            "odds": 1.12,
-            "implied": 89.3,
-            "edge": 0.7,
+            "prob": 88.5,
+            "odds": 1.09,
+            "implied": 91.7,
+            "edge": -3.2,
             "flag": null
           },
           "9.5": {
-            "prob": 80,
-            "odds": 1.28,
-            "implied": 78.1,
-            "edge": 1.9,
+            "prob": 76,
+            "odds": 1.24,
+            "implied": 80.6,
+            "edge": -4.6,
             "flag": null
           },
           "10.5": {
-            "prob": 70,
-            "odds": 1.53,
-            "implied": 65.4,
-            "edge": 4.6,
+            "prob": 68.5,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": -0.9,
             "flag": null
           }
         },
         "btts": {
-          "prob": 50,
-          "odds": 1.62,
-          "implied": 61.7,
-          "edge": -11.7,
+          "prob": 56.5,
+          "odds": 1.53,
+          "implied": 65.4,
+          "edge": -8.9,
           "flag": null
         }
       },
@@ -1195,7 +1528,7 @@
         },
         {
           "date": "2026-05-17",
-          "opp": "IBV",
+          "opp": "ÍBV",
           "ha": "A",
           "gf": 2,
           "ga": 0,
@@ -1206,7 +1539,7 @@
         },
         {
           "date": "2026-05-08",
-          "opp": "Thor",
+          "opp": "Thór",
           "ha": "H",
           "gf": 6,
           "ga": 0,
@@ -1285,7 +1618,7 @@
         },
         {
           "date": "2026-05-10",
-          "opp": "IBV",
+          "opp": "ÍBV",
           "ha": "H",
           "gf": 2,
           "ga": 0,
@@ -1296,7 +1629,7 @@
         },
         {
           "date": "2026-05-02",
-          "opp": "Thor",
+          "opp": "Thór",
           "ha": "A",
           "gf": 1,
           "ga": 0,
@@ -1310,7 +1643,7 @@
         {
           "date": "2026-04-17",
           "home": "KA",
-          "away": "Vikingur Reykjavik",
+          "away": "Víkingur Reykjavík",
           "hg": 0,
           "ag": 2,
           "corners": 11,
@@ -1319,14 +1652,13907 @@
       ]
     },
     {
+      "id": "8471306",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-03",
+      "time": "13:00",
+      "home": {
+        "name": "Yunnan Yukun",
+        "short": "YUN",
+        "logo": "https://cdn.footystats.org/img/teams/china-yunnan-yukun-fc.png"
+      },
+      "away": {
+        "name": "Henan Jianye",
+        "short": "HEN",
+        "logo": "https://cdn.footystats.org/img/teams/china-henan-jianye-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 9.8,
+      "cards_avg": 1.9,
+      "btts_pct": 62.5,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 81.5,
+        "2.5": 68.5,
+        "3.5": 25,
+        "4.5": 12.5
+      },
+      "corners_over": {
+        "8.5": 50,
+        "9.5": 44,
+        "10.5": 31.5,
+        "11.5": 31.5
+      },
+      "cards_over": {
+        "2.5": 72,
+        "3.5": 53,
+        "4.5": 34.5,
+        "5.5": 25.5
+      },
+      "goals_odds": {
+        "2.5": 1.5,
+        "3.5": 2.28,
+        "4.5": 3.81
+      },
+      "corners_odds": {
+        "8.5": 1.36,
+        "9.5": 1.66,
+        "10.5": 2.06
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.42,
+      "goals_under_odds": {
+        "0.5": 17.0,
+        "1.5": 7.28,
+        "2.5": 2.5,
+        "3.5": 1.64
+      },
+      "corners_under_odds": {
+        "8.5": 2.76,
+        "9.5": 2.25,
+        "10.5": 1.68,
+        "11.5": 1.39
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.66,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 68.5,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": 1.8,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 25,
+            "odds": 2.28,
+            "implied": 43.9,
+            "edge": -18.9,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 12.5,
+            "odds": 3.81,
+            "implied": 26.2,
+            "edge": -13.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 50,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": -23.5,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 44,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": -16.2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 31.5,
+            "odds": 2.06,
+            "implied": 48.5,
+            "edge": -17,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 62.5,
+          "odds": 1.42,
+          "implied": 70.4,
+          "edge": -7.9,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Wuhan Three Towns",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Qingdao Youth Island",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Beijing Guoan",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 13,
+          "cards": 0,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Shenyang Urban",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-15",
+          "home": "Henan Jianye",
+          "away": "Yunnan Yukun",
+          "hg": 2,
+          "ag": 1,
+          "corners": 10,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8431901",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-03",
+      "time": "16:30",
+      "home": {
+        "name": "JäPS",
+        "short": "JÄP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-jarvenpaan-palloseura.png"
+      },
+      "away": {
+        "name": "SJK Akatemia",
+        "short": "SJK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-kerho-07-sjk-ii.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 9.9,
+      "cards_avg": 2,
+      "btts_pct": 21,
+      "goals_over": {
+        "0.5": 92,
+        "1.5": 58.5,
+        "2.5": 33.5,
+        "3.5": 16.5,
+        "4.5": 8.5
+      },
+      "corners_over": {
+        "8.5": 62.5,
+        "9.5": 54.5,
+        "10.5": 37.5,
+        "11.5": 25
+      },
+      "cards_over": {
+        "2.5": 54.5,
+        "3.5": 54.5,
+        "4.5": 29,
+        "5.5": 12.5
+      },
+      "goals_odds": {
+        "2.5": 1.59,
+        "3.5": 2.41,
+        "4.5": 4.25
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.52,
+      "goals_under_odds": {
+        "0.5": 11.9,
+        "1.5": 4.1,
+        "2.5": 2.15,
+        "3.5": 1.45
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.32,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 33.5,
+            "odds": 1.59,
+            "implied": 62.9,
+            "edge": -29.4,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 16.5,
+            "odds": 2.41,
+            "implied": 41.5,
+            "edge": -25,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 8.5,
+            "odds": 4.25,
+            "implied": 23.5,
+            "edge": -15,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": {
+          "prob": 21,
+          "odds": 1.52,
+          "implied": 65.8,
+          "edge": -44.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-09",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "EIF",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "JäPS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-09",
+          "home": "SJK Akatemia",
+          "away": "JäPS",
+          "hg": 0,
+          "ag": 2,
+          "corners": 8,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8431908",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-03",
+      "time": "16:30",
+      "home": {
+        "name": "KTP",
+        "short": "KTP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-kotkan-tyovaen-palloilijat.png"
+      },
+      "away": {
+        "name": "JIPPO",
+        "short": "JIP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-jippo-joensuu.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2,
+      "corners_avg": 9.6,
+      "cards_avg": 1.6,
+      "btts_pct": 37.5,
+      "goals_over": {
+        "0.5": 83.5,
+        "1.5": 54,
+        "2.5": 33,
+        "3.5": 12.5,
+        "4.5": 8.5
+      },
+      "corners_over": {
+        "8.5": 46,
+        "9.5": 42,
+        "10.5": 37.5,
+        "11.5": 29
+      },
+      "cards_over": {
+        "2.5": 83,
+        "3.5": 53.5,
+        "4.5": 25,
+        "5.5": 12.5
+      },
+      "goals_odds": {
+        "2.5": 2.0,
+        "3.5": 3.42,
+        "4.5": 6.75
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.79,
+      "goals_under_odds": {
+        "0.5": 8.4,
+        "1.5": 3.04,
+        "2.5": 1.72,
+        "3.5": 1.23
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.9,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 33,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": -17,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 12.5,
+            "odds": 3.42,
+            "implied": 29.2,
+            "edge": -16.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 8.5,
+            "odds": 6.75,
+            "implied": 14.8,
+            "edge": -6.3,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": {
+          "prob": 37.5,
+          "odds": 1.79,
+          "implied": 55.9,
+          "edge": -18.4,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "EIF",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-08",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 17,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "KäPa",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "EIF",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "KäPa",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-09",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-18",
+          "home": "JIPPO",
+          "away": "KTP",
+          "hg": 0,
+          "ag": 0,
+          "corners": 8,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8412546",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-03",
+      "time": "17:00",
+      "home": {
+        "name": "Raufoss",
+        "short": "RAU",
+        "logo": "https://cdn.footystats.org/img/teams/norway-raufoss-il.png"
+      },
+      "away": {
+        "name": "Strømmen",
+        "short": "STR",
+        "logo": "https://cdn.footystats.org/img/teams/norway-strommen-if.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.8,
+      "corners_avg": 9.7,
+      "cards_avg": 1.5,
+      "btts_pct": 58,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 85,
+        "2.5": 77,
+        "3.5": 46,
+        "4.5": 30.5
+      },
+      "corners_over": {
+        "8.5": 61.5,
+        "9.5": 46,
+        "10.5": 42,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 54,
+        "3.5": 31,
+        "4.5": 11.5,
+        "5.5": 4
+      },
+      "goals_odds": {
+        "2.5": 1.44,
+        "3.5": 2.25,
+        "4.5": 3.5
+      },
+      "corners_odds": {
+        "8.5": 1.38,
+        "9.5": 1.73,
+        "10.5": 1.93
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.41,
+      "goals_under_odds": {
+        "0.5": 15.0,
+        "1.5": 6.0,
+        "2.5": 2.43,
+        "3.5": 1.63
+      },
+      "corners_under_odds": {
+        "8.5": 2.75,
+        "9.5": 2.22,
+        "10.5": 1.77,
+        "11.5": 1.46
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.7,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 77,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": 7.6,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 46,
+            "odds": 2.25,
+            "implied": 44.4,
+            "edge": 1.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 30.5,
+            "odds": 3.5,
+            "implied": 28.6,
+            "edge": 1.9,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 61.5,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": -11,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 46,
+            "odds": 1.73,
+            "implied": 57.8,
+            "edge": -11.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 42,
+            "odds": 1.93,
+            "implied": 51.8,
+            "edge": -9.8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 58,
+          "odds": 1.41,
+          "implied": 70.9,
+          "edge": -12.9,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Sandnes Ulf",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Sogndal",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Strømsgodset",
+          "ha": "A",
+          "gf": 1,
+          "ga": 6,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Haugesund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Åsane",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Bryne",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Stabæk",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Lyn",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Moss",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Stabæk",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Sandnes Ulf",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Ranheim",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Sogndal",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Lyn",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Haugesund",
+          "ha": "H",
+          "gf": 0,
+          "ga": 7,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Bryne",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8412581",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-03",
+      "time": "17:00",
+      "home": {
+        "name": "Kongsvinger",
+        "short": "KON",
+        "logo": "https://cdn.footystats.org/img/teams/norway-kongsvinger-il.png"
+      },
+      "away": {
+        "name": "Sogndal",
+        "short": "SOG",
+        "logo": "https://cdn.footystats.org/img/teams/norway-sogndal-fotball.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4.1,
+      "corners_avg": 11.8,
+      "cards_avg": 1.6,
+      "btts_pct": 69.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 100,
+        "2.5": 85,
+        "3.5": 57.5,
+        "4.5": 30.5
+      },
+      "corners_over": {
+        "8.5": 81,
+        "9.5": 73,
+        "10.5": 58,
+        "11.5": 46
+      },
+      "cards_over": {
+        "2.5": 61.5,
+        "3.5": 30.5,
+        "4.5": 15.5,
+        "5.5": 0
+      },
+      "goals_odds": {
+        "2.5": 1.27,
+        "3.5": 1.78,
+        "4.5": 2.65
+      },
+      "corners_odds": {
+        "8.5": 1.24,
+        "9.5": 1.4,
+        "10.5": 1.8
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.34,
+      "goals_under_odds": {
+        "0.5": 18.5,
+        "1.5": 7.1,
+        "2.5": 3.4,
+        "3.5": 1.98
+      },
+      "corners_under_odds": {
+        "8.5": 3.34,
+        "9.5": 2.7,
+        "10.5": 1.9,
+        "11.5": 1.56
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.93,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 85,
+            "odds": 1.27,
+            "implied": 78.7,
+            "edge": 6.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 57.5,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": 1.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 30.5,
+            "odds": 2.65,
+            "implied": 37.7,
+            "edge": -7.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 81,
+            "odds": 1.24,
+            "implied": 80.6,
+            "edge": 0.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 73,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": 1.6,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 58,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": 2.4,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 69.5,
+          "odds": 1.34,
+          "implied": 74.6,
+          "edge": -5.1,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Haugesund",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 16,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Strømsgodset",
+          "ha": "H",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Hødd",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Åsane",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Stabæk",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Odd",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Lyn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Ranheim",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Egersund",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Raufoss",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Moss",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Strømmen",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Sandnes Ulf",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Stabæk",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 25,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Hødd",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Haugesund",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8465695",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-03",
+      "time": "17:00",
+      "home": {
+        "name": "Nõmme United",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-nomme-united.png"
+      },
+      "away": {
+        "name": "Nõmme Kalju",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-nomme-kalju-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 10.6,
+      "cards_avg": 2.1,
+      "btts_pct": 69,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 86,
+        "2.5": 66.5,
+        "3.5": 38,
+        "4.5": 20.5
+      },
+      "corners_over": {
+        "8.5": 74.5,
+        "9.5": 57.5,
+        "10.5": 51.5,
+        "11.5": 34.5
+      },
+      "cards_over": {
+        "2.5": 82.5,
+        "3.5": 65.5,
+        "4.5": 45.5,
+        "5.5": 28.5
+      },
+      "goals_odds": {
+        "2.5": 1.5,
+        "3.5": 2.12,
+        "4.5": 3.4
+      },
+      "corners_odds": {
+        "8.5": 1.22,
+        "9.5": 1.38,
+        "10.5": 1.64
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.5,
+      "goals_under_odds": {
+        "0.5": 16.0,
+        "1.5": 5.4,
+        "2.5": 2.5,
+        "3.5": 1.68
+      },
+      "corners_under_odds": {
+        "8.5": 3.6,
+        "9.5": 2.7,
+        "10.5": 2.08,
+        "11.5": 1.71
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.38,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 66.5,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": -0.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 38,
+            "odds": 2.12,
+            "implied": 47.2,
+            "edge": -9.2,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 20.5,
+            "odds": 3.4,
+            "implied": 29.4,
+            "edge": -8.9,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 74.5,
+            "odds": 1.22,
+            "implied": 82,
+            "edge": -7.5,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 57.5,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": -15,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 51.5,
+            "odds": 1.64,
+            "implied": 61,
+            "edge": -9.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 69,
+          "odds": 1.5,
+          "implied": 66.7,
+          "edge": 2.3,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-20",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Trans",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Kuressaare",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-20",
+          "opp": "Tallinna FC Levadia",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Tammeka",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Harju Jalgpallikool",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Kuressaare",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 18,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-22",
+          "home": "Nõmme Kalju",
+          "away": "Nõmme United",
+          "hg": 7,
+          "ag": 1,
+          "corners": 9,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8412421",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-03",
+      "time": "18:00",
+      "home": {
+        "name": "Ranheim",
+        "short": "RAN",
+        "logo": "https://cdn.footystats.org/img/teams/norway-ranheim-fotball.png"
+      },
+      "away": {
+        "name": "Stabæk",
+        "short": "STA",
+        "logo": "https://cdn.footystats.org/img/teams/norway-stabaek-fotball.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.9,
+      "corners_avg": 12,
+      "cards_avg": 1.5,
+      "btts_pct": 65.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 92.5,
+        "2.5": 80.5,
+        "3.5": 65.5,
+        "4.5": 31
+      },
+      "corners_over": {
+        "8.5": 85,
+        "9.5": 73.5,
+        "10.5": 54,
+        "11.5": 42
+      },
+      "cards_over": {
+        "2.5": 61.5,
+        "3.5": 38.5,
+        "4.5": 26.5,
+        "5.5": 11.5
+      },
+      "goals_odds": {
+        "2.5": 1.36,
+        "3.5": 1.89,
+        "4.5": 2.81
+      },
+      "corners_odds": {
+        "8.5": 1.19,
+        "9.5": 1.37,
+        "10.5": 1.75
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.3,
+      "goals_under_odds": {
+        "0.5": 19.0,
+        "1.5": 6.8,
+        "2.5": 3.1,
+        "3.5": 1.93
+      },
+      "corners_under_odds": {
+        "8.5": 3.76,
+        "9.5": 2.8,
+        "10.5": 2.16,
+        "11.5": 1.61
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 3.2,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 80.5,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": 7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 65.5,
+            "odds": 1.89,
+            "implied": 52.9,
+            "edge": 12.6,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 31,
+            "odds": 2.81,
+            "implied": 35.6,
+            "edge": -4.6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 85,
+            "odds": 1.19,
+            "implied": 84,
+            "edge": 1,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 73.5,
+            "odds": 1.37,
+            "implied": 73,
+            "edge": 0.5,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 54,
+            "odds": 1.75,
+            "implied": 57.1,
+            "edge": -3.1,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 65.5,
+          "odds": 1.3,
+          "implied": 76.9,
+          "edge": -11.4,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Åsane",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Lyn",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Haugesund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Strømmen",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Sandnes Ulf",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Odd",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Hødd",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Strømsgodset",
+          "ha": "A",
+          "gf": 4,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Bryne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Strømmen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Egersund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Moss",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Kongsvinger",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Sogndal",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 25,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Raufoss",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Sandnes Ulf",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420464",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-03",
+      "time": "18:00",
+      "home": {
+        "name": "Sirius",
+        "short": "SIR",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-ik-sirius-fotboll.png"
+      },
+      "away": {
+        "name": "Mjällby",
+        "short": "MJÄ",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-mjallby-aif.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 9.4,
+      "cards_avg": 1.7,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 95,
+        "1.5": 90,
+        "2.5": 60,
+        "3.5": 35,
+        "4.5": 30
+      },
+      "corners_over": {
+        "8.5": 60,
+        "9.5": 50,
+        "10.5": 40,
+        "11.5": 35
+      },
+      "cards_over": {
+        "2.5": 60,
+        "3.5": 55,
+        "4.5": 30,
+        "5.5": 20
+      },
+      "goals_odds": {
+        "2.5": 1.66,
+        "3.5": 2.48,
+        "4.5": 5.0
+      },
+      "corners_odds": {
+        "8.5": 1.29,
+        "9.5": 1.7,
+        "10.5": 1.9
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.63,
+      "goals_under_odds": {
+        "0.5": 11.5,
+        "1.5": 4.33,
+        "2.5": 2.15,
+        "3.5": 1.43
+      },
+      "corners_under_odds": {
+        "8.5": 3.04,
+        "9.5": 2.43,
+        "10.5": 1.78,
+        "11.5": 1.45
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.14,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 60,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": -0.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 35,
+            "odds": 2.48,
+            "implied": 40.3,
+            "edge": -5.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 30,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": 10,
+            "flag": "value"
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 60,
+            "odds": 1.29,
+            "implied": 77.5,
+            "edge": -17.5,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 50,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -8.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 40,
+            "odds": 1.9,
+            "implied": 52.6,
+            "edge": -12.6,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 50,
+          "odds": 1.63,
+          "implied": 61.3,
+          "edge": -11.3,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "AIK",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-11",
+          "opp": "Örgryte",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Kalmar",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Häcken",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Västerås SK",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-25",
+          "opp": "IFK Göteborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Halmstad",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8464484",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-03",
+      "time": "18:30",
+      "home": {
+        "name": "Tallinna Kalev",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-tallinna-kalev.png"
+      },
+      "away": {
+        "name": "Maardu Linnameeskond",
+        "short": "MAA",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-maardu-linnameeskond.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.6,
+      "corners_avg": 10.8,
+      "cards_avg": 1.7,
+      "btts_pct": 70,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 90.5,
+        "2.5": 69.5,
+        "3.5": 42.5,
+        "4.5": 33.5
+      },
+      "corners_over": {
+        "8.5": 64,
+        "9.5": 54.5,
+        "10.5": 51.5,
+        "11.5": 45.5
+      },
+      "cards_over": {
+        "2.5": 54,
+        "3.5": 47,
+        "4.5": 22.5,
+        "5.5": 10
+      },
+      "goals_odds": {
+        "2.5": 1.28,
+        "3.5": 1.75,
+        "4.5": 2.08
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.32,
+      "goals_under_odds": {
+        "0.5": 34.0,
+        "1.5": 8.5,
+        "2.5": 3.3,
+        "3.5": 1.96
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 3.15,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 69.5,
+            "odds": 1.28,
+            "implied": 78.1,
+            "edge": -8.6,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 42.5,
+            "odds": 1.75,
+            "implied": 57.1,
+            "edge": -14.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 33.5,
+            "odds": 2.08,
+            "implied": 48.1,
+            "edge": -14.6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": {
+          "prob": 70,
+          "odds": 1.32,
+          "implied": 75.8,
+          "edge": -5.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-21",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-14",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-22",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-11",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 15,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-03",
+          "home": "Maardu Linnameeskond",
+          "away": "Tallinna Kalev",
+          "hg": 1,
+          "ag": 1,
+          "corners": 12,
+          "cards": 1
+        }
+      ]
+    },
+    {
+      "id": "8408055",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-03",
+      "time": "19:45",
+      "home": {
+        "name": "Sligo Rovers",
+        "short": "SLI",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-sligo-rovers-fc.png"
+      },
+      "away": {
+        "name": "Shamrock Rovers",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-shamrock-rovers-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 10.1,
+      "cards_avg": 2,
+      "btts_pct": 47.5,
+      "goals_over": {
+        "0.5": 91,
+        "1.5": 69.5,
+        "2.5": 43.5,
+        "3.5": 26,
+        "4.5": 11
+      },
+      "corners_over": {
+        "8.5": 59,
+        "9.5": 40,
+        "10.5": 31.5,
+        "11.5": 29
+      },
+      "cards_over": {
+        "2.5": 78,
+        "3.5": 56,
+        "4.5": 45,
+        "5.5": 25.5
+      },
+      "goals_odds": {
+        "2.5": 1.79,
+        "3.5": 2.89,
+        "4.5": 6.0
+      },
+      "corners_odds": {
+        "8.5": 1.44,
+        "9.5": 1.98,
+        "10.5": 2.07
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.87,
+      "goals_under_odds": {
+        "0.5": 10.9,
+        "1.5": 3.62,
+        "2.5": 2.0,
+        "3.5": 1.32
+      },
+      "corners_under_odds": {
+        "8.5": 2.52,
+        "9.5": 1.94,
+        "10.5": 1.64,
+        "11.5": 1.4
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.9,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 43.5,
+            "odds": 1.79,
+            "implied": 55.9,
+            "edge": -12.4,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 26,
+            "odds": 2.89,
+            "implied": 34.6,
+            "edge": -8.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 11,
+            "odds": 6.0,
+            "implied": 16.7,
+            "edge": -5.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 59,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": -10.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 40,
+            "odds": 1.98,
+            "implied": 50.5,
+            "edge": -10.5,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 31.5,
+            "odds": 2.07,
+            "implied": 48.3,
+            "edge": -16.8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 47.5,
+          "odds": 1.87,
+          "implied": 53.5,
+          "edge": -6,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 21,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Galway United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 18,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "St Patrick's Athl.",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Galway United",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "St Patrick's Athl.",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Sligo Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Dundalk",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-22",
+          "home": "Shamrock Rovers",
+          "away": "Sligo Rovers",
+          "hg": 1,
+          "ag": 2,
+          "corners": 7,
+          "cards": 3
+        },
+        {
+          "date": "2026-03-13",
+          "home": "Sligo Rovers",
+          "away": "Shamrock Rovers",
+          "hg": 0,
+          "ag": 2,
+          "corners": 8,
+          "cards": 8
+        }
+      ]
+    },
+    {
+      "id": "8408060",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-03",
+      "time": "19:45",
+      "home": {
+        "name": "Derry City",
+        "short": "DER",
+        "logo": "https://cdn.footystats.org/img/teams/northern-ireland-derry-city-fc.png"
+      },
+      "away": {
+        "name": "Waterford",
+        "short": "WAT",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-waterford-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 10.6,
+      "cards_avg": 2.6,
+      "btts_pct": 61,
+      "goals_over": {
+        "0.5": 89,
+        "1.5": 76.5,
+        "2.5": 50,
+        "3.5": 33,
+        "4.5": 20
+      },
+      "corners_over": {
+        "8.5": 74,
+        "9.5": 52,
+        "10.5": 41.5,
+        "11.5": 37
+      },
+      "cards_over": {
+        "2.5": 87,
+        "3.5": 67.5,
+        "4.5": 47.5,
+        "5.5": 28
+      },
+      "goals_odds": {
+        "2.5": 1.66,
+        "3.5": 2.48,
+        "4.5": 4.3
+      },
+      "corners_odds": {
+        "8.5": 1.34,
+        "9.5": 1.8,
+        "10.5": 2.02
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.8,
+      "goals_under_odds": {
+        "0.5": 12.0,
+        "1.5": 4.41,
+        "2.5": 2.18,
+        "3.5": 1.43
+      },
+      "corners_under_odds": {
+        "8.5": 2.82,
+        "9.5": 2.12,
+        "10.5": 1.71,
+        "11.5": 1.41
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.85,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 50,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": -10.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 33,
+            "odds": 2.48,
+            "implied": 40.3,
+            "edge": -7.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 20,
+            "odds": 4.3,
+            "implied": 23.3,
+            "edge": -3.3,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 74,
+            "odds": 1.34,
+            "implied": 74.6,
+            "edge": -0.6,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 52,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": -3.6,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 41.5,
+            "odds": 2.02,
+            "implied": 49.5,
+            "edge": -8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 61,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": 5.4,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Galway United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Dundalk",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "St Patrick's Athl.",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 10,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Dundalk",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Sligo Rovers",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Drogheda United",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-15",
+          "home": "Waterford",
+          "away": "Derry City",
+          "hg": 2,
+          "ag": 2,
+          "corners": 7,
+          "cards": 4
+        },
+        {
+          "date": "2026-02-27",
+          "home": "Derry City",
+          "away": "Waterford",
+          "hg": 4,
+          "ag": 2,
+          "corners": 9,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8408065",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-03",
+      "time": "19:45",
+      "home": {
+        "name": "St Patrick's Athl.",
+        "short": "ST ",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-st-patricks-athletic-fc.png"
+      },
+      "away": {
+        "name": "Galway United",
+        "short": "GAL",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-galway-united-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 10.6,
+      "cards_avg": 1.8,
+      "btts_pct": 53.5,
+      "goals_over": {
+        "0.5": 93,
+        "1.5": 72,
+        "2.5": 44,
+        "3.5": 37,
+        "4.5": 18.5
+      },
+      "corners_over": {
+        "8.5": 74.5,
+        "9.5": 62,
+        "10.5": 51.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 81.5,
+        "3.5": 58,
+        "4.5": 32,
+        "5.5": 14
+      },
+      "goals_odds": {
+        "2.5": 1.63,
+        "3.5": 2.62,
+        "4.5": 4.8
+      },
+      "corners_odds": {
+        "8.5": 1.3,
+        "9.5": 1.73,
+        "10.5": 1.94
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.83,
+      "goals_under_odds": {
+        "0.5": 15.0,
+        "1.5": 4.3,
+        "2.5": 2.35,
+        "3.5": 1.44
+      },
+      "corners_under_odds": {
+        "8.5": 2.99,
+        "9.5": 2.22,
+        "10.5": 1.79,
+        "11.5": 1.46
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.9,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 44,
+            "odds": 1.63,
+            "implied": 61.3,
+            "edge": -17.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 37,
+            "odds": 2.62,
+            "implied": 38.2,
+            "edge": -1.2,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 18.5,
+            "odds": 4.8,
+            "implied": 20.8,
+            "edge": -2.3,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 74.5,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": -2.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 62,
+            "odds": 1.73,
+            "implied": 57.8,
+            "edge": 4.2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 51.5,
+            "odds": 1.94,
+            "implied": 51.5,
+            "edge": 0,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 53.5,
+          "odds": 1.83,
+          "implied": 54.6,
+          "edge": -1.1,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Sligo Rovers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 21,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 10,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 10,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Sligo Rovers",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Dundalk",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sligo Rovers",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-01",
+          "home": "Galway United",
+          "away": "St Patrick's Athl.",
+          "hg": 2,
+          "ag": 2,
+          "corners": 7,
+          "cards": 4
+        },
+        {
+          "date": "2026-03-02",
+          "home": "St Patrick's Athl.",
+          "away": "Galway United",
+          "hg": 1,
+          "ag": 0,
+          "corners": 12,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8408066",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-03",
+      "time": "19:45",
+      "home": {
+        "name": "Shelbourne",
+        "short": "SHE",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-shelbourne-fc.png"
+      },
+      "away": {
+        "name": "Dundalk",
+        "short": "DUN",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-dundalk-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 10.2,
+      "cards_avg": 2.8,
+      "btts_pct": 71,
+      "goals_over": {
+        "0.5": 93.5,
+        "1.5": 82,
+        "2.5": 62,
+        "3.5": 38,
+        "4.5": 17.5
+      },
+      "corners_over": {
+        "8.5": 73.5,
+        "9.5": 60.5,
+        "10.5": 43,
+        "11.5": 29
+      },
+      "cards_over": {
+        "2.5": 84.5,
+        "3.5": 71,
+        "4.5": 57.5,
+        "5.5": 44.5
+      },
+      "goals_odds": {
+        "2.5": 1.6,
+        "3.5": 2.51,
+        "4.5": 4.87
+      },
+      "corners_odds": {
+        "8.5": 1.45,
+        "9.5": 1.67,
+        "10.5": 2.24
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.5,
+      "goals_under_odds": {
+        "0.5": 13.2,
+        "1.5": 4.2,
+        "2.5": 2.2,
+        "3.5": 1.42
+      },
+      "corners_under_odds": {
+        "8.5": 2.48,
+        "9.5": 2.02,
+        "10.5": 1.56,
+        "11.5": 1.31
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.38,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 62,
+            "odds": 1.6,
+            "implied": 62.5,
+            "edge": -0.5,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 38,
+            "odds": 2.51,
+            "implied": 39.8,
+            "edge": -1.8,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 17.5,
+            "odds": 4.87,
+            "implied": 20.5,
+            "edge": -3,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 73.5,
+            "odds": 1.45,
+            "implied": 69,
+            "edge": 4.5,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 60.5,
+            "odds": 1.67,
+            "implied": 59.9,
+            "edge": 0.6,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 43,
+            "odds": 2.24,
+            "implied": 44.6,
+            "edge": -1.6,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 71,
+          "odds": 1.5,
+          "implied": 66.7,
+          "edge": 4.3,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Sligo Rovers",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Drogheda United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Galway United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 10,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Galway United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Drogheda United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 21,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-01",
+          "home": "Dundalk",
+          "away": "Shelbourne",
+          "hg": 1,
+          "ag": 2,
+          "corners": 10,
+          "cards": 9
+        },
+        {
+          "date": "2026-04-03",
+          "home": "Shelbourne",
+          "away": "Dundalk",
+          "hg": 2,
+          "ag": 3,
+          "corners": 11,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8408145",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-03",
+      "time": "19:45",
+      "home": {
+        "name": "Drogheda United",
+        "short": "DRO",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-drogheda-united-fc.png"
+      },
+      "away": {
+        "name": "Bohemians",
+        "short": "BOH",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-bohemian-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 10,
+      "cards_avg": 1.9,
+      "btts_pct": 63.5,
+      "goals_over": {
+        "0.5": 89.5,
+        "1.5": 76,
+        "2.5": 56.5,
+        "3.5": 34.5,
+        "4.5": 18
+      },
+      "corners_over": {
+        "8.5": 65.5,
+        "9.5": 56,
+        "10.5": 39,
+        "11.5": 30.5
+      },
+      "cards_over": {
+        "2.5": 80.5,
+        "3.5": 65.5,
+        "4.5": 46,
+        "5.5": 24
+      },
+      "goals_odds": {
+        "2.5": 1.78,
+        "3.5": 2.88,
+        "4.5": 5.52
+      },
+      "corners_odds": {
+        "8.5": 1.4,
+        "9.5": 1.72,
+        "10.5": 2.15
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.7,
+      "goals_under_odds": {
+        "0.5": 10.5,
+        "1.5": 3.62,
+        "2.5": 2.05,
+        "3.5": 1.39
+      },
+      "corners_under_odds": {
+        "8.5": 2.6,
+        "9.5": 1.98,
+        "10.5": 1.58,
+        "11.5": 1.33
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.0,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 56.5,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": 0.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 34.5,
+            "odds": 2.88,
+            "implied": 34.7,
+            "edge": -0.2,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 18,
+            "odds": 5.52,
+            "implied": 18.1,
+            "edge": -0.1,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 65.5,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -5.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 56,
+            "odds": 1.72,
+            "implied": 58.1,
+            "edge": -2.1,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 39,
+            "odds": 2.15,
+            "implied": 46.5,
+            "edge": -7.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 63.5,
+          "odds": 1.7,
+          "implied": 58.8,
+          "edge": 4.7,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Dundalk",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "St Patrick's Athl.",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Dundalk",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Sligo Rovers",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Galway United",
+          "ha": "A",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-15",
+          "home": "Bohemians",
+          "away": "Drogheda United",
+          "hg": 2,
+          "ag": 1,
+          "corners": 16,
+          "cards": 5
+        },
+        {
+          "date": "2026-04-03",
+          "home": "Drogheda United",
+          "away": "Bohemians",
+          "hg": 0,
+          "ag": 0,
+          "corners": 10,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8447230",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-03",
+      "time": "20:15",
+      "home": {
+        "name": "FH",
+        "short": "FH",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-fh-hafnarfjordur.png"
+      },
+      "away": {
+        "name": "Stjarnan",
+        "short": "STJ",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-umf-stjarnan.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4,
+      "corners_avg": 12.6,
+      "cards_avg": 2.5,
+      "btts_pct": 83.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 92,
+        "2.5": 76,
+        "3.5": 55.5,
+        "4.5": 44
+      },
+      "corners_over": {
+        "8.5": 84,
+        "9.5": 84,
+        "10.5": 76,
+        "11.5": 68
+      },
+      "cards_over": {
+        "2.5": 80,
+        "3.5": 76,
+        "4.5": 51.5,
+        "5.5": 39.5
+      },
+      "goals_odds": {
+        "2.5": 1.3,
+        "3.5": 1.78,
+        "4.5": 2.64
+      },
+      "corners_odds": {
+        "8.5": 1.1,
+        "9.5": 1.25,
+        "10.5": 1.48
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.2,
+      "goals_under_odds": {
+        "0.5": 19.5,
+        "1.5": 6.7,
+        "2.5": 3.4,
+        "3.5": 1.98
+      },
+      "corners_under_odds": {
+        "8.5": 4.83,
+        "9.5": 3.24,
+        "10.5": 2.4,
+        "11.5": 1.88
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 3.34,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 76,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": -0.9,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 55.5,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": -0.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 44,
+            "odds": 2.64,
+            "implied": 37.9,
+            "edge": 6.1,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 84,
+            "odds": 1.1,
+            "implied": 90.9,
+            "edge": -6.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 84,
+            "odds": 1.25,
+            "implied": 80,
+            "edge": 4,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 76,
+            "odds": 1.48,
+            "implied": 67.6,
+            "edge": 8.4,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 83.5,
+          "odds": 1.2,
+          "implied": 83.3,
+          "edge": 0.2,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Thór",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Keflavík",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "ÍA",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Víkingur Reykjavík",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "KA",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Breidablik",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 21,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "KA",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 20,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "ÍBV",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Breidablik",
+          "ha": "H",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-26",
+          "opp": "Víkingur Reykjavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Keflavík",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "KR",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-17",
+          "home": "Stjarnan",
+          "away": "FH",
+          "hg": 3,
+          "ag": 2,
+          "corners": 13,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8483493",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "11:00",
+      "home": {
+        "name": "Yanbian Longding",
+        "short": "YAN",
+        "logo": "https://cdn.footystats.org/img/teams/china-yanbian-longding-fc.png"
+      },
+      "away": {
+        "name": "Heilongjiang Lava Spring",
+        "short": "HEI",
+        "logo": "https://cdn.footystats.org/img/teams/china-heilongjiang-lava-spring-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 10.2,
+      "cards_avg": 1.8,
+      "btts_pct": 67,
+      "goals_over": {
+        "0.5": 87.5,
+        "1.5": 79.5,
+        "2.5": 41.5,
+        "3.5": 25,
+        "4.5": 12.5
+      },
+      "corners_over": {
+        "8.5": 62.5,
+        "9.5": 50,
+        "10.5": 41,
+        "11.5": 41
+      },
+      "cards_over": {
+        "2.5": 78.5,
+        "3.5": 58,
+        "4.5": 45,
+        "5.5": 16.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 15,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Guangzhou E-Power",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8436178",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Anyang",
+        "short": "ANY",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-fc-anyang.png"
+      },
+      "away": {
+        "name": "Pohang Steelers",
+        "short": "POH",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-pohang-steelers-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2,
+      "corners_avg": 9.1,
+      "cards_avg": 2.4,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 93,
+        "1.5": 60,
+        "2.5": 20,
+        "3.5": 10,
+        "4.5": 7
+      },
+      "corners_over": {
+        "8.5": 53.5,
+        "9.5": 36.5,
+        "10.5": 30,
+        "11.5": 20
+      },
+      "cards_over": {
+        "2.5": 93,
+        "3.5": 70,
+        "4.5": 46.5,
+        "5.5": 30
+      },
+      "goals_odds": {
+        "2.5": 2.4,
+        "3.5": 5.0,
+        "4.5": 9.5
+      },
+      "corners_odds": {
+        "8.5": 1.78,
+        "9.5": 2.28,
+        "10.5": 2.95
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 2.0,
+      "goals_under_odds": {
+        "0.5": 6.91,
+        "1.5": 2.48,
+        "2.5": 1.53,
+        "3.5": 1.13
+      },
+      "corners_under_odds": {
+        "8.5": 1.9,
+        "9.5": 1.55,
+        "10.5": 1.34,
+        "11.5": 1.2
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.72,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 20,
+            "odds": 2.4,
+            "implied": 41.7,
+            "edge": -21.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 10,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -10,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 7,
+            "odds": 9.5,
+            "implied": 10.5,
+            "edge": -3.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 53.5,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": -2.7,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 36.5,
+            "odds": 2.28,
+            "implied": 43.9,
+            "edge": -7.4,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 30,
+            "odds": 2.95,
+            "implied": 33.9,
+            "edge": -3.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 50,
+          "odds": 2.0,
+          "implied": 50,
+          "edge": 0,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-17",
+          "opp": "Jeju United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Bucheon 1995",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Pohang Steelers",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-17",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Gwangju",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Anyang",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-19",
+          "home": "Pohang Steelers",
+          "away": "Anyang",
+          "hg": 0,
+          "ag": 1,
+          "corners": 7,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8436179",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Daejeon Citizen",
+        "short": "DAE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-daejeon-citizen-fc.png"
+      },
+      "away": {
+        "name": "Bucheon 1995",
+        "short": "BUC",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-bucheon-fc-1995.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2,
+      "corners_avg": 8.1,
+      "cards_avg": 1.8,
+      "btts_pct": 33.5,
+      "goals_over": {
+        "0.5": 86.5,
+        "1.5": 57,
+        "2.5": 27,
+        "3.5": 16.5,
+        "4.5": 10
+      },
+      "corners_over": {
+        "8.5": 40,
+        "9.5": 26.5,
+        "10.5": 23.5,
+        "11.5": 10
+      },
+      "cards_over": {
+        "2.5": 83.5,
+        "3.5": 60,
+        "4.5": 36.5,
+        "5.5": 20
+      },
+      "goals_odds": {
+        "2.5": 2.15,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.66,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 27,
+            "odds": 2.15,
+            "implied": 46.5,
+            "edge": -19.5,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-16",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 2,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-17",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-07",
+          "home": "Bucheon 1995",
+          "away": "Daejeon Citizen",
+          "hg": 1,
+          "ag": 1,
+          "corners": 8,
+          "cards": 0
+        }
+      ]
+    },
+    {
+      "id": "8436180",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Jeonbuk Motors",
+        "short": "JEO",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-jeonbuk-hyundai-motors-fc.png"
+      },
+      "away": {
+        "name": "Gangwon",
+        "short": "GAN",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gangwon-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 8.4,
+      "cards_avg": 2.4,
+      "btts_pct": 43.5,
+      "goals_over": {
+        "0.5": 87,
+        "1.5": 70,
+        "2.5": 30,
+        "3.5": 13.5,
+        "4.5": 6.5
+      },
+      "corners_over": {
+        "8.5": 40,
+        "9.5": 33.5,
+        "10.5": 17,
+        "11.5": 13.5
+      },
+      "cards_over": {
+        "2.5": 83,
+        "3.5": 63.5,
+        "4.5": 53,
+        "5.5": 23.5
+      },
+      "goals_odds": {
+        "2.5": 2.35,
+        "3.5": 4.63,
+        "4.5": 9.5
+      },
+      "corners_odds": {
+        "8.5": 1.86,
+        "9.5": 2.4,
+        "10.5": 3.2
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.95,
+      "goals_under_odds": {
+        "0.5": 6.95,
+        "1.5": 2.57,
+        "2.5": 1.56,
+        "3.5": 1.19
+      },
+      "corners_under_odds": {
+        "8.5": 1.82,
+        "9.5": 1.49,
+        "10.5": 1.29,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.73,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 30,
+            "odds": 2.35,
+            "implied": 42.6,
+            "edge": -12.6,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 13.5,
+            "odds": 4.63,
+            "implied": 21.6,
+            "edge": -8.1,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 6.5,
+            "odds": 9.5,
+            "implied": 10.5,
+            "edge": -4,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 40,
+            "odds": 1.86,
+            "implied": 53.8,
+            "edge": -13.8,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 33.5,
+            "odds": 2.4,
+            "implied": 41.7,
+            "edge": -8.2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 17,
+            "odds": 3.2,
+            "implied": 31.2,
+            "edge": -14.2,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 43.5,
+          "odds": 1.95,
+          "implied": 51.3,
+          "edge": -7.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-17",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Gwangju",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Jeju United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-17",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Daejeon Citizen",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Sangju Sangmu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-18",
+          "home": "Gangwon",
+          "away": "Jeonbuk Motors",
+          "hg": 1,
+          "ag": 1,
+          "corners": 10,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8471636",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Suwon Bluewings",
+        "short": "SUW",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-suwon-samsung-bluewings-fc.png"
+      },
+      "away": {
+        "name": "Seongnam",
+        "short": "SEO",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-seongnam-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 8.2,
+      "cards_avg": 1.9,
+      "btts_pct": 53.5,
+      "goals_over": {
+        "0.5": 82.5,
+        "1.5": 60.5,
+        "2.5": 43,
+        "3.5": 21,
+        "4.5": 7
+      },
+      "corners_over": {
+        "8.5": 43,
+        "9.5": 28,
+        "10.5": 14,
+        "11.5": 10.5
+      },
+      "cards_over": {
+        "2.5": 89.5,
+        "3.5": 67.5,
+        "4.5": 49.5,
+        "5.5": 32
+      },
+      "goals_odds": {
+        "2.5": 2.29,
+        "3.5": 4.1,
+        "4.5": 6.1
+      },
+      "corners_odds": {
+        "8.5": 1.84,
+        "9.5": 2.91,
+        "10.5": 3.24
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.98,
+      "goals_under_odds": {
+        "0.5": 7.8,
+        "1.5": 2.7,
+        "2.5": 1.61,
+        "3.5": 1.21
+      },
+      "corners_under_odds": {
+        "8.5": 1.85,
+        "9.5": 1.5,
+        "10.5": 1.26,
+        "11.5": 1.1
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.72,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 43,
+            "odds": 2.29,
+            "implied": 43.7,
+            "edge": -0.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 21,
+            "odds": 4.1,
+            "implied": 24.4,
+            "edge": -3.4,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 7,
+            "odds": 6.1,
+            "implied": 16.4,
+            "edge": -9.4,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 43,
+            "odds": 1.84,
+            "implied": 54.3,
+            "edge": -11.3,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 28,
+            "odds": 2.91,
+            "implied": 34.4,
+            "edge": -6.4,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 14,
+            "odds": 3.24,
+            "implied": 30.9,
+            "edge": -16.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 53.5,
+          "odds": 1.98,
+          "implied": 50.5,
+          "edge": 3,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-06",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Asan Mugunghwa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Busan I'Park",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-05",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Jeonnam Dragons",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Paju Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471638",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Cheongju",
+        "short": "CHE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-cheongju-fc.png"
+      },
+      "away": {
+        "name": "Daegu",
+        "short": "DAE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-daegu-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 9.1,
+      "cards_avg": 1.7,
+      "btts_pct": 71.5,
+      "goals_over": {
+        "0.5": 86,
+        "1.5": 79,
+        "2.5": 60.5,
+        "3.5": 46.5,
+        "4.5": 21.5
+      },
+      "corners_over": {
+        "8.5": 60,
+        "9.5": 46,
+        "10.5": 28,
+        "11.5": 14
+      },
+      "cards_over": {
+        "2.5": 75,
+        "3.5": 60.5,
+        "4.5": 35.5,
+        "5.5": 10.5
+      },
+      "goals_odds": {
+        "2.5": 1.86,
+        "3.5": 2.92,
+        "4.5": 5.4
+      },
+      "corners_odds": {
+        "8.5": 1.84,
+        "9.5": 2.91,
+        "10.5": 3.24
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.78,
+      "goals_under_odds": {
+        "0.5": 9.3,
+        "1.5": 3.42,
+        "2.5": 1.9,
+        "3.5": 1.32
+      },
+      "corners_under_odds": {
+        "8.5": 1.86,
+        "9.5": 1.5,
+        "10.5": 1.26,
+        "11.5": 1.1
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.95,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 60.5,
+            "odds": 1.86,
+            "implied": 53.8,
+            "edge": 6.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 46.5,
+            "odds": 2.92,
+            "implied": 34.2,
+            "edge": 12.3,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 21.5,
+            "odds": 5.4,
+            "implied": 18.5,
+            "edge": 3,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 60,
+            "odds": 1.84,
+            "implied": 54.3,
+            "edge": 5.7,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 46,
+            "odds": 2.91,
+            "implied": 34.4,
+            "edge": 11.6,
+            "flag": "value"
+          },
+          "10.5": {
+            "prob": 28,
+            "odds": 3.24,
+            "implied": 30.9,
+            "edge": -2.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 71.5,
+          "odds": 1.78,
+          "implied": 56.2,
+          "edge": 15.3,
+          "flag": "value"
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-07",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Hwaseong",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Jeonnam Dragons",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Paju Citizen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-05",
+          "opp": "Paju Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Ansan Greeners",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Gimhae City",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Suwon Bluewings",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471639",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Ansan Greeners",
+        "short": "ANS",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-ansan-greeners-fc.png"
+      },
+      "away": {
+        "name": "Suwon",
+        "short": "SUW",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-suwon-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 8.7,
+      "cards_avg": 1.6,
+      "btts_pct": 75,
+      "goals_over": {
+        "0.5": 96.5,
+        "1.5": 89.5,
+        "2.5": 68,
+        "3.5": 39.5,
+        "4.5": 10.5
+      },
+      "corners_over": {
+        "8.5": 49.5,
+        "9.5": 35,
+        "10.5": 21.5,
+        "11.5": 17.5
+      },
+      "cards_over": {
+        "2.5": 82.5,
+        "3.5": 53.5,
+        "4.5": 35.5,
+        "5.5": 17.5
+      },
+      "goals_odds": {
+        "2.5": 1.7,
+        "3.5": 2.75,
+        "4.5": 3.95
+      },
+      "corners_odds": {
+        "8.5": 1.87,
+        "9.5": 2.41,
+        "10.5": 3.32
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.58,
+      "goals_under_odds": {
+        "0.5": 12.3,
+        "1.5": 4.15,
+        "2.5": 2.1,
+        "3.5": 1.38
+      },
+      "corners_under_odds": {
+        "8.5": 1.83,
+        "9.5": 1.48,
+        "10.5": 1.24,
+        "11.5": 1.09
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.2,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 68,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": 9.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 39.5,
+            "odds": 2.75,
+            "implied": 36.4,
+            "edge": 3.1,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 10.5,
+            "odds": 3.95,
+            "implied": 25.3,
+            "edge": -14.8,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 49.5,
+            "odds": 1.87,
+            "implied": 53.5,
+            "edge": -4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 35,
+            "odds": 2.41,
+            "implied": 41.5,
+            "edge": -6.5,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 21.5,
+            "odds": 3.32,
+            "implied": 30.1,
+            "edge": -8.6,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 75,
+          "odds": 1.58,
+          "implied": 63.3,
+          "edge": 11.7,
+          "flag": "value"
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Daegu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Yongin City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Jeonnam Dragons",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 3,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-07",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 16,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Asan Mugunghwa",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Suwon Bluewings",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471640",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-04",
+      "time": "11:30",
+      "home": {
+        "name": "Paju Citizen",
+        "short": "PAJ",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-paju-citizen-fc.png"
+      },
+      "away": {
+        "name": "Yongin City",
+        "short": "YON",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-yongin-city-government-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 8.3,
+      "cards_avg": 2.7,
+      "btts_pct": 60.5,
+      "goals_over": {
+        "0.5": 86,
+        "1.5": 68,
+        "2.5": 57,
+        "3.5": 43,
+        "4.5": 14
+      },
+      "corners_over": {
+        "8.5": 46.5,
+        "9.5": 32,
+        "10.5": 17.5,
+        "11.5": 14
+      },
+      "cards_over": {
+        "2.5": 82.5,
+        "3.5": 75,
+        "4.5": 49.5,
+        "5.5": 35.5
+      },
+      "goals_odds": {
+        "2.5": 1.98,
+        "3.5": 3.63,
+        "4.5": 8.0
+      },
+      "corners_odds": {
+        "8.5": 1.91,
+        "9.5": 2.49,
+        "10.5": 3.46
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.8,
+      "goals_under_odds": {
+        "0.5": 9.0,
+        "1.5": 3.21,
+        "2.5": 1.74,
+        "3.5": 1.25
+      },
+      "corners_under_odds": {
+        "8.5": 1.79,
+        "9.5": 1.45,
+        "10.5": 1.22,
+        "11.5": 1.08
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.89,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 57,
+            "odds": 1.98,
+            "implied": 50.5,
+            "edge": 6.5,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 43,
+            "odds": 3.63,
+            "implied": 27.5,
+            "edge": 15.5,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 14,
+            "odds": 8.0,
+            "implied": 12.5,
+            "edge": 1.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 46.5,
+            "odds": 1.91,
+            "implied": 52.4,
+            "edge": -5.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 32,
+            "odds": 2.49,
+            "implied": 40.2,
+            "edge": -8.2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 17.5,
+            "odds": 3.46,
+            "implied": 28.9,
+            "edge": -11.4,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 60.5,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": 4.9,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-05",
+          "opp": "Daegu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Cheongju",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-06",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471163",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Qingdao Youth Island",
+        "short": "QIN",
+        "logo": "https://cdn.footystats.org/img/teams/china-qingdao-youth-island-fc.png"
+      },
+      "away": {
+        "name": "Shanghai SIPG",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shanghai-sipg-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 10,
+      "cards_avg": 2.4,
+      "btts_pct": 75,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 81,
+        "2.5": 50.5,
+        "3.5": 38,
+        "4.5": 19
+      },
+      "corners_over": {
+        "8.5": 56.5,
+        "9.5": 44,
+        "10.5": 38,
+        "11.5": 31
+      },
+      "cards_over": {
+        "2.5": 75,
+        "3.5": 69,
+        "4.5": 44,
+        "5.5": 22
+      },
+      "goals_odds": {
+        "2.5": 1.69,
+        "3.5": 2.72,
+        "4.5": 4.8
+      },
+      "corners_odds": {
+        "8.5": 1.48,
+        "9.5": 2.06,
+        "10.5": 2.3
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.57,
+      "goals_under_odds": {
+        "0.5": 9.0,
+        "1.5": 4.21,
+        "2.5": 2.12,
+        "3.5": 1.46
+      },
+      "corners_under_odds": {
+        "8.5": 2.42,
+        "9.5": 1.88,
+        "10.5": 1.53,
+        "11.5": 1.29
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.23,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 50.5,
+            "odds": 1.69,
+            "implied": 59.2,
+            "edge": -8.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 38,
+            "odds": 2.72,
+            "implied": 36.8,
+            "edge": 1.2,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 19,
+            "odds": 4.8,
+            "implied": 20.8,
+            "edge": -1.8,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 56.5,
+            "odds": 1.48,
+            "implied": 67.6,
+            "edge": -11.1,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 44,
+            "odds": 2.06,
+            "implied": 48.5,
+            "edge": -4.5,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 38,
+            "odds": 2.3,
+            "implied": 43.5,
+            "edge": -5.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 75,
+          "odds": 1.57,
+          "implied": 63.7,
+          "edge": 11.3,
+          "flag": "value"
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Beijing Guoan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 11,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-15",
+          "home": "Shanghai SIPG",
+          "away": "Qingdao Youth Island",
+          "hg": 4,
+          "ag": 1,
+          "corners": 19,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8471164",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Shenyang Urban",
+        "short": "SHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-shenyang-urban-fc.png"
+      },
+      "away": {
+        "name": "Chongqing Tongliang Long",
+        "short": "CHO",
+        "logo": "https://cdn.footystats.org/img/teams/china-chongqing-tongliang-long-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 9.7,
+      "cards_avg": 1.8,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 65.5,
+        "2.5": 53.5,
+        "3.5": 31.5,
+        "4.5": 16
+      },
+      "corners_over": {
+        "8.5": 56.5,
+        "9.5": 47,
+        "10.5": 37.5,
+        "11.5": 31.5
+      },
+      "cards_over": {
+        "2.5": 72,
+        "3.5": 53.5,
+        "4.5": 34.5,
+        "5.5": 19
+      },
+      "goals_odds": {
+        "2.5": 2.05,
+        "3.5": 3.55,
+        "4.5": 6.4
+      },
+      "corners_odds": {
+        "8.5": 1.44,
+        "9.5": 2.01,
+        "10.5": 2.24
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.8,
+      "goals_under_odds": {
+        "0.5": 9.0,
+        "1.5": 3.28,
+        "2.5": 1.78,
+        "3.5": 1.28
+      },
+      "corners_under_odds": {
+        "8.5": 2.48,
+        "9.5": 1.92,
+        "10.5": 1.56,
+        "11.5": 1.31
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.92,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 53.5,
+            "odds": 2.05,
+            "implied": 48.8,
+            "edge": 4.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 31.5,
+            "odds": 3.55,
+            "implied": 28.2,
+            "edge": 3.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 16,
+            "odds": 6.4,
+            "implied": 15.6,
+            "edge": 0.4,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 56.5,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": -12.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 47,
+            "odds": 2.01,
+            "implied": 49.8,
+            "edge": -2.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 37.5,
+            "odds": 2.24,
+            "implied": 44.6,
+            "edge": -7.1,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 50,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": -5.6,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Wuhan Three Towns",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Beijing Guoan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-14",
+          "home": "Chongqing Tongliang Long",
+          "away": "Shenyang Urban",
+          "hg": 1,
+          "ag": 0,
+          "corners": 8,
+          "cards": 7
+        }
+      ]
+    },
+    {
+      "id": "8483441",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Shaanxi Union",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shaanxi-union-fc.png"
+      },
+      "away": {
+        "name": "Wuxi Wugou",
+        "short": "WUX",
+        "logo": "https://cdn.footystats.org/img/teams/china-wuxi-wugou-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 8.9,
+      "cards_avg": 2.1,
+      "btts_pct": 47,
+      "goals_over": {
+        "0.5": 87,
+        "1.5": 65,
+        "2.5": 39,
+        "3.5": 25.5,
+        "4.5": 17
+      },
+      "corners_over": {
+        "8.5": 51,
+        "9.5": 38.5,
+        "10.5": 34.5,
+        "11.5": 17
+      },
+      "cards_over": {
+        "2.5": 78.5,
+        "3.5": 53,
+        "4.5": 34.5,
+        "5.5": 25.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 15,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483447",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Shanghai Jiading",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shanghai-jiading-city-development.png"
+      },
+      "away": {
+        "name": "Hebei Kungfu",
+        "short": "HEB",
+        "logo": "https://cdn.footystats.org/img/teams/china-hebei-kungfu-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 8.2,
+      "cards_avg": 1.4,
+      "btts_pct": 45.5,
+      "goals_over": {
+        "0.5": 87.5,
+        "1.5": 66.5,
+        "2.5": 45.5,
+        "3.5": 8.5,
+        "4.5": 4
+      },
+      "corners_over": {
+        "8.5": 41.5,
+        "9.5": 29,
+        "10.5": 21,
+        "11.5": 12.5
+      },
+      "cards_over": {
+        "2.5": 70,
+        "3.5": 54.5,
+        "4.5": 25,
+        "5.5": 16.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shaanxi Union",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 2,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Suzhou Dongwu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shenzhen Juniors",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Wuxi Wugou",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483554",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Suzhou Dongwu",
+        "short": "SUZ",
+        "logo": "https://cdn.footystats.org/img/teams/china-suzhou-dongwu-fc.png"
+      },
+      "away": {
+        "name": "Guangzhou E-Power",
+        "short": "GUA",
+        "logo": "https://cdn.footystats.org/img/teams/china-guangdong-gz-power-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9.6,
+      "cards_avg": 1.7,
+      "btts_pct": 54,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 66.5,
+        "2.5": 50,
+        "3.5": 20.5,
+        "4.5": 8.5
+      },
+      "corners_over": {
+        "8.5": 54,
+        "9.5": 42,
+        "10.5": 37,
+        "11.5": 32.5
+      },
+      "cards_over": {
+        "2.5": 79.5,
+        "3.5": 62.5,
+        "4.5": 29.5,
+        "5.5": 8
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shenzhen Juniors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Yanbian Longding",
+          "ha": "H",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483642",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:00",
+      "home": {
+        "name": "Shenzhen Juniors",
+        "short": "SHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-shenzhen-juniors-fc.png"
+      },
+      "away": {
+        "name": "Nantong Zhiyun",
+        "short": "NAN",
+        "logo": "https://cdn.footystats.org/img/teams/china-nantong-zhiyun-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9.8,
+      "cards_avg": 2.4,
+      "btts_pct": 37.5,
+      "goals_over": {
+        "0.5": 87.5,
+        "1.5": 62.5,
+        "2.5": 41.5,
+        "3.5": 29.5,
+        "4.5": 8.5
+      },
+      "corners_over": {
+        "8.5": 62,
+        "9.5": 46,
+        "10.5": 46,
+        "11.5": 29
+      },
+      "cards_over": {
+        "2.5": 83.5,
+        "3.5": 67,
+        "4.5": 41.5,
+        "5.5": 12.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 4,
+          "ga": 5,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Dongguan United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Yanbian Longding",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shanghai Jiading",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Guangxi Hengchen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Shaanxi Union",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471162",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:35",
+      "home": {
+        "name": "Dalian Zhixing",
+        "short": "DAL",
+        "logo": "https://cdn.footystats.org/img/teams/china-dalian-zhixing-fc.png"
+      },
+      "away": {
+        "name": "Wuhan Three Towns",
+        "short": "WUH",
+        "logo": "https://cdn.footystats.org/img/teams/china-wuhan-three-towns-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 10.6,
+      "cards_avg": 2.3,
+      "btts_pct": 62.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 81.5,
+        "2.5": 59.5,
+        "3.5": 44,
+        "4.5": 22
+      },
+      "corners_over": {
+        "8.5": 66,
+        "9.5": 53.5,
+        "10.5": 37.5,
+        "11.5": 34.5
+      },
+      "cards_over": {
+        "2.5": 81.5,
+        "3.5": 72,
+        "4.5": 44,
+        "5.5": 25
+      },
+      "goals_odds": {
+        "2.5": 1.74,
+        "3.5": 3.16,
+        "4.5": 5.5
+      },
+      "corners_odds": {
+        "8.5": 1.42,
+        "9.5": 1.94,
+        "10.5": 2.17
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.64,
+      "goals_under_odds": {
+        "0.5": 14.8,
+        "1.5": 4.95,
+        "2.5": 2.09,
+        "3.5": 1.4
+      },
+      "corners_under_odds": {
+        "8.5": 2.58,
+        "9.5": 1.98,
+        "10.5": 1.6,
+        "11.5": 1.34
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.1,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 59.5,
+            "odds": 1.74,
+            "implied": 57.5,
+            "edge": 2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 44,
+            "odds": 3.16,
+            "implied": 31.6,
+            "edge": 12.4,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 22,
+            "odds": 5.5,
+            "implied": 18.2,
+            "edge": 3.8,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 66,
+            "odds": 1.42,
+            "implied": 70.4,
+            "edge": -4.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 53.5,
+            "odds": 1.94,
+            "implied": 51.5,
+            "edge": 2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 37.5,
+            "odds": 2.17,
+            "implied": 46.1,
+            "edge": -8.6,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 62.5,
+          "odds": 1.64,
+          "implied": 61,
+          "edge": 1.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Qingdao Youth Island",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 5,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shenyang Urban",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-13",
+          "home": "Wuhan Three Towns",
+          "away": "Dalian Zhixing",
+          "hg": 4,
+          "ag": 1,
+          "corners": 8,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8471305",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "12:35",
+      "home": {
+        "name": "Beijing Guoan",
+        "short": "BEI",
+        "logo": "https://cdn.footystats.org/img/teams/china-beijing-guoan-fc.png"
+      },
+      "away": {
+        "name": "Shandong Luneng",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shandong-luneng-taishan-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 10,
+      "cards_avg": 2,
+      "btts_pct": 72,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 84.5,
+        "2.5": 69,
+        "3.5": 37.5,
+        "4.5": 28
+      },
+      "corners_over": {
+        "8.5": 69,
+        "9.5": 47,
+        "10.5": 40.5,
+        "11.5": 37.5
+      },
+      "cards_over": {
+        "2.5": 84.5,
+        "3.5": 72,
+        "4.5": 47,
+        "5.5": 22
+      },
+      "goals_odds": {
+        "2.5": 1.4,
+        "3.5": 1.98,
+        "4.5": 3.64
+      },
+      "corners_odds": {
+        "8.5": 1.39,
+        "9.5": 1.7,
+        "10.5": 2.1
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.38,
+      "goals_under_odds": {
+        "0.5": 26.0,
+        "1.5": 11.7,
+        "2.5": 3.34,
+        "3.5": 1.84
+      },
+      "corners_under_odds": {
+        "8.5": 2.67,
+        "9.5": 2.04,
+        "10.5": 1.65,
+        "11.5": 1.4
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.88,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 69,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -2.4,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 37.5,
+            "odds": 1.98,
+            "implied": 50.5,
+            "edge": -13,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 28,
+            "odds": 3.64,
+            "implied": 27.5,
+            "edge": 0.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 69,
+            "odds": 1.39,
+            "implied": 71.9,
+            "edge": -2.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 47,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -11.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 40.5,
+            "odds": 2.1,
+            "implied": 47.6,
+            "edge": -7.1,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 72,
+          "odds": 1.38,
+          "implied": 72.5,
+          "edge": -0.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 13,
+          "cards": 0,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 5,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Qingdao Youth Island",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-14",
+          "home": "Shandong Luneng",
+          "away": "Beijing Guoan",
+          "hg": 2,
+          "ag": 1,
+          "corners": 9,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8412463",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-04",
+      "time": "13:00",
+      "home": {
+        "name": "Egersund",
+        "short": "EGE",
+        "logo": "https://cdn.footystats.org/img/teams/norway-egersunds-ik.png"
+      },
+      "away": {
+        "name": "Moss",
+        "short": "MOS",
+        "logo": "https://cdn.footystats.org/img/teams/norway-moss-fk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.8,
+      "corners_avg": 10.5,
+      "cards_avg": 1.7,
+      "btts_pct": 69.5,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 84.5,
+        "2.5": 81,
+        "3.5": 57.5,
+        "4.5": 38.5
+      },
+      "corners_over": {
+        "8.5": 73,
+        "9.5": 61.5,
+        "10.5": 42,
+        "11.5": 30.5
+      },
+      "cards_over": {
+        "2.5": 65.5,
+        "3.5": 38.5,
+        "4.5": 31,
+        "5.5": 11.5
+      },
+      "goals_odds": {
+        "2.5": 1.53,
+        "3.5": 2.25,
+        "4.5": 3.68
+      },
+      "corners_odds": {
+        "8.5": 1.3,
+        "9.5": 1.72,
+        "10.5": 1.93
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.44,
+      "goals_under_odds": {
+        "0.5": 14.5,
+        "1.5": 4.9,
+        "2.5": 2.4,
+        "3.5": 1.61
+      },
+      "corners_under_odds": {
+        "8.5": 3.0,
+        "9.5": 2.23,
+        "10.5": 1.78,
+        "11.5": 1.47
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.6,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 81,
+            "odds": 1.53,
+            "implied": 65.4,
+            "edge": 15.6,
+            "flag": "value"
+          },
+          "3.5": {
+            "prob": 57.5,
+            "odds": 2.25,
+            "implied": 44.4,
+            "edge": 13.1,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 38.5,
+            "odds": 3.68,
+            "implied": 27.2,
+            "edge": 11.3,
+            "flag": "value"
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 73,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": -3.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 61.5,
+            "odds": 1.72,
+            "implied": 58.1,
+            "edge": 3.4,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 42,
+            "odds": 1.93,
+            "implied": 51.8,
+            "edge": -9.8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 69.5,
+          "odds": 1.44,
+          "implied": 69.4,
+          "edge": 0.1,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Sogndal",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Haugesund",
+          "ha": "H",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Stabæk",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Strømsgodset",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 15,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Hødd",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Lyn",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Sandnes Ulf",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-11",
+          "opp": "Odd",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Strømmen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Sandnes Ulf",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Sogndal",
+          "ha": "A",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Stabæk",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Haugesund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 20,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Strømsgodset",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Odd",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Bryne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8419900",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-04",
+      "time": "13:00",
+      "home": {
+        "name": "Lahti",
+        "short": "LAH",
+        "logo": "https://cdn.footystats.org/img/teams/finland-fc-lahti.png"
+      },
+      "away": {
+        "name": "Gnistan",
+        "short": "GNI",
+        "logo": "https://cdn.footystats.org/img/teams/finland-if-gnistan.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9.5,
+      "cards_avg": 2.5,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 77,
+        "2.5": 38,
+        "3.5": 19,
+        "4.5": 19
+      },
+      "corners_over": {
+        "8.5": 61.5,
+        "9.5": 50,
+        "10.5": 42,
+        "11.5": 30.5
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 65.5,
+        "4.5": 38,
+        "5.5": 23
+      },
+      "goals_odds": {
+        "2.5": 1.85,
+        "3.5": 3.0,
+        "4.5": 5.75
+      },
+      "corners_odds": {
+        "8.5": 1.32,
+        "9.5": 1.58,
+        "10.5": 1.98
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.61,
+      "goals_under_odds": {
+        "0.5": 9.1,
+        "1.5": 3.7,
+        "2.5": 1.95,
+        "3.5": 1.34
+      },
+      "corners_under_odds": {
+        "8.5": 2.88,
+        "9.5": 2.15,
+        "10.5": 1.72,
+        "11.5": 1.41
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.18,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 38,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -16.1,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 19,
+            "odds": 3.0,
+            "implied": 33.3,
+            "edge": -14.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 19,
+            "odds": 5.75,
+            "implied": 17.4,
+            "edge": 1.6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 61.5,
+            "odds": 1.32,
+            "implied": 75.8,
+            "edge": -14.3,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 50,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": -13.3,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 42,
+            "odds": 1.98,
+            "implied": 50.5,
+            "edge": -8.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 50,
+          "odds": 1.61,
+          "implied": 62.1,
+          "edge": -12.1,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "TPS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "SJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Ilves",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "KuPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Mariehamn",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Jaro",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Lahti",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Mariehamn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "SJK",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "VPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-17",
+          "home": "Gnistan",
+          "away": "Lahti",
+          "hg": 1,
+          "ag": 0,
+          "corners": 8,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8464276",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-04",
+      "time": "13:00",
+      "home": {
+        "name": "FC Tallinn",
+        "short": "FC ",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-tallinn.png"
+      },
+      "away": {
+        "name": "Nõmme United II",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-nomme-united-u21-nomme-united-ii.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4,
+      "corners_avg": 9.6,
+      "cards_avg": 1.5,
+      "btts_pct": 70,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 91,
+        "2.5": 73.5,
+        "3.5": 64,
+        "4.5": 33.5
+      },
+      "corners_over": {
+        "8.5": 67,
+        "9.5": 42.5,
+        "10.5": 36,
+        "11.5": 28
+      },
+      "cards_over": {
+        "2.5": 62,
+        "3.5": 48.5,
+        "4.5": 27,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-21",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 2,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 15,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-14",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-07",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-30",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 2,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Elva",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-22",
+          "home": "Nõmme United II",
+          "away": "FC Tallinn",
+          "hg": 2,
+          "ag": 2,
+          "corners": 7,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8471304",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-04",
+      "time": "13:00",
+      "home": {
+        "name": "Tianjin Teda",
+        "short": "TIA",
+        "logo": "https://cdn.footystats.org/img/teams/china-tianjin-teda-fc.png"
+      },
+      "away": {
+        "name": "Sichuan Jiuniu",
+        "short": "SIC",
+        "logo": "https://cdn.footystats.org/img/teams/china-sichuan-jiuniu-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 11.2,
+      "cards_avg": 2.2,
+      "btts_pct": 63,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 72,
+        "2.5": 50,
+        "3.5": 25,
+        "4.5": 22
+      },
+      "corners_over": {
+        "8.5": 78.5,
+        "9.5": 56.5,
+        "10.5": 47,
+        "11.5": 47
+      },
+      "cards_over": {
+        "2.5": 81.5,
+        "3.5": 75.5,
+        "4.5": 50,
+        "5.5": 25
+      },
+      "goals_odds": {
+        "2.5": 1.92,
+        "3.5": 3.3,
+        "4.5": 9.4
+      },
+      "corners_odds": {
+        "8.5": 1.35,
+        "9.5": 1.78,
+        "10.5": 2.24
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.7,
+      "goals_under_odds": {
+        "0.5": 23.0,
+        "1.5": 3.5,
+        "2.5": 1.9,
+        "3.5": 1.31
+      },
+      "corners_under_odds": {
+        "8.5": 2.9,
+        "9.5": 1.92,
+        "10.5": 1.56,
+        "11.5": 1.31
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.04,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 50,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": -2.1,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 25,
+            "odds": 3.3,
+            "implied": 30.3,
+            "edge": -5.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 22,
+            "odds": 9.4,
+            "implied": 10.6,
+            "edge": 11.4,
+            "flag": "value"
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 78.5,
+            "odds": 1.35,
+            "implied": 74.1,
+            "edge": 4.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 56.5,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": 0.3,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 47,
+            "odds": 2.24,
+            "implied": 44.6,
+            "edge": 2.4,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 63,
+          "odds": 1.7,
+          "implied": 58.8,
+          "edge": 4.2,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 16,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Shanghai SIPG",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Shanghai SIPG",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-14",
+          "home": "Sichuan Jiuniu",
+          "away": "Tianjin Teda",
+          "hg": 1,
+          "ag": 0,
+          "corners": 9,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8420307",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-04",
+      "time": "14:00",
+      "home": {
+        "name": "Degerfors",
+        "short": "DEG",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-degerfors-if.png"
+      },
+      "away": {
+        "name": "Malmö FF",
+        "short": "MAL",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-malmo-ff.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 9.8,
+      "cards_avg": 1.9,
+      "btts_pct": 75,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 85,
+        "2.5": 65,
+        "3.5": 45,
+        "4.5": 35
+      },
+      "corners_over": {
+        "8.5": 55,
+        "9.5": 40,
+        "10.5": 35,
+        "11.5": 25
+      },
+      "cards_over": {
+        "2.5": 75,
+        "3.5": 50,
+        "4.5": 20,
+        "5.5": 15
+      },
+      "goals_odds": {
+        "2.5": 1.85,
+        "3.5": 3.0,
+        "4.5": 5.43
+      },
+      "corners_odds": {
+        "8.5": 1.33,
+        "9.5": 1.6,
+        "10.5": 2.02
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.65,
+      "goals_under_odds": {
+        "0.5": 10.0,
+        "1.5": 3.54,
+        "2.5": 1.95,
+        "3.5": 1.38
+      },
+      "corners_under_odds": {
+        "8.5": 2.83,
+        "9.5": 2.11,
+        "10.5": 1.69,
+        "11.5": 1.57
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.1,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 65,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": 10.9,
+            "flag": "value"
+          },
+          "3.5": {
+            "prob": 45,
+            "odds": 3.0,
+            "implied": 33.3,
+            "edge": 11.7,
+            "flag": "value"
+          },
+          "4.5": {
+            "prob": 35,
+            "odds": 5.43,
+            "implied": 18.4,
+            "edge": 16.6,
+            "flag": "value"
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 55,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": -20.2,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 40,
+            "odds": 1.6,
+            "implied": 62.5,
+            "edge": -22.5,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 35,
+            "odds": 2.02,
+            "implied": 49.5,
+            "edge": -14.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 75,
+          "odds": 1.65,
+          "implied": 60.6,
+          "edge": 14.4,
+          "flag": "value"
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Örgryte",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-17",
+          "opp": "Elfsborg",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Halmstad",
+          "ha": "H",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Västerås SK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Häcken",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "AIK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 22,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Sirius",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-17",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 9,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420399",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-04",
+      "time": "14:00",
+      "home": {
+        "name": "Halmstad",
+        "short": "HAL",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-halmstads-bk.png"
+      },
+      "away": {
+        "name": "Västerås SK",
+        "short": "VÄS",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-vasteras-sk-fotboll.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 9.8,
+      "cards_avg": 1.2,
+      "btts_pct": 65,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 90,
+        "2.5": 55,
+        "3.5": 35,
+        "4.5": 25
+      },
+      "corners_over": {
+        "8.5": 65,
+        "9.5": 50,
+        "10.5": 35,
+        "11.5": 30
+      },
+      "cards_over": {
+        "2.5": 60,
+        "3.5": 45,
+        "4.5": 20,
+        "5.5": 10
+      },
+      "goals_odds": {
+        "2.5": 1.85,
+        "3.5": 2.85,
+        "4.5": 5.4
+      },
+      "corners_odds": {
+        "8.5": 1.4,
+        "9.5": 1.7,
+        "10.5": 2.05
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.62,
+      "goals_under_odds": {
+        "0.5": 10.1,
+        "1.5": 3.54,
+        "2.5": 1.95,
+        "3.5": 1.33
+      },
+      "corners_under_odds": {
+        "8.5": 2.6,
+        "9.5": 2.05,
+        "10.5": 1.7,
+        "11.5": 1.47
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.15,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 55,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": 0.9,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 35,
+            "odds": 2.85,
+            "implied": 35.1,
+            "edge": -0.1,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 25,
+            "odds": 5.4,
+            "implied": 18.5,
+            "edge": 6.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 65,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -6.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 50,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -8.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 35,
+            "odds": 2.05,
+            "implied": 48.8,
+            "edge": -13.8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 65,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": 3.3,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 2,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Örgryte",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Elfsborg",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Mjällby",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "IFK Göteborg",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "IFK Göteborg",
+          "ha": "H",
+          "gf": 4,
+          "ga": 5,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Brommapojkarna",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 14,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Sirius",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8431902",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-04",
+      "time": "14:00",
+      "home": {
+        "name": "EIF",
+        "short": "EIF",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ekenas-if.png"
+      },
+      "away": {
+        "name": "PK-35",
+        "short": "PK-",
+        "logo": "https://cdn.footystats.org/img/teams/finland-pallokerho-35-ry.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 10.4,
+      "cards_avg": 1.6,
+      "btts_pct": 45.5,
+      "goals_over": {
+        "0.5": 91.5,
+        "1.5": 58.5,
+        "2.5": 50,
+        "3.5": 29,
+        "4.5": 25
+      },
+      "corners_over": {
+        "8.5": 66,
+        "9.5": 57,
+        "10.5": 46,
+        "11.5": 33
+      },
+      "cards_over": {
+        "2.5": 79,
+        "3.5": 53.5,
+        "4.5": 16.5,
+        "5.5": 8
+      },
+      "goals_odds": {
+        "2.5": 2.0,
+        "3.5": 3.08,
+        "4.5": 5.95
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.69,
+      "goals_under_odds": {
+        "0.5": 8.5,
+        "1.5": 3.25,
+        "2.5": 1.75,
+        "3.5": 1.29
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.85,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 50,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": 0,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 29,
+            "odds": 3.08,
+            "implied": 32.5,
+            "edge": -3.5,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 25,
+            "odds": 5.95,
+            "implied": 16.8,
+            "edge": 8.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null
+        },
+        "btts": {
+          "prob": 45.5,
+          "odds": 1.69,
+          "implied": 59.2,
+          "edge": -13.7,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "KäPa",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 17,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-07",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-03",
+          "home": "PK-35",
+          "away": "EIF",
+          "hg": 4,
+          "ag": 2,
+          "corners": 11,
+          "cards": 1
+        }
+      ]
+    },
+    {
+      "id": "8412577",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-04",
+      "time": "15:00",
+      "home": {
+        "name": "Hødd",
+        "short": "HØD",
+        "logo": "https://cdn.footystats.org/img/teams/norway-il-hodd.png"
+      },
+      "away": {
+        "name": "Strømsgodset",
+        "short": "STR",
+        "logo": "https://cdn.footystats.org/img/teams/norway-stromsgodset-if.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.5,
+      "corners_avg": 11.9,
+      "cards_avg": 1.4,
+      "btts_pct": 62,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 80.5,
+        "2.5": 65.5,
+        "3.5": 38.5,
+        "4.5": 26.5
+      },
+      "corners_over": {
+        "8.5": 92,
+        "9.5": 81,
+        "10.5": 61.5,
+        "11.5": 53.5
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 50,
+        "4.5": 27,
+        "5.5": 4
+      },
+      "goals_odds": {
+        "2.5": 1.36,
+        "3.5": 1.93,
+        "4.5": 2.97
+      },
+      "corners_odds": {
+        "8.5": 1.14,
+        "9.5": 1.3,
+        "10.5": 1.58
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.47,
+      "goals_under_odds": {
+        "0.5": 18.0,
+        "1.5": 6.53,
+        "2.5": 3.1,
+        "3.5": 1.85
+      },
+      "corners_under_odds": {
+        "8.5": 4.22,
+        "9.5": 2.91,
+        "10.5": 2.2,
+        "11.5": 1.78
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.4,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 65.5,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": -8,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 38.5,
+            "odds": 1.93,
+            "implied": 51.8,
+            "edge": -13.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 26.5,
+            "odds": 2.97,
+            "implied": 33.7,
+            "edge": -7.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 92,
+            "odds": 1.14,
+            "implied": 87.7,
+            "edge": 4.3,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 81,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": 4.1,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 61.5,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": -1.8,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 62,
+          "odds": 1.47,
+          "implied": 68,
+          "edge": -6,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Lyn",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Odd",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Kongsvinger",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Bryne",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Egersund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Ranheim",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sogndal",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Strømmen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Odd",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Kongsvinger",
+          "ha": "A",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Raufoss",
+          "ha": "H",
+          "gf": 6,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Egersund",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Bryne",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Moss",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Ranheim",
+          "ha": "H",
+          "gf": 5,
+          "ga": 4,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Åsane",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8419805",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-04",
+      "time": "15:00",
+      "home": {
+        "name": "SJK",
+        "short": "SJK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-seinajoen-jalkapallokerho.png"
+      },
+      "away": {
+        "name": "TPS",
+        "short": "TPS",
+        "logo": "https://cdn.footystats.org/img/teams/finland-turun-palloseura.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9.4,
+      "cards_avg": 2.2,
+      "btts_pct": 58,
+      "goals_over": {
+        "0.5": 92,
+        "1.5": 73.5,
+        "2.5": 46,
+        "3.5": 23,
+        "4.5": 11.5
+      },
+      "corners_over": {
+        "8.5": 61.5,
+        "9.5": 54,
+        "10.5": 42,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 61.5,
+        "4.5": 42.5,
+        "5.5": 30.5
+      },
+      "goals_odds": {
+        "2.5": 1.66,
+        "3.5": 2.57,
+        "4.5": 5.0
+      },
+      "corners_odds": {
+        "8.5": 1.36,
+        "9.5": 1.65,
+        "10.5": 2.04
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.65,
+      "goals_under_odds": {
+        "0.5": 12.3,
+        "1.5": 4.05,
+        "2.5": 2.15,
+        "3.5": 1.47
+      },
+      "corners_under_odds": {
+        "8.5": 2.75,
+        "9.5": 2.08,
+        "10.5": 1.64,
+        "11.5": 1.36
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.11,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 46,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": -14.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 23,
+            "odds": 2.57,
+            "implied": 38.9,
+            "edge": -15.9,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 11.5,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -8.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 61.5,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": -12,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 54,
+            "odds": 1.65,
+            "implied": 60.6,
+            "edge": -6.6,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 42,
+            "odds": 2.04,
+            "implied": 49,
+            "edge": -7,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 58,
+          "odds": 1.65,
+          "implied": 60.6,
+          "edge": -2.6,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Inter Turku",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 3,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Oulu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "KuPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 13,
+          "cards": 7,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Inter Turku",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-18",
+          "home": "TPS",
+          "away": "SJK",
+          "hg": 2,
+          "ag": 0,
+          "corners": 12,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8419823",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-04",
+      "time": "15:00",
+      "home": {
+        "name": "Jaro",
+        "short": "JAR",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ff-jaro.png"
+      },
+      "away": {
+        "name": "Ilves",
+        "short": "ILV",
+        "logo": "https://cdn.footystats.org/img/teams/finland-tampereen-ilves.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 8.8,
+      "cards_avg": 1.6,
+      "btts_pct": 57,
+      "goals_over": {
+        "0.5": 96.5,
+        "1.5": 86,
+        "2.5": 64,
+        "3.5": 50,
+        "4.5": 29
+      },
+      "corners_over": {
+        "8.5": 60.5,
+        "9.5": 32,
+        "10.5": 21,
+        "11.5": 17.5
+      },
+      "cards_over": {
+        "2.5": 63.5,
+        "3.5": 35.5,
+        "4.5": 14,
+        "5.5": 10.5
+      },
+      "goals_odds": {
+        "2.5": 1.58,
+        "3.5": 2.48,
+        "4.5": 4.36
+      },
+      "corners_odds": {
+        "8.5": 1.4,
+        "9.5": 1.72,
+        "10.5": 2.16
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.5,
+      "goals_under_odds": {
+        "0.5": 10.0,
+        "1.5": 4.65,
+        "2.5": 2.35,
+        "3.5": 1.55
+      },
+      "corners_under_odds": {
+        "8.5": 2.6,
+        "9.5": 1.98,
+        "10.5": 1.57,
+        "11.5": 1.34
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.42,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 64,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": 0.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 50,
+            "odds": 2.48,
+            "implied": 40.3,
+            "edge": 9.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 29,
+            "odds": 4.36,
+            "implied": 22.9,
+            "edge": 6.1,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 60.5,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -10.9,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 32,
+            "odds": 1.72,
+            "implied": 58.1,
+            "edge": -26.1,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 21,
+            "odds": 2.16,
+            "implied": 46.3,
+            "edge": -25.3,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 57,
+          "odds": 1.5,
+          "implied": 66.7,
+          "edge": -9.7,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "TPS",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Mariehamn",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "KuPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "SJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "KuPS",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "TPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 4,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "HJK",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-17",
+          "home": "Ilves",
+          "away": "Jaro",
+          "hg": 5,
+          "ag": 0,
+          "corners": 9,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8447218",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-04",
+      "time": "15:00",
+      "home": {
+        "name": "ÍA",
+        "short": "ÍA",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-ia-akranes.png"
+      },
+      "away": {
+        "name": "Breidablik",
+        "short": "BRE",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-breidablik-ubk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.9,
+      "corners_avg": 12.5,
+      "cards_avg": 2.1,
+      "btts_pct": 66.5,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 79,
+        "2.5": 66.5,
+        "3.5": 54.5,
+        "4.5": 33.5
+      },
+      "corners_over": {
+        "8.5": 83.5,
+        "9.5": 75,
+        "10.5": 70,
+        "11.5": 62
+      },
+      "cards_over": {
+        "2.5": 83.5,
+        "3.5": 70,
+        "4.5": 49.5,
+        "5.5": 37.5
+      },
+      "goals_odds": {
+        "2.5": 1.28,
+        "3.5": 1.7,
+        "4.5": 2.43
+      },
+      "corners_odds": {
+        "8.5": 1.11,
+        "9.5": 1.33,
+        "10.5": 1.5
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.25,
+      "goals_under_odds": {
+        "0.5": 19.5,
+        "1.5": 7.7,
+        "2.5": 3.5,
+        "3.5": 2.09
+      },
+      "corners_under_odds": {
+        "8.5": 4.7,
+        "9.5": 3.18,
+        "10.5": 2.36,
+        "11.5": 1.88
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 3.56,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 66.5,
+            "odds": 1.28,
+            "implied": 78.1,
+            "edge": -11.6,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 54.5,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -4.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 33.5,
+            "odds": 2.43,
+            "implied": 41.2,
+            "edge": -7.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 83.5,
+            "odds": 1.11,
+            "implied": 90.1,
+            "edge": -6.6,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 75,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": -0.2,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 70,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": 3.3,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 66.5,
+          "odds": 1.25,
+          "implied": 80,
+          "edge": -13.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-29",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "KR",
+          "ha": "A",
+          "gf": 3,
+          "ga": 5,
+          "res": "L",
+          "corners": 17,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 20,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Keflavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Stjarnan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-25",
+          "opp": "Víkingur Reykjavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "KA",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Stjarnan",
+          "ha": "A",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Fram",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "KR",
+          "ha": "H",
+          "gf": 6,
+          "ga": 3,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Valur",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 17,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "FH",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 21,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "ÍBV",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-17",
+          "home": "Breidablik",
+          "away": "ÍA",
+          "hg": 1,
+          "ag": 0,
+          "corners": 12,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8419923",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-04",
+      "time": "16:00",
+      "home": {
+        "name": "VPS",
+        "short": "VPS",
+        "logo": "https://cdn.footystats.org/img/teams/finland-vaasan-palloseura.png"
+      },
+      "away": {
+        "name": "Mariehamn",
+        "short": "MAR",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ifk-mariehamn.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.3,
+      "corners_avg": 10,
+      "cards_avg": 2,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 92.5,
+        "1.5": 69.5,
+        "2.5": 38.5,
+        "3.5": 15,
+        "4.5": 7.5
+      },
+      "corners_over": {
+        "8.5": 69.5,
+        "9.5": 58,
+        "10.5": 46,
+        "11.5": 38
+      },
+      "cards_over": {
+        "2.5": 65.5,
+        "3.5": 46,
+        "4.5": 19,
+        "5.5": 15.5
+      },
+      "goals_odds": {
+        "2.5": 1.61,
+        "3.5": 2.63,
+        "4.5": 4.33
+      },
+      "corners_odds": {
+        "8.5": 1.35,
+        "9.5": 1.57,
+        "10.5": 1.89
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.86,
+      "goals_under_odds": {
+        "0.5": 15.0,
+        "1.5": 4.6,
+        "2.5": 2.25,
+        "3.5": 1.45
+      },
+      "corners_under_odds": {
+        "8.5": 2.88,
+        "9.5": 2.23,
+        "10.5": 1.79,
+        "11.5": 1.5
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.82,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 38.5,
+            "odds": 1.61,
+            "implied": 62.1,
+            "edge": -23.6,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 15,
+            "odds": 2.63,
+            "implied": 38,
+            "edge": -23,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 7.5,
+            "odds": 4.33,
+            "implied": 23.1,
+            "edge": -15.6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 69.5,
+            "odds": 1.35,
+            "implied": 74.1,
+            "edge": -4.6,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 58,
+            "odds": 1.57,
+            "implied": 63.7,
+            "edge": -5.7,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 46,
+            "odds": 1.89,
+            "implied": 52.9,
+            "edge": -6.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 50,
+          "odds": 1.86,
+          "implied": 53.8,
+          "edge": -3.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Oulu",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "SJK",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "TPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "HJK",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Jaro",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-02",
+          "home": "Mariehamn",
+          "away": "VPS",
+          "hg": 0,
+          "ag": 1,
+          "corners": 12,
+          "cards": 0
+        }
+      ]
+    },
+    {
+      "id": "8412578",
+      "league": "First Division",
+      "region": "Norway",
+      "date": "2026-07-04",
+      "time": "17:00",
+      "home": {
+        "name": "Bryne",
+        "short": "BRY",
+        "logo": "https://cdn.footystats.org/img/teams/norway-bryne-fk.png"
+      },
+      "away": {
+        "name": "Sandnes Ulf",
+        "short": "SAN",
+        "logo": "https://cdn.footystats.org/img/teams/norway-sandnes-ulf.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 10.8,
+      "cards_avg": 2.1,
+      "btts_pct": 42,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 80.5,
+        "2.5": 54,
+        "3.5": 31,
+        "4.5": 27
+      },
+      "corners_over": {
+        "8.5": 81,
+        "9.5": 62,
+        "10.5": 54,
+        "11.5": 38.5
+      },
+      "cards_over": {
+        "2.5": 73,
+        "3.5": 46,
+        "4.5": 30.5,
+        "5.5": 11.5
+      },
+      "goals_odds": {
+        "2.5": 1.61,
+        "3.5": 2.3,
+        "4.5": 4.25
+      },
+      "corners_odds": {
+        "8.5": 1.3,
+        "9.5": 1.43,
+        "10.5": 1.92
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.55,
+      "goals_under_odds": {
+        "0.5": 12.7,
+        "1.5": 4.15,
+        "2.5": 2.25,
+        "3.5": 1.44
+      },
+      "corners_under_odds": {
+        "8.5": 3.0,
+        "9.5": 2.6,
+        "10.5": 1.78,
+        "11.5": 1.47
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.3,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 54,
+            "odds": 1.61,
+            "implied": 62.1,
+            "edge": -8.1,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 31,
+            "odds": 2.3,
+            "implied": 43.5,
+            "edge": -12.5,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 27,
+            "odds": 4.25,
+            "implied": 23.5,
+            "edge": 3.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 81,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": 4.1,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 62,
+            "odds": 1.43,
+            "implied": 69.9,
+            "edge": -7.9,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 54,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": 1.9,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 42,
+          "odds": 1.55,
+          "implied": 64.5,
+          "edge": -22.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Stabæk",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Åsane",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Lyn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Hødd",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Strømsgodset",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Raufoss",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Strømmen",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Moss",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Raufoss",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Moss",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Strømmen",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Ranheim",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Sogndal",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Åsane",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Egersund",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Stabæk",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
       "id": "8447219",
-      "league": "Urvalsdeild",
+      "league": "Úrvalsdeild",
       "region": "Iceland",
       "date": "2026-07-04",
       "time": "17:00",
       "home": {
-        "name": "IBV",
-        "short": "IBV",
+        "name": "ÍBV",
+        "short": "ÍBV",
         "logo": "https://cdn.footystats.org/img/teams/iceland-ib-vestmannaeyja.png"
       },
       "away": {
@@ -1342,37 +15568,37 @@
         "btts": false
       },
       "goals_avg": 3.9,
-      "corners_avg": 11,
-      "cards_avg": 4.3,
+      "corners_avg": 11.7,
+      "cards_avg": 2.4,
       "btts_pct": 80,
       "goals_over": {
         "0.5": 100,
-        "1.5": 90,
-        "2.5": 70,
-        "3.5": 45,
-        "4.5": 40
+        "1.5": 92.5,
+        "2.5": 72,
+        "3.5": 48,
+        "4.5": 39.5
       },
       "corners_over": {
-        "8.5": 70,
-        "9.5": 60,
-        "10.5": 55,
-        "11.5": 45
+        "8.5": 76,
+        "9.5": 67.5,
+        "10.5": 63.5,
+        "11.5": 55
       },
       "cards_over": {
-        "2.5": 65,
-        "3.5": 60,
-        "4.5": 40,
-        "5.5": 30
+        "2.5": 59.5,
+        "3.5": 56,
+        "4.5": 36.5,
+        "5.5": 28
       },
       "goals_odds": {
-        "2.5": 1.36,
-        "3.5": 2.04,
-        "4.5": 3.05
+        "2.5": 1.44,
+        "3.5": 1.92,
+        "4.5": 3.29
       },
       "corners_odds": {
         "8.5": 1.17,
-        "9.5": 1.47,
-        "10.5": 1.59
+        "9.5": 1.33,
+        "10.5": 1.66
       },
       "cards_odds": {
         "3.5": null,
@@ -1381,67 +15607,67 @@
       },
       "btts_odds": 1.36,
       "goals_under_odds": {
-        "0.5": 17,
-        "1.5": 5.7,
+        "0.5": 16.5,
+        "1.5": 5.65,
         "2.5": 2.62,
-        "3.5": 1.75
+        "3.5": 1.74
       },
       "corners_under_odds": {
-        "8.5": 4,
-        "9.5": 2.71,
-        "10.5": 2.13,
-        "11.5": 1.72
+        "8.5": 4.0,
+        "9.5": 2.83,
+        "10.5": 2.08,
+        "11.5": 1.7
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.9,
+      "btts_no_odds": 2.89,
       "value": {
         "goals": {
           "2.5": {
-            "prob": 70,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": -3.5,
+            "prob": 72,
+            "odds": 1.44,
+            "implied": 69.4,
+            "edge": 2.6,
             "flag": null
           },
           "3.5": {
-            "prob": 45,
-            "odds": 2.04,
-            "implied": 49,
-            "edge": -4,
+            "prob": 48,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": -4.1,
             "flag": null
           },
           "4.5": {
-            "prob": 40,
-            "odds": 3.05,
-            "implied": 32.8,
-            "edge": 7.2,
+            "prob": 39.5,
+            "odds": 3.29,
+            "implied": 30.4,
+            "edge": 9.1,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
-            "prob": 70,
+            "prob": 76,
             "odds": 1.17,
             "implied": 85.5,
-            "edge": -15.5,
+            "edge": -9.5,
             "flag": null
           },
           "9.5": {
-            "prob": 60,
-            "odds": 1.47,
-            "implied": 68,
-            "edge": -8,
+            "prob": 67.5,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": -7.7,
             "flag": null
           },
           "10.5": {
-            "prob": 55,
-            "odds": 1.59,
-            "implied": 62.9,
-            "edge": -7.9,
+            "prob": 63.5,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": 3.3,
             "flag": null
           }
         },
@@ -1478,7 +15704,7 @@
         },
         {
           "date": "2026-06-14",
-          "opp": "Thor",
+          "opp": "Thór",
           "ha": "A",
           "gf": 4,
           "ga": 1,
@@ -1489,7 +15715,7 @@
         },
         {
           "date": "2026-05-31",
-          "opp": "Keflavik",
+          "opp": "Keflavík",
           "ha": "H",
           "gf": 6,
           "ga": 1,
@@ -1500,7 +15726,7 @@
         },
         {
           "date": "2026-05-21",
-          "opp": "IA",
+          "opp": "ÍA",
           "ha": "A",
           "gf": 2,
           "ga": 2,
@@ -1511,7 +15737,7 @@
         },
         {
           "date": "2026-05-17",
-          "opp": "Vikingur Reykjavik",
+          "opp": "Víkingur Reykjavík",
           "ha": "H",
           "gf": 0,
           "ga": 2,
@@ -1546,7 +15772,7 @@
       "away_form": [
         {
           "date": "2026-06-28",
-          "opp": "Thor",
+          "opp": "Thór",
           "ha": "A",
           "gf": 4,
           "ga": 2,
@@ -1557,7 +15783,7 @@
         },
         {
           "date": "2026-06-21",
-          "opp": "Keflavik",
+          "opp": "Keflavík",
           "ha": "H",
           "gf": 1,
           "ga": 1,
@@ -1568,7 +15794,7 @@
         },
         {
           "date": "2026-06-16",
-          "opp": "IA",
+          "opp": "ÍA",
           "ha": "A",
           "gf": 0,
           "ga": 1,
@@ -1579,7 +15805,7 @@
         },
         {
           "date": "2026-05-31",
-          "opp": "Vikingur Reykjavik",
+          "opp": "Víkingur Reykjavík",
           "ha": "H",
           "gf": 1,
           "ga": 5,
@@ -1637,7 +15863,7 @@
         {
           "date": "2026-04-17",
           "home": "Valur",
-          "away": "IBV",
+          "away": "ÍBV",
           "hg": 2,
           "ag": 1,
           "corners": 11,
@@ -1646,20 +15872,347 @@
       ]
     },
     {
-      "id": "8420429",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-05",
-      "time": "13:00",
+      "id": "8465926",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-04",
+      "time": "17:00",
       "home": {
-        "name": "IFK Goteborg",
-        "short": "IFK",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-ifk-goteborg.png"
+        "name": "Paide",
+        "short": "PAI",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-paide-linnameeskond.png"
       },
       "away": {
-        "name": "AIK",
-        "short": "AIK",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-aik-fotboll.png"
+        "name": "Vaprus",
+        "short": "VAP",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-parnu-jk-vaprus.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 10.3,
+      "cards_avg": 2.2,
+      "btts_pct": 63,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 71.5,
+        "2.5": 54.5,
+        "3.5": 34,
+        "4.5": 20.5
+      },
+      "corners_over": {
+        "8.5": 68.5,
+        "9.5": 57.5,
+        "10.5": 49,
+        "11.5": 37.5
+      },
+      "cards_over": {
+        "2.5": 85.5,
+        "3.5": 71.5,
+        "4.5": 51.5,
+        "5.5": 28.5
+      },
+      "goals_odds": {
+        "2.5": 1.54,
+        "3.5": 2.33,
+        "4.5": 4.05
+      },
+      "corners_odds": {
+        "8.5": 1.27,
+        "9.5": 1.46,
+        "10.5": 1.74
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.68,
+      "goals_under_odds": {
+        "0.5": 13.4,
+        "1.5": 4.35,
+        "2.5": 2.27,
+        "3.5": 1.48
+      },
+      "corners_under_odds": {
+        "8.5": 3.25,
+        "9.5": 2.43,
+        "10.5": 1.93,
+        "11.5": 1.6
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.04,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 54.5,
+            "odds": 1.54,
+            "implied": 64.9,
+            "edge": -10.4,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 34,
+            "odds": 2.33,
+            "implied": 42.9,
+            "edge": -8.9,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 20.5,
+            "odds": 4.05,
+            "implied": 24.7,
+            "edge": -4.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 68.5,
+            "odds": 1.27,
+            "implied": 78.7,
+            "edge": -10.2,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 57.5,
+            "odds": 1.46,
+            "implied": 68.5,
+            "edge": -11,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 49,
+            "odds": 1.74,
+            "implied": 57.5,
+            "edge": -8.5,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 63,
+          "odds": 1.68,
+          "implied": 59.5,
+          "edge": 3.5,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Nõmme Kalju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tallinna FC Flora",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Harju Jalgpallikool",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Nõmme Kalju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Kuressaare",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Trans",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Nõmme United",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "Kuressaare",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 16,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 6,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-07",
+          "home": "Vaprus",
+          "away": "Paide",
+          "hg": 3,
+          "ag": 2,
+          "corners": 13,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8465956",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-04",
+      "time": "17:00",
+      "home": {
+        "name": "Trans",
+        "short": "TRA",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-narva-trans.png"
+      },
+      "away": {
+        "name": "Tallinna FC Levadia",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-levadia.png"
       },
       "result": {
         "hg": 0,
@@ -1669,1747 +16222,154 @@
         "btts": false
       },
       "goals_avg": 3.2,
-      "corners_avg": 10.8,
-      "cards_avg": 4.6,
-      "btts_pct": 65,
+      "corners_avg": 10.7,
+      "cards_avg": 2.4,
+      "btts_pct": 53.5,
       "goals_over": {
-        "0.5": 100,
+        "0.5": 97,
         "1.5": 85,
-        "2.5": 50,
-        "3.5": 30,
-        "4.5": 20
+        "2.5": 71.5,
+        "3.5": 28.5,
+        "4.5": 14.5
       },
       "corners_over": {
-        "8.5": 80,
-        "9.5": 60,
-        "10.5": 50,
-        "11.5": 45
+        "8.5": 77,
+        "9.5": 65.5,
+        "10.5": 51.5,
+        "11.5": 40
       },
       "cards_over": {
-        "2.5": 75,
-        "3.5": 65,
-        "4.5": 45,
-        "5.5": 25
+        "2.5": 88.5,
+        "3.5": 57.5,
+        "4.5": 51.5,
+        "5.5": 23
       },
       "goals_odds": {
-        "2.5": 1.83,
-        "3.5": 2.75,
-        "4.5": 4.74
+        "2.5": 1.36,
+        "3.5": 1.92,
+        "4.5": 2.92
       },
       "corners_odds": {
-        "8.5": 1.25,
-        "9.5": 1.42,
-        "10.5": 1.68
+        "8.5": 1.19,
+        "9.5": 1.32,
+        "10.5": 1.52
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.53,
+      "btts_odds": 1.86,
       "goals_under_odds": {
-        "0.5": 11.7,
-        "1.5": 4.15,
-        "2.5": 1.98,
-        "3.5": 1.42
+        "0.5": 16.0,
+        "1.5": 6.5,
+        "2.5": 3.1,
+        "3.5": 1.79
       },
       "corners_under_odds": {
-        "8.5": 3.5,
-        "9.5": 2.6,
-        "10.5": 2.02,
-        "11.5": 1.68
+        "8.5": 4.0,
+        "9.5": 3.0,
+        "10.5": 2.3,
+        "11.5": 1.86
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 1.8,
       "value": {
         "goals": {
           "2.5": {
-            "prob": 50,
-            "odds": 1.83,
-            "implied": 54.6,
-            "edge": -4.6,
+            "prob": 71.5,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": -2,
             "flag": null
           },
           "3.5": {
-            "prob": 30,
-            "odds": 2.75,
-            "implied": 36.4,
-            "edge": -6.4,
+            "prob": 28.5,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": -23.6,
             "flag": null
           },
           "4.5": {
-            "prob": 20,
-            "odds": 4.74,
-            "implied": 21.1,
-            "edge": -1.1,
+            "prob": 14.5,
+            "odds": 2.92,
+            "implied": 34.2,
+            "edge": -19.7,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
-            "prob": 80,
-            "odds": 1.25,
-            "implied": 80,
-            "edge": 0,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 60,
-            "odds": 1.42,
-            "implied": 70.4,
-            "edge": -10.4,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 50,
-            "odds": 1.68,
-            "implied": 59.5,
-            "edge": -9.5,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 65,
-          "odds": 1.53,
-          "implied": 65.4,
-          "edge": -0.4,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-05-31",
-          "opp": "Vasteras SK",
-          "ha": "A",
-          "gf": 5,
-          "ga": 4,
-          "res": "W",
-          "corners": 10,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Mjallby",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 9,
-          "btts": true
-        },
-        {
-          "date": "2026-05-19",
-          "opp": "Orgryte",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Hammarby",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Djurgarden",
-          "ha": "A",
-          "gf": 0,
-          "ga": 6,
-          "res": "L",
-          "corners": 14,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-04-26",
-          "opp": "GAIS",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Kalmar",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 13,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Halmstad",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 2,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-30",
-          "opp": "Sirius",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Hammarby",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Vasteras SK",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Djurgarden",
-          "ha": "H",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 16,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Elfsborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Malmo FF",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 22,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Degerfors",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-04-19",
-          "opp": "Kalmar",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420463",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-05",
-      "time": "13:00",
-      "home": {
-        "name": "Kalmar",
-        "short": "KAL",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-kalmar-ff.png"
-      },
-      "away": {
-        "name": "Orgryte",
-        "short": "ORG",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-orgryte-is.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.1,
-      "corners_avg": 10.4,
-      "cards_avg": 3.2,
-      "btts_pct": 55,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 85,
-        "2.5": 50,
-        "3.5": 30,
-        "4.5": 20
-      },
-      "corners_over": {
-        "8.5": 70,
-        "9.5": 55,
-        "10.5": 50,
-        "11.5": 45
-      },
-      "cards_over": {
-        "2.5": 75,
-        "3.5": 40,
-        "4.5": 20,
-        "5.5": 5
-      },
-      "goals_odds": {
-        "2.5": 1.66,
-        "3.5": 2.7,
-        "4.5": 4.65
-      },
-      "corners_odds": {
-        "8.5": 1.25,
-        "9.5": 1.42,
-        "10.5": 1.68
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.73,
-      "goals_under_odds": {
-        "0.5": 12,
-        "1.5": 4,
-        "2.5": 2.15,
-        "3.5": 1.4
-      },
-      "corners_under_odds": {
-        "8.5": 3.45,
-        "9.5": 2.6,
-        "10.5": 2.02,
-        "11.5": 1.68
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.97,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 50,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -10.2,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 30,
-            "odds": 2.7,
-            "implied": 37,
+            "prob": 77,
+            "odds": 1.19,
+            "implied": 84,
             "edge": -7,
             "flag": null
           },
-          "4.5": {
-            "prob": 20,
-            "odds": 4.65,
-            "implied": 21.5,
-            "edge": -1.5,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 70,
-            "odds": 1.25,
-            "implied": 80,
-            "edge": -10,
-            "flag": null
-          },
           "9.5": {
-            "prob": 55,
-            "odds": 1.42,
-            "implied": 70.4,
-            "edge": -15.4,
+            "prob": 65.5,
+            "odds": 1.32,
+            "implied": 75.8,
+            "edge": -10.3,
             "flag": null
           },
           "10.5": {
-            "prob": 50,
-            "odds": 1.68,
-            "implied": 59.5,
-            "edge": -9.5,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 55,
-          "odds": 1.73,
-          "implied": 57.8,
-          "edge": -2.8,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-05-30",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 11,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Degerfors",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Brommapojkarna",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 7,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Halmstad",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 15,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Sirius",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Elfsborg",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 4,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "IFK Goteborg",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 13,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-19",
-          "opp": "AIK",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-29",
-          "opp": "Elfsborg",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 6,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Halmstad",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 8,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-19",
-          "opp": "IFK Goteborg",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-11",
-          "opp": "Sirius",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 9,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 0,
-          "ga": 4,
-          "res": "L",
-          "corners": 10,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Degerfors",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-22",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 3,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Hammarby",
-          "ha": "A",
-          "gf": 1,
-          "ga": 8,
-          "res": "L",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420307",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-04",
-      "time": "14:00",
-      "home": {
-        "name": "Degerfors",
-        "short": "DEG",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-degerfors-if.png"
-      },
-      "away": {
-        "name": "Malmo FF",
-        "short": "MAL",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-malmo-ff.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.4,
-      "corners_avg": 9.9,
-      "cards_avg": 3.7,
-      "btts_pct": 75,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 85,
-        "2.5": 65,
-        "3.5": 45,
-        "4.5": 35
-      },
-      "corners_over": {
-        "8.5": 55,
-        "9.5": 40,
-        "10.5": 35,
-        "11.5": 25
-      },
-      "cards_over": {
-        "2.5": 75,
-        "3.5": 50,
-        "4.5": 20,
-        "5.5": 15
-      },
-      "goals_odds": {
-        "2.5": 1.85,
-        "3.5": 2.89,
-        "4.5": 5.4
-      },
-      "corners_odds": {
-        "8.5": 1.3,
-        "9.5": 1.52,
-        "10.5": 1.95
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.67,
-      "goals_under_odds": {
-        "0.5": 9,
-        "1.5": 3.8,
-        "2.5": 1.95,
-        "3.5": 1.38
-      },
-      "corners_under_odds": {
-        "8.5": 3.1,
-        "9.5": 2.33,
-        "10.5": 1.77,
-        "11.5": 1.55
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.08,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 65,
-            "odds": 1.85,
-            "implied": 54.1,
-            "edge": 10.9,
-            "flag": "value"
-          },
-          "3.5": {
-            "prob": 45,
-            "odds": 2.89,
-            "implied": 34.6,
-            "edge": 10.4,
-            "flag": "value"
-          },
-          "4.5": {
-            "prob": 35,
-            "odds": 5.4,
-            "implied": 18.5,
-            "edge": 16.5,
-            "flag": "value"
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 55,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -21.9,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 40,
+            "prob": 51.5,
             "odds": 1.52,
             "implied": 65.8,
-            "edge": -25.8,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 35,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -16.3,
+            "edge": -14.3,
             "flag": null
           }
         },
         "btts": {
-          "prob": 75,
-          "odds": 1.67,
-          "implied": 59.9,
-          "edge": 15.1,
-          "flag": "value"
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-05-31",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 8,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Kalmar",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Mjallby",
-          "ha": "H",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Hacken",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Orgryte",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "AIK",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-04-17",
-          "opp": "Elfsborg",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 8,
-          "cards": 8,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-30",
-          "opp": "Halmstad",
-          "ha": "H",
-          "gf": 5,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Vasteras SK",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 5,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Hammarby",
-          "ha": "A",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 13,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Hacken",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 9,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Mjallby",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "AIK",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 22,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Sirius",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-17",
-          "opp": "Djurgarden",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 9,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420399",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-04",
-      "time": "14:00",
-      "home": {
-        "name": "Halmstad",
-        "short": "HAL",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-halmstads-bk.png"
-      },
-      "away": {
-        "name": "Vasteras SK",
-        "short": "VAS",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-vasteras-sk-fotboll.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.4,
-      "corners_avg": 9.8,
-      "cards_avg": 3.3,
-      "btts_pct": 65,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 90,
-        "2.5": 55,
-        "3.5": 35,
-        "4.5": 25
-      },
-      "corners_over": {
-        "8.5": 65,
-        "9.5": 50,
-        "10.5": 35,
-        "11.5": 30
-      },
-      "cards_over": {
-        "2.5": 60,
-        "3.5": 45,
-        "4.5": 20,
-        "5.5": 10
-      },
-      "goals_odds": {
-        "2.5": 1.82,
-        "3.5": 2.85,
-        "4.5": 5.35
-      },
-      "corners_odds": {
-        "8.5": 1.37,
-        "9.5": 1.72,
-        "10.5": 1.97
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.62,
-      "goals_under_odds": {
-        "0.5": 10,
-        "1.5": 3.82,
-        "2.5": 1.98,
-        "3.5": 1.33
-      },
-      "corners_under_odds": {
-        "8.5": 2.8,
-        "9.5": 2.14,
-        "10.5": 1.73,
-        "11.5": 1.33
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.1,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 55,
-            "odds": 1.82,
-            "implied": 54.9,
-            "edge": 0.1,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 35,
-            "odds": 2.85,
-            "implied": 35.1,
-            "edge": -0.1,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 25,
-            "odds": 5.35,
-            "implied": 18.7,
-            "edge": 6.3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 65,
-            "odds": 1.37,
-            "implied": 73,
-            "edge": -8,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 50,
-            "odds": 1.72,
-            "implied": 58.1,
-            "edge": -8.1,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 35,
-            "odds": 1.97,
-            "implied": 50.8,
-            "edge": -15.8,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 65,
-          "odds": 1.62,
-          "implied": 61.7,
-          "edge": 3.3,
+          "prob": 53.5,
+          "odds": 1.86,
+          "implied": 53.8,
+          "edge": -0.3,
           "flag": null
         }
       },
       "home_form": [
         {
-          "date": "2026-05-30",
-          "opp": "Malmo FF",
-          "ha": "A",
-          "gf": 2,
-          "ga": 5,
-          "res": "L",
-          "corners": 9,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Orgryte",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Elfsborg",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Kalmar",
+          "date": "2026-06-21",
+          "opp": "Tammeka",
           "ha": "A",
           "gf": 0,
-          "ga": 2,
+          "ga": 1,
           "res": "L",
-          "corners": 15,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 9,
+          "corners": 10,
           "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Mjallby",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 13,
-          "cards": 2,
           "btts": false
         },
         {
-          "date": "2026-04-22",
-          "opp": "Hammarby",
+          "date": "2026-06-16",
+          "opp": "Kuressaare",
           "ha": "A",
-          "gf": 1,
-          "ga": 1,
+          "gf": 0,
+          "ga": 0,
           "res": "D",
-          "corners": 9,
+          "corners": 12,
           "cards": 5,
-          "btts": true
+          "btts": false
         },
         {
-          "date": "2026-04-18",
-          "opp": "IFK Goteborg",
+          "date": "2026-06-13",
+          "opp": "Nõmme United",
           "ha": "H",
           "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 2,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-31",
-          "opp": "IFK Goteborg",
-          "ha": "H",
-          "gf": 4,
-          "ga": 5,
-          "res": "L",
-          "corners": 10,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Malmo FF",
-          "ha": "A",
-          "gf": 3,
           "ga": 2,
-          "res": "W",
-          "corners": 5,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "AIK",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "GAIS",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
           "res": "L",
-          "corners": 6,
+          "corners": 9,
           "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Hammarby",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-04-26",
-          "opp": "Brommapojkarna",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 1,
           "btts": true
         },
-        {
-          "date": "2026-04-22",
-          "opp": "Hacken",
-          "ha": "H",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 14,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Sirius",
-          "ha": "A",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420464",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-03",
-      "time": "18:00",
-      "home": {
-        "name": "Sirius",
-        "short": "SIR",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-ik-sirius-fotboll.png"
-      },
-      "away": {
-        "name": "Mjallby",
-        "short": "MJA",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-mjallby-aif.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.1,
-      "corners_avg": 9.5,
-      "cards_avg": 3.6,
-      "btts_pct": 50,
-      "goals_over": {
-        "0.5": 95,
-        "1.5": 90,
-        "2.5": 60,
-        "3.5": 35,
-        "4.5": 30
-      },
-      "corners_over": {
-        "8.5": 60,
-        "9.5": 50,
-        "10.5": 40,
-        "11.5": 35
-      },
-      "cards_over": {
-        "2.5": 60,
-        "3.5": 55,
-        "4.5": 30,
-        "5.5": 20
-      },
-      "goals_odds": {
-        "2.5": 1.68,
-        "3.5": 2.51,
-        "4.5": 4.4
-      },
-      "corners_odds": {
-        "8.5": 1.3,
-        "9.5": 1.5,
-        "10.5": 1.79
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.64,
-      "goals_under_odds": {
-        "0.5": 11.5,
-        "1.5": 4.33,
-        "2.5": 2.15,
-        "3.5": 1.42
-      },
-      "corners_under_odds": {
-        "8.5": 3.15,
-        "9.5": 2.38,
-        "10.5": 1.89,
-        "11.5": 1.58
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.13,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 60,
-            "odds": 1.68,
-            "implied": 59.5,
-            "edge": 0.5,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 35,
-            "odds": 2.51,
-            "implied": 39.8,
-            "edge": -4.8,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 30,
-            "odds": 4.4,
-            "implied": 22.7,
-            "edge": 7.3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 60,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -16.9,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 50,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": -16.7,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 40,
-            "odds": 1.79,
-            "implied": 55.9,
-            "edge": -15.9,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 50,
-          "odds": 1.64,
-          "implied": 61,
-          "edge": -11,
-          "flag": null
-        }
-      },
-      "home_form": [
         {
           "date": "2026-05-30",
-          "opp": "AIK",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "GAIS",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-18",
-          "opp": "Djurgarden",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-11",
-          "opp": "Orgryte",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Kalmar",
-          "ha": "H",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Hacken",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 14,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Malmo FF",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Vasteras SK",
-          "ha": "H",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-25",
-          "opp": "IFK Goteborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 9,
-          "btts": true
-        },
-        {
-          "date": "2026-05-21",
-          "opp": "Elfsborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Hacken",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 12,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Degerfors",
-          "ha": "A",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Malmo FF",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 7,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Halmstad",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 6,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420348",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-06",
-      "time": "18:00",
-      "home": {
-        "name": "Brommapojkarna",
-        "short": "BRO",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-if-brommapojkarna.png"
-      },
-      "away": {
-        "name": "GAIS",
-        "short": "GAI",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-gais.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.7,
-      "corners_avg": 9,
-      "cards_avg": 3.6,
-      "btts_pct": 60,
-      "goals_over": {
-        "0.5": 95,
-        "1.5": 80,
-        "2.5": 65,
-        "3.5": 30,
-        "4.5": 0
-      },
-      "corners_over": {
-        "8.5": 60,
-        "9.5": 40,
-        "10.5": 40,
-        "11.5": 20
-      },
-      "cards_over": {
-        "2.5": 75,
-        "3.5": 45,
-        "4.5": 20,
-        "5.5": 10
-      },
-      "goals_odds": {
-        "2.5": 1.81,
-        "3.5": null,
-        "4.5": null
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": null,
-      "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": 1.9,
-        "3.5": null
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": null,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 65,
-            "odds": 1.81,
-            "implied": 55.2,
-            "edge": 9.8,
-            "flag": null
-          },
-          "3.5": null,
-          "4.5": null
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null
-        },
-        "btts": null
-      },
-      "home_form": [
-        {
-          "date": "2026-05-31",
-          "opp": "Degerfors",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 8,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Djurgarden",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Kalmar",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Elfsborg",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Halmstad",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-04-26",
-          "opp": "Vasteras SK",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-22",
-          "opp": "Orgryte",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 3,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Mjallby",
+          "opp": "Harju Jalgpallikool",
           "ha": "A",
           "gf": 0,
           "ga": 3,
@@ -3417,416 +16377,153 @@
           "corners": 6,
           "cards": 4,
           "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-30",
-          "opp": "Kalmar",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 11,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Sirius",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
         },
         {
           "date": "2026-05-20",
-          "opp": "Hammarby",
+          "opp": "Paide",
           "ha": "H",
-          "gf": 2,
+          "gf": 1,
           "ga": 0,
           "res": "W",
-          "corners": 5,
-          "cards": 4,
+          "corners": 13,
+          "cards": 5,
           "btts": false
         },
         {
           "date": "2026-05-16",
-          "opp": "Degerfors",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-20",
+          "opp": "Nõmme Kalju",
           "ha": "H",
           "gf": 1,
           "ga": 1,
           "res": "D",
-          "corners": 9,
-          "cards": 3,
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Nõmme United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tallinna FC Flora",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 6,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
           "btts": true
         },
         {
           "date": "2026-05-09",
-          "opp": "Vasteras SK",
-          "ha": "A",
-          "gf": 1,
+          "opp": "Harju Jalgpallikool",
+          "ha": "H",
+          "gf": 3,
           "ga": 0,
           "res": "W",
-          "corners": 6,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Orgryte",
-          "ha": "H",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-04-26",
-          "opp": "IFK Goteborg",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Mjallby",
-          "ha": "H",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420330",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-05",
-      "time": "15:30",
-      "home": {
-        "name": "Elfsborg",
-        "short": "ELF",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-if-elfsborg.png"
-      },
-      "away": {
-        "name": "Hammarby",
-        "short": "HAM",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-hammarby-if.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.8,
-      "corners_avg": 8.5,
-      "cards_avg": 3.4,
-      "btts_pct": 60,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 90,
-        "2.5": 40,
-        "3.5": 20,
-        "4.5": 10
-      },
-      "corners_over": {
-        "8.5": 55,
-        "9.5": 30,
-        "10.5": 25,
-        "11.5": 20
-      },
-      "cards_over": {
-        "2.5": 55,
-        "3.5": 45,
-        "4.5": 30,
-        "5.5": 10
-      },
-      "goals_odds": {
-        "2.5": 1.75,
-        "3.5": 2.85,
-        "4.5": 4.95
-      },
-      "corners_odds": {
-        "8.5": 1.36,
-        "9.5": 1.6,
-        "10.5": 1.95
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.6,
-      "goals_under_odds": {
-        "0.5": 11.8,
-        "1.5": 4.05,
-        "2.5": 2.1,
-        "3.5": 1.42
-      },
-      "corners_under_odds": {
-        "8.5": 2.85,
-        "9.5": 2.17,
-        "10.5": 1.75,
-        "11.5": 1.48
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.14,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 40,
-            "odds": 1.75,
-            "implied": 57.1,
-            "edge": -17.1,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 20,
-            "odds": 2.85,
-            "implied": 35.1,
-            "edge": -15.1,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 10,
-            "odds": 4.95,
-            "implied": 20.2,
-            "edge": -10.2,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 55,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": -18.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 30,
-            "odds": 1.6,
-            "implied": 62.5,
-            "edge": -32.5,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 25,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -26.3,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 60,
-          "odds": 1.6,
-          "implied": 62.5,
-          "edge": -2.5,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-05-29",
-          "opp": "Orgryte",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 6,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Hacken",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-21",
-          "opp": "Mjallby",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Halmstad",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "AIK",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Kalmar",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
           "corners": 4,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-04-22",
-          "opp": "Djurgarden",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-31",
-          "opp": "Hacken",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 15,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "AIK",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 5,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Malmo FF",
-          "ha": "H",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 13,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "IFK Goteborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Vasteras SK",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
           "cards": 3,
           "btts": false
-        },
-        {
-          "date": "2026-04-26",
-          "opp": "Djurgarden",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 3,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-04-22",
-          "opp": "Halmstad",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
         }
       ],
-      "h2h": []
+      "h2h": [
+        {
+          "date": "2026-04-26",
+          "home": "Tallinna FC Levadia",
+          "away": "Trans",
+          "hg": 7,
+          "ag": 0,
+          "corners": 13,
+          "cards": 3
+        }
+      ]
     }
   ]
 }

--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -16,6 +16,18 @@ type ValueCell = FormValueCell | null;
 type TablesPayload = { leagues: { name: string; region: string }[]; fixtures: Fixture[] };
 const SNAPSHOT = raw as unknown as TablesPayload;
 
+/**
+ * Is a live payload healthy enough to trust? A stale/broken build shows up as
+ * unresolved league labels ("League 16696"). If most fixtures lack a real league
+ * name we fall back to the bundled slate rather than render the broken feed.
+ */
+function isHealthy(p: TablesPayload | null): p is TablesPayload {
+  const fx = p?.fixtures ?? [];
+  if (fx.length === 0) return false;
+  const named = fx.filter((f) => f.league && !/^League\s*\d+$/i.test(String(f.league))).length;
+  return named / fx.length >= 0.6;
+}
+
 /** Live today's slate from daily_form_tables (built 3am UK); snapshot fallback. */
 function useFormTablesData(): { data: TablesPayload; live: boolean } {
   const { data } = useQuery({
@@ -34,7 +46,8 @@ function useFormTablesData(): { data: TablesPayload; live: boolean } {
       return { leagues: Array.isArray(data.leagues) ? data.leagues : [], fixtures: data.fixtures as Fixture[] };
     },
   });
-  return data ? { data, live: true } : { data: SNAPSHOT, live: false };
+  // Use the live feed only when it's healthy; otherwise the bundled slate.
+  return isHealthy(data ?? null) ? { data: data!, live: true } : { data: SNAPSHOT, live: false };
 }
 
 /* ── Category config — over + under per market ───────────────────────── */


### PR DESCRIPTION
Frontend-only fix so the form tables are correct **now**, independent of the Supabase edge-function deploy.

- **Regenerated the bundled slate** from the live FootyStats API: 12 active leagues, 52 fixtures across today + 2 days, real league names (Iceland · Úrvalsdeild, Norway · First Division, China · Chinese Super League…), real combined averages, odds and form.
- **Health check**: the page now falls back to the bundled slate when the live feed is unhealthy (unresolved "League 16696" labels), so it never renders a broken build — and switches back to live automatically once that feed is healthy.

Verified in preview: AVG populated and ranked, Today/Tmrw/4 Jul, PLAYING TODAY badges, purple Gaffer's banker, real logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_