### PR TITLE
Fantasy engine: FPL read proxies + data layer + page rebind to locked rules

### DIFF
--- a/src/components/fantasy/FantasyPageHero.tsx
+++ b/src/components/fantasy/FantasyPageHero.tsx
@@ -1,103 +1,84 @@
 import { Link } from 'react-router-dom';
-import { Crown, ArrowRight, ChevronDown, Trophy, Users, TrendingUp, TrendingDown, Minus } from 'lucide-react';
-import { useFantasyPlayers, useFantasyStandings, useFantasyMeta } from '@/hooks/useFantasyLeague';
+import { Crown, Trophy, ChevronDown, TrendingUp, TrendingDown, Minus, CalendarClock } from 'lucide-react';
+import { useFantasyPlayers, useFantasyStandings, useFantasyGameweek, FANTASY_RULES } from '@/hooks/useFantasyLeague';
+import type { FantasyStandingRow } from '@/types/footy';
 import { PlayerCard } from './PlayerCard';
 import { Countdown } from './Countdown';
 
 const STADIUM = '/images/backgrounds/bg-stadium.jpg';
 const GAFFER = '/images/gaffer/gaffer-pointing-you.png';
 
-function MovementIcon({ m }: { m: 'up' | 'down' | 'same' }) {
-  if (m === 'up') return <TrendingUp className="h-3 w-3 text-emerald-400" />;
-  if (m === 'down') return <TrendingDown className="h-3 w-3 text-red-400" />;
+const isGaffer = (r: FantasyStandingRow) => /gaffer/i.test(r.manager_name) || /gaffer/i.test(r.team_name);
+
+function Movement({ m }: { m: number }) {
+  if (m > 0) return <TrendingUp className="h-3 w-3 text-emerald-400" />;
+  if (m < 0) return <TrendingDown className="h-3 w-3 text-red-400" />;
   return <Minus className="h-3 w-3 text-white/30" />;
 }
 
 /**
  * Fantasy page hero — brand lockup, "Pick your XI. Beat the Gaffer.", live GW
- * countdown, entry CTAs, a showcase of the top-rated players and a live mini
- * leaderboard. The Gaffer fronts it. All data-driven; art is decorative.
+ * countdown, entry CTA, a showcase of the top point-scorers and a live mini
+ * leaderboard. Bound to the fantasy read contracts; art is decorative.
  */
 export function FantasyPageHero() {
   const { data: pd } = useFantasyPlayers();
   const { data: sd } = useFantasyStandings();
-  const { data: md } = useFantasyMeta();
+  const { data: gw } = useFantasyGameweek();
 
-  const showcase = (pd?.players ?? [])
-    .slice()
-    .sort((a, b) => b.rating - a.rating)
-    .slice(0, 3);
+  const showcase = (pd?.players ?? []).slice().sort((a, b) => b.total_points - a.total_points).slice(0, 3);
   const leaders = (sd?.rows ?? []).slice(0, 5);
-  const meta = md;
 
   return (
     <section className="relative overflow-hidden">
-      {/* background: stadium + purple wash */}
       <img src={STADIUM} alt="" aria-hidden loading="eager" className="absolute inset-0 h-full w-full object-cover opacity-30" />
       <div aria-hidden className="absolute inset-0 bg-[radial-gradient(circle_at_80%_-10%,rgba(124,58,237,0.45),transparent_50%),radial-gradient(circle_at_10%_20%,rgba(245,197,66,0.14),transparent_45%),linear-gradient(180deg,rgba(5,2,11,0.55),#05020b_88%)]" />
       <div aria-hidden className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:40px_40px] opacity-30" />
 
       <div className="relative mx-auto grid max-w-7xl items-center gap-8 px-4 py-14 md:px-6 md:py-20 lg:grid-cols-[1.05fr_0.95fr]">
-        {/* ── left: copy ── */}
+        {/* left */}
         <div>
-          {/* brand lockup */}
           <div className="inline-flex flex-col">
             <div className="flex items-center gap-2">
               <Crown className="h-5 w-5 fill-[#f5c542] text-[#f5c542]" />
-              <span className="font-display text-2xl leading-none md:text-3xl">
-                <span className="text-[#f5c542]">FOOTY</span> <span className="text-white">ORACLES</span>
-              </span>
+              <span className="font-display text-2xl leading-none md:text-3xl"><span className="text-[#f5c542]">FOOTY</span> <span className="text-white">ORACLES</span></span>
             </div>
-            <span className="mt-2 inline-flex items-center gap-2 self-start rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.32em] text-[#f8e7a1]">
-              Fantasy Football
-            </span>
+            <span className="mt-2 inline-flex items-center gap-2 self-start rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.32em] text-[#f8e7a1]">Fantasy Football</span>
           </div>
 
           <h1 className="mt-5 font-display text-5xl uppercase leading-[0.86] tracking-tight text-white md:text-7xl">
-            Pick Your XI.
-            <br />
+            Pick Your XI.<br />
             <span className="bg-gradient-to-r from-violet-400 via-fuchsia-500 to-violet-500 bg-clip-text text-transparent">Beat</span> The Gaffer.
           </h1>
 
           <p className="mt-4 max-w-md text-sm leading-relaxed text-white/70 md:text-base">
-            Build your dream squad on a <span className="font-bold text-[#f8e7a1]">£{pd?.rules.budget ?? 95}m</span> budget, climb the
-            leaderboard and chase real cash. Outscore The Gaffer and the bragging rights are yours.
+            Build your dream squad on a <span className="font-bold text-[#f8e7a1]">£{FANTASY_RULES.budget}m</span> budget —
+            {' '}<span className="font-bold text-white">{FANTASY_RULES.squadSize} players</span>, climb the leaderboard and chase real cash. Outscore The Gaffer and the bragging rights are yours.
           </p>
 
-          {/* GW deadline countdown */}
           <div className="mt-6 inline-flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0b0518]/70 p-4 backdrop-blur sm:flex-row sm:items-center sm:gap-5">
             <div className="leading-tight">
-              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-violet-300">{meta?.gameweek.label ?? 'Next Gameweek'} deadline</div>
+              <div className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.2em] text-violet-300"><CalendarClock className="h-3.5 w-3.5" /> Gameweek {gw?.gameweek ?? ''} deadline</div>
               <div className="text-[11px] text-white/45">Lock your team before kick-off</div>
             </div>
-            <Countdown deadline={meta?.gameweek.deadline ?? null} />
+            <Countdown deadline={gw?.deadline_at ?? null} />
           </div>
 
-          {/* CTAs */}
           <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <Link to={meta?.season.joinUrl ?? '/pricing'} className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-7 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">
-              <Trophy className="h-4 w-4 fill-current" /> Enter the League
-            </Link>
-            <a href="#pick-squad" className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-400/45 bg-violet-500/[0.08] px-7 py-3.5 text-sm font-black uppercase tracking-wide text-violet-100 transition-all hover:-translate-y-0.5 hover:bg-violet-500/15">
-              Build Your Squad <ChevronDown className="h-4 w-4" />
-            </a>
+            <Link to="/pricing" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-7 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5"><Trophy className="h-4 w-4 fill-current" /> Enter the League</Link>
+            <a href="#pick-squad" className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-400/45 bg-violet-500/[0.08] px-7 py-3.5 text-sm font-black uppercase tracking-wide text-violet-100 transition-all hover:-translate-y-0.5 hover:bg-violet-500/15">Build Your Squad <ChevronDown className="h-4 w-4" /></a>
           </div>
 
-          {/* entries */}
-          {meta && (
-            <div className="mt-5 inline-flex items-center gap-2 text-[12px] font-black uppercase tracking-[0.14em] text-white/55">
-              <Users className="h-4 w-4 text-violet-300" /> {meta.entries.toLocaleString()} managers already in
-            </div>
-          )}
+          <div className="mt-5 inline-flex items-center gap-2 text-[12px] font-black uppercase tracking-[0.14em] text-white/55">
+            <Crown className="h-4 w-4 text-violet-300" /> Registration open · season starts Aug 2026
+          </div>
         </div>
 
-        {/* ── right: Gaffer + showcase + mini leaderboard ── */}
+        {/* right */}
         <div className="relative">
           <div className="relative mx-auto max-w-md lg:max-w-none">
-            {/* Gaffer */}
             <img src={GAFFER} alt="The Gaffer" loading="eager" draggable={false} className="pointer-events-none relative z-10 mx-auto h-[300px] w-auto select-none object-contain drop-shadow-[0_30px_60px_rgba(124,58,237,0.5)] md:h-[420px]" />
 
-            {/* player showcase — top-rated cards, floating bottom-left */}
             <div className="absolute -bottom-2 left-0 z-20 flex -space-x-4 sm:-space-x-2">
               {showcase.map((p, i) => (
                 <div key={p.id} className={i === 1 ? 'z-10 -mt-4' : ''} style={{ transform: `rotate(${(i - 1) * 6}deg)` }}>
@@ -106,7 +87,6 @@ export function FantasyPageHero() {
               ))}
             </div>
 
-            {/* mini leaderboard — floating top-right */}
             <div className="absolute -right-1 top-2 z-20 w-[220px] rounded-2xl border border-[#f5c542]/25 bg-[#0b0518]/90 p-3 shadow-[0_20px_50px_-18px_rgba(0,0,0,0.9)] backdrop-blur-md sm:right-0 md:w-[240px]">
               <div className="flex items-center gap-1.5 border-b border-white/10 pb-2">
                 <Crown className="h-3.5 w-3.5 fill-[#f5c542] text-[#f5c542]" />
@@ -114,11 +94,11 @@ export function FantasyPageHero() {
               </div>
               <ul className="mt-1.5 space-y-0.5">
                 {leaders.map((r) => (
-                  <li key={r.rank} className={`flex items-center gap-2 rounded-lg px-1.5 py-1 text-[11px] ${r.isGaffer ? 'bg-[#f5c542]/12' : ''}`}>
+                  <li key={r.team_id} className={`flex items-center gap-2 rounded-lg px-1.5 py-1 text-[11px] ${isGaffer(r) ? 'bg-[#f5c542]/12' : ''}`}>
                     <span className={`w-4 text-center font-black ${r.rank <= 3 ? 'text-[#f5c542]' : 'text-white/40'}`}>{r.rank}</span>
-                    <MovementIcon m={r.movement} />
-                    <span className={`flex-1 truncate font-bold ${r.isGaffer ? 'text-[#f8e7a1]' : 'text-white/80'}`}>{r.team}</span>
-                    <span className="font-black tabular-nums text-white/90">{r.total.toLocaleString()}</span>
+                    <Movement m={r.movement} />
+                    <span className={`flex-1 truncate font-bold ${isGaffer(r) ? 'text-[#f8e7a1]' : 'text-white/80'}`}>{r.team_name}</span>
+                    <span className="font-black tabular-nums text-white/90">{r.total_points.toLocaleString()}</span>
                   </li>
                 ))}
               </ul>
@@ -127,7 +107,6 @@ export function FantasyPageHero() {
         </div>
       </div>
 
-      {/* gold divider */}
       <div className="h-[3px] w-full bg-[linear-gradient(90deg,transparent,#f5c542_50%,transparent)]" />
     </section>
   );

--- a/src/components/fantasy/FantasyPrizes.tsx
+++ b/src/components/fantasy/FantasyPrizes.tsx
@@ -1,86 +1,74 @@
 import { Link } from 'react-router-dom';
 import { Gift, Plane, ChevronRight, Sparkles } from 'lucide-react';
-import { useFantasyPrizes, type FantasyPrize } from '@/hooks/useFantasyLeague';
+import { useFantasyPrizes } from '@/hooks/useFantasyLeague';
+import type { FantasyPrize } from '@/types/footy';
 
 const GAFFER = '/images/gaffer/gaffer-celebrating.png';
 
+const CATEGORY_LABEL: Record<FantasyPrize['category'], string> = {
+  seasonal: 'Season', weekly: 'Weekly', themed: 'Special', random: 'Wooden Spoon',
+};
+
 function PrizeTile({ p }: { p: FantasyPrize }) {
-  const fun = p.kind === 'fun';
+  const fun = p.category === 'random';
   return (
-    <div
-      className={`group relative overflow-hidden rounded-2xl border bg-[#0b0518]/70 transition-all hover:-translate-y-1 ${
-        fun ? 'border-amber-400/30 hover:border-amber-400/60 hover:shadow-[0_0_34px_-10px_rgba(245,197,66,0.7)]' : 'border-violet-400/25 hover:border-violet-400/55 hover:shadow-[0_0_34px_-10px_rgba(139,92,246,0.7)]'
-      }`}
-    >
-      <div className="relative h-28 overflow-hidden">
-        <img src={p.image} alt={p.title} loading="lazy" draggable={false} className={`h-full w-full object-cover transition-transform duration-500 group-hover:scale-105 ${fun ? 'group-hover:-rotate-1' : ''}`} />
+    <div className={`group relative overflow-hidden rounded-2xl border bg-[#0b0518]/70 transition-all hover:-translate-y-1 ${fun ? 'border-amber-400/30 hover:border-amber-400/60 hover:shadow-[0_0_34px_-10px_rgba(245,197,66,0.7)]' : 'border-violet-400/25 hover:border-violet-400/55 hover:shadow-[0_0_34px_-10px_rgba(139,92,246,0.7)]'}`}>
+      <div className="relative h-28 overflow-hidden bg-[#160a24]">
+        {p.image_url && <img src={p.image_url} alt={p.title} loading="lazy" draggable={false} className={`h-full w-full object-cover transition-transform duration-500 group-hover:scale-105 ${fun ? 'group-hover:-rotate-1' : ''}`} />}
         <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-[#0b0518] via-transparent to-transparent" />
-        <span className="absolute right-2 top-2 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-white/80 backdrop-blur">{p.tag}</span>
+        <span className="absolute right-2 top-2 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-white/80 backdrop-blur">{CATEGORY_LABEL[p.category]}</span>
       </div>
       <div className="p-3.5">
         <div className="text-[13px] font-black uppercase tracking-wide text-white">{p.title}</div>
-        <p className="mt-1 text-[12px] leading-snug text-white/55">{p.subtitle}</p>
+        <p className="mt-1 text-[12px] leading-snug text-white/55">{p.description}</p>
       </div>
     </div>
   );
 }
 
 /**
- * FantasyPrizes — "Prizes & Glory". Grand prize feature + prize tiles, all
- * driven by the prizes contract. Photos are decorative; titles/tags are HTML.
+ * FantasyPrizes — "Prizes & Glory" from the prizes contract. The seasonal
+ * headline gets the hero; the rest tile out. Photos are decorative; titles and
+ * descriptions are live HTML.
  */
 export function FantasyPrizes() {
   const { data, isLoading } = useFantasyPrizes();
+  if (isLoading && !data) return <div className="h-[460px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
-  if (isLoading && !data) {
-    return <div className="h-[460px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
-  }
-
-  const grand = data?.grand;
   const prizes = data?.prizes ?? [];
+  const grand = prizes.find((p) => p.category === 'seasonal') ?? prizes[0];
+  const tiles = prizes.filter((p) => p.id !== grand?.id).slice(0, 4);
 
   return (
     <section id="prizes" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(124,58,237,0.7)] md:rounded-[2rem]">
       <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
       <div aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_-10%,rgba(124,58,237,0.28),transparent_45%),radial-gradient(circle_at_90%_110%,rgba(245,197,66,0.12),transparent_45%)]" />
-
-      {/* Gaffer presenting, decorative right */}
       <img src={GAFFER} alt="" aria-hidden loading="lazy" draggable={false} className="pointer-events-none absolute -right-6 top-6 z-0 hidden h-[280px] w-auto select-none object-contain opacity-90 xl:block" />
 
       <div className="relative z-[1] p-5 md:p-7">
         <div className="max-w-xl">
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">
-            <Sparkles className="h-3.5 w-3.5" /> Prizes &amp; Glory
-          </span>
-          <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">
-            <span className="text-[#f5c542]">Win big.</span> Laugh harder.
-          </h2>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]"><Sparkles className="h-3.5 w-3.5" /> Prizes &amp; Glory</span>
+          <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl"><span className="text-[#f5c542]">Win big.</span> Laugh harder.</h2>
           <p className="mt-2 text-sm text-white/60">Real cash, real getaways, and the odd pair of donkey ears.</p>
         </div>
 
         <div className="mt-6 grid gap-4 lg:grid-cols-[1.15fr_1fr]">
-          {/* grand prize */}
           {grand && (
-            <div className="group relative overflow-hidden rounded-2xl border border-[#f5c542]/35 shadow-[0_0_44px_-16px_rgba(245,197,66,0.8)]">
-              <img src={grand.image} alt={grand.title} loading="lazy" draggable={false} className="h-full min-h-[240px] w-full object-cover transition-transform duration-700 group-hover:scale-105" />
+            <div className="group relative overflow-hidden rounded-2xl border border-[#f5c542]/35 bg-[#160a24] shadow-[0_0_44px_-16px_rgba(245,197,66,0.8)]">
+              {grand.image_url && <img src={grand.image_url} alt={grand.title} loading="lazy" draggable={false} className="h-full min-h-[240px] w-full object-cover transition-transform duration-700 group-hover:scale-105" />}
               <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-[#05020b] via-[#05020b]/40 to-transparent" />
-              <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-black/50 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-[#f8e7a1] backdrop-blur">
-                <Plane className="h-3.5 w-3.5" /> {grand.tag}
-              </span>
+              <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-black/50 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-[#f8e7a1] backdrop-blur"><Plane className="h-3.5 w-3.5" /> Grand Prize</span>
               <div className="absolute inset-x-0 bottom-0 p-5">
                 <div className="font-display text-4xl uppercase leading-none text-white md:text-5xl">{grand.title}</div>
-                <p className="mt-1.5 max-w-sm text-sm text-white/70">{grand.subtitle}</p>
+                <p className="mt-1.5 max-w-sm text-sm text-white/70">{grand.description}</p>
               </div>
             </div>
           )}
-
-          {/* prize tiles */}
           <div className="grid grid-cols-2 gap-4">
-            {prizes.map((p) => <PrizeTile key={p.id} p={p} />)}
+            {tiles.map((p) => <PrizeTile key={p.id} p={p} />)}
           </div>
         </div>
 
-        {/* CTA */}
         <div className="mt-6 flex flex-col items-center justify-between gap-3 rounded-2xl border border-white/10 bg-[#0b0518]/60 p-4 sm:flex-row">
           <div className="flex items-center gap-3">
             <span className="grid h-11 w-11 place-items-center rounded-xl border border-[#f5c542]/30 bg-[#f5c542]/10 text-[#f5c542]"><Gift className="h-5 w-5" /></span>
@@ -89,9 +77,7 @@ export function FantasyPrizes() {
               <div className="text-[12px] text-white/55">One league. Weekly rewards. Season-long glory.</div>
             </div>
           </div>
-          <Link to="/pricing" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">
-            Play Fantasy Now <ChevronRight className="h-4 w-4" />
-          </Link>
+          <Link to="/pricing" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Play Fantasy Now <ChevronRight className="h-4 w-4" /></Link>
         </div>
       </div>
     </section>

--- a/src/components/fantasy/LeagueStandings.tsx
+++ b/src/components/fantasy/LeagueStandings.tsx
@@ -1,107 +1,98 @@
 import { Link } from 'react-router-dom';
-import { Crown, TrendingUp, TrendingDown, Minus, Trophy, ChevronRight } from 'lucide-react';
-import { useFantasyStandings, type FantasyStandingRow } from '@/hooks/useFantasyLeague';
+import { Crown, TrendingUp, TrendingDown, Minus, Trophy, ChevronRight, Award } from 'lucide-react';
+import { useFantasyStandings } from '@/hooks/useFantasyLeague';
+import type { FantasyStandingRow } from '@/types/footy';
 
 const GAFFER = '/images/gaffer/gaffer-arms-crossed.png';
 
-function Movement({ m }: { m: FantasyStandingRow['movement'] }) {
-  if (m === 'up') return <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />;
-  if (m === 'down') return <TrendingDown className="h-3.5 w-3.5 text-red-400" />;
+// Cash rail is product/marketing copy (admin-set), not an FPL field.
+const CHAMPION = '£10,000 Cash';
+const TIERS = [
+  { rank: 1, label: '1st', value: '£10,000' },
+  { rank: 2, label: '2nd', value: '£3,000' },
+  { rank: 3, label: '3rd', value: '£1,000' },
+];
+
+const isGaffer = (r: FantasyStandingRow) => /gaffer/i.test(r.manager_name) || /gaffer/i.test(r.team_name);
+const isYou = (r: FantasyStandingRow) => /^you$/i.test(r.manager_name);
+
+function Movement({ m }: { m: number }) {
+  if (m > 0) return <span className="inline-flex items-center text-emerald-400"><TrendingUp className="h-3.5 w-3.5" /><span className="text-[10px] font-black">{m}</span></span>;
+  if (m < 0) return <span className="inline-flex items-center text-red-400"><TrendingDown className="h-3.5 w-3.5" /><span className="text-[10px] font-black">{Math.abs(m)}</span></span>;
   return <Minus className="h-3.5 w-3.5 text-white/25" />;
 }
 
-const RANK_TONE = (rank: number) =>
-  rank === 1 ? 'bg-[#f5c542] text-[#16051f]' : rank === 2 ? 'bg-slate-300 text-[#16051f]' : rank === 3 ? 'bg-amber-700 text-white' : 'bg-white/8 text-white/60';
+const RANK_TONE = (rank: number) => rank === 1 ? 'bg-[#f5c542] text-[#16051f]' : rank === 2 ? 'bg-slate-300 text-[#16051f]' : rank === 3 ? 'bg-amber-700 text-white' : 'bg-white/8 text-white/60';
 
 /**
- * LeagueStandings — the live "Beat the Gaffer" leaderboard. Rank movement,
- * GW + total points, the Gaffer's row highlighted, and the cash prize rail.
- * All rows come from the standings contract (never a baked table).
+ * LeagueStandings — the live "Beat the Gaffer" leaderboard from the standings
+ * contract. Rank movement, GW + total points, the Gaffer and your own row
+ * highlighted, plus the cash prize rail.
  */
 export function LeagueStandings() {
   const { data, isLoading } = useFantasyStandings();
-
-  if (isLoading && !data) {
-    return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
-  }
+  if (isLoading && !data) return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
   const rows = data?.rows ?? [];
-  const tiers = data?.tiers ?? [];
 
   return (
     <section id="standings" className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(245,197,66,0.6)] md:rounded-[2rem]">
       <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
       <div aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_100%_0%,rgba(245,197,66,0.14),transparent_42%),radial-gradient(circle_at_0%_100%,rgba(124,58,237,0.18),transparent_45%)]" />
-
-      {/* Gaffer, decorative, top-right */}
       <img src={GAFFER} alt="" aria-hidden loading="lazy" draggable={false} className="pointer-events-none absolute -right-4 bottom-0 z-0 hidden h-[300px] w-auto select-none object-contain opacity-90 xl:block" />
 
       <div className="relative z-[1] p-5 md:p-7">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">
-              {data?.gameweek ?? 'League'}
-            </span>
-            <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">
-              League <span className="text-[#f5c542]">Standings</span>
-            </h2>
-            <p className="mt-2 text-sm text-white/55">Climb the table. Chase the prizes.</p>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">Gameweek {data?.gameweek ?? ''}</span>
+            <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">League <span className="text-[#f5c542]">Standings</span></h2>
+            <p className="mt-2 text-sm text-white/55">The table doesn’t lie. Climb it, hold it, or get bragged at.</p>
           </div>
-
-          {/* champion prize */}
           <div className="flex items-center gap-3 rounded-2xl border border-[#f5c542]/30 bg-[#f5c542]/10 px-4 py-3">
             <Trophy className="h-8 w-8 fill-[#f5c542] text-[#f5c542]" />
             <div className="leading-tight">
               <div className="text-[10px] font-black uppercase tracking-widest text-[#f8e7a1]">Champion’s Prize</div>
-              <div className="font-display text-2xl text-white">{data?.champion ?? '£10,000'}</div>
+              <div className="font-display text-2xl text-white">{CHAMPION}</div>
             </div>
           </div>
         </div>
 
         <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_240px]">
-          {/* table */}
           <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0b0518]/60">
-            {/* head */}
             <div className="grid grid-cols-[44px_1fr_60px_72px] items-center gap-2 border-b border-white/10 px-3 py-2.5 text-[10px] font-black uppercase tracking-widest text-white/40 sm:grid-cols-[52px_1fr_72px_88px]">
-              <span className="text-center">#</span>
-              <span>Team</span>
-              <span className="text-right">GW</span>
-              <span className="text-right">Total</span>
+              <span className="text-center">#</span><span>Team</span><span className="text-right">GW</span><span className="text-right">Total</span>
             </div>
             <ul>
-              {rows.map((r) => (
-                <li
-                  key={r.rank}
-                  className={`grid grid-cols-[44px_1fr_60px_72px] items-center gap-2 border-b border-white/[0.06] px-3 py-2.5 transition-colors sm:grid-cols-[52px_1fr_72px_88px] ${
-                    r.isGaffer ? 'bg-[#f5c542]/12 ring-1 ring-inset ring-[#f5c542]/30' : 'hover:bg-white/[0.03]'
-                  }`}
-                >
-                  <span className="flex items-center justify-center gap-1">
-                    <span className={`grid h-6 w-6 place-items-center rounded-md text-[11px] font-black ${RANK_TONE(r.rank)}`}>{r.rank}</span>
-                  </span>
-                  <span className="flex min-w-0 items-center gap-2">
-                    <Movement m={r.movement} />
-                    <span className="min-w-0">
-                      <span className={`flex items-center gap-1.5 truncate text-[13px] font-black ${r.isGaffer ? 'text-[#f8e7a1]' : 'text-white'}`}>
-                        {r.isGaffer && <Crown className="h-3.5 w-3.5 shrink-0 fill-[#f5c542] text-[#f5c542]" />}
-                        {r.team}
+              {rows.map((r) => {
+                const you = isYou(r); const gaffer = isGaffer(r);
+                return (
+                  <li key={r.team_id} className={`grid grid-cols-[44px_1fr_60px_72px] items-center gap-2 border-b border-white/[0.06] px-3 py-2.5 transition-colors sm:grid-cols-[52px_1fr_72px_88px] ${gaffer ? 'bg-[#f5c542]/12 ring-1 ring-inset ring-[#f5c542]/30' : you ? 'bg-violet-500/12 ring-1 ring-inset ring-violet-400/30' : 'hover:bg-white/[0.03]'}`}>
+                    <span className="flex items-center justify-center gap-1"><span className={`grid h-6 w-6 place-items-center rounded-md text-[11px] font-black ${RANK_TONE(r.rank)}`}>{r.rank}</span></span>
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Movement m={r.movement} />
+                      <span className="min-w-0">
+                        <span className={`flex items-center gap-1.5 truncate text-[13px] font-black ${gaffer ? 'text-[#f8e7a1]' : you ? 'text-violet-100' : 'text-white'}`}>
+                          {gaffer && <Crown className="h-3.5 w-3.5 shrink-0 fill-[#f5c542] text-[#f5c542]" />}
+                          {r.team_name}
+                          {you && <span className="rounded bg-violet-500/25 px-1.5 py-px text-[9px] font-black uppercase text-violet-100">You</span>}
+                          {!!r.awards_count && <span className="inline-flex items-center gap-0.5 text-[10px] text-[#f8e7a1]"><Award className="h-3 w-3" />{r.awards_count}</span>}
+                        </span>
+                        <span className="block truncate text-[10px] font-semibold uppercase tracking-wide text-white/40">{r.manager_name}{r.transfer_hits > 0 && <span className="text-red-400"> · −{r.transfer_hits}</span>}</span>
                       </span>
-                      <span className="block truncate text-[10px] font-semibold uppercase tracking-wide text-white/40">{r.manager}</span>
                     </span>
-                  </span>
-                  <span className="text-right text-[13px] font-bold tabular-nums text-white/70">{r.gwPoints}</span>
-                  <span className="text-right font-display text-lg tabular-nums text-[#f5c542]">{r.total.toLocaleString()}</span>
-                </li>
-              ))}
+                    <span className="text-right text-[13px] font-bold tabular-nums text-white/70">{r.gameweek_points}</span>
+                    <span className="text-right font-display text-lg tabular-nums text-[#f5c542]">{r.total_points.toLocaleString()}</span>
+                  </li>
+                );
+              })}
             </ul>
           </div>
 
-          {/* prize rail */}
           <div className="flex flex-col gap-3">
             <div className="rounded-2xl border border-white/10 bg-[#0b0518]/60 p-4">
               <div className="text-[10px] font-black uppercase tracking-widest text-white/45">Top 3 Prizes</div>
               <ul className="mt-2 space-y-2">
-                {tiers.map((t) => (
+                {TIERS.map((t) => (
                   <li key={t.rank} className="flex items-center gap-3">
                     <span className={`grid h-8 w-8 place-items-center rounded-lg text-[12px] font-black ${RANK_TONE(t.rank)}`}>{t.rank}</span>
                     <span className="flex-1 text-[12px] font-bold uppercase tracking-wide text-white/60">{t.label}</span>
@@ -110,12 +101,7 @@ export function LeagueStandings() {
                 ))}
               </ul>
             </div>
-            <Link
-              to="/pricing"
-              className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-5 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5"
-            >
-              Join &amp; Climb <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
+            <Link to="/pricing" className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-5 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Join &amp; Climb <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" /></Link>
           </div>
         </div>
       </div>

--- a/src/components/fantasy/PlayerCard.tsx
+++ b/src/components/fantasy/PlayerCard.tsx
@@ -1,5 +1,5 @@
-import { Plus, X } from 'lucide-react';
-import type { FantasyPlayer, FantasyPosition } from '@/hooks/useFantasyLeague';
+import { Plus, X, AlertTriangle } from 'lucide-react';
+import type { FantasyPlayer, FantasyPosition } from '@/types/footy';
 
 const POS_TONE: Record<FantasyPosition, { ring: string; chip: string; glow: string }> = {
   GK: { ring: 'ring-emerald-400/50', chip: 'bg-emerald-400/20 text-emerald-200', glow: 'shadow-[0_0_28px_-10px_rgba(16,185,129,0.7)]' },
@@ -8,32 +8,49 @@ const POS_TONE: Record<FantasyPosition, { ring: string; chip: string; glow: stri
   FWD: { ring: 'ring-[#f5c542]/60', chip: 'bg-[#f5c542]/20 text-[#f8e7a1]', glow: 'shadow-[0_0_30px_-10px_rgba(245,197,66,0.85)]' },
 };
 
-/** Initials for the "player portrait" placeholder (no external headshots). */
+const STATUS_TONE: Record<FantasyPlayer['status'], string | null> = {
+  available: null,
+  doubtful: 'text-amber-400',
+  injured: 'text-red-400',
+  suspended: 'text-red-400',
+  unavailable: 'text-red-400',
+};
+
+/** Last name for the "portrait" placeholder (no external headshots). */
 function initials(name: string) {
   const parts = name.replace(/[^A-Za-z\s.'-]/g, '').split(/\s+/).filter(Boolean);
-  const last = parts[parts.length - 1] ?? '';
-  return last.slice(0, 2).toUpperCase();
+  return (parts[parts.length - 1] ?? '').slice(0, 2).toUpperCase();
+}
+function lastName(name: string) {
+  const parts = name.split(/\s+/).filter(Boolean);
+  return parts[parts.length - 1] ?? name;
 }
 
 type Props = {
   player: FantasyPlayer;
   size?: 'sm' | 'md' | 'lg';
+  /** What the big number shows: season total (default) or this GW's points. */
+  metric?: 'total' | 'gameweek';
   onClick?: () => void;
   onRemove?: () => void;
   selected?: boolean;
   affordable?: boolean;
+  captain?: boolean;
+  vice?: boolean;
 };
 
 /**
- * FUT-style player card — gold/purple foil, rating + position corner, name,
- * club and price. Used in the hero showcase, the pitch slots and the picker.
- * Purely presentational; all data comes from the fantasy players contract.
+ * FUT-style player card, bound to the FantasyPlayer contract. Headlines the real
+ * fantasy points (no fabricated rating), with position, club, price, an armband
+ * for (C)/(V) and an availability flag for injured/doubtful players.
  */
-export function PlayerCard({ player, size = 'md', onClick, onRemove, selected, affordable = true }: Props) {
+export function PlayerCard({ player, size = 'md', metric = 'total', onClick, onRemove, selected, affordable = true, captain, vice }: Props) {
   const tone = POS_TONE[player.position];
-  const dims =
-    size === 'lg' ? 'w-[132px] p-3' : size === 'sm' ? 'w-[92px] p-2' : 'w-[112px] p-2.5';
+  const dims = size === 'lg' ? 'w-[132px] p-3' : size === 'sm' ? 'w-[92px] p-2' : 'w-[112px] p-2.5';
   const nameSize = size === 'lg' ? 'text-[13px]' : 'text-[11px]';
+  const bigNum = metric === 'gameweek' ? (player.gameweek_points ?? 0) : player.total_points;
+  const bigLabel = metric === 'gameweek' ? 'GW' : 'PTS';
+  const statusTone = STATUS_TONE[player.status];
 
   return (
     <button
@@ -45,21 +62,18 @@ export function PlayerCard({ player, size = 'md', onClick, onRemove, selected, a
         affordable ? '' : 'opacity-45 saturate-50'
       } ${onClick ? 'hover:-translate-y-0.5 active:translate-y-0' : ''}`}
     >
-      {/* foil sheen */}
       <span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_-10%,rgba(245,197,66,0.16),transparent_55%)]" />
 
-      {/* rating + position */}
       <div className="relative flex items-start justify-between">
         <div className="leading-none">
-          <div className="font-display text-2xl text-[#f8e7a1]">{player.rating}</div>
-          <div className={`mt-0.5 inline-block rounded px-1 py-px text-[9px] font-black tracking-wide ${tone.chip}`}>{player.position}</div>
+          <div className="font-display text-2xl text-[#f8e7a1]">{bigNum}</div>
+          <div className="mt-0.5 flex items-center gap-1">
+            <span className={`inline-block rounded px-1 py-px text-[9px] font-black tracking-wide ${tone.chip}`}>{player.position}</span>
+            <span className="text-[8px] font-black uppercase tracking-wider text-white/35">{bigLabel}</span>
+          </div>
         </div>
         {onRemove ? (
-          <span
-            onClick={(e) => { e.stopPropagation(); onRemove(); }}
-            className="grid h-5 w-5 place-items-center rounded-full bg-black/50 text-white/70 transition-colors hover:bg-red-500/80 hover:text-white"
-            aria-label={`Remove ${player.name}`}
-          >
+          <span onClick={(e) => { e.stopPropagation(); onRemove(); }} className="grid h-5 w-5 place-items-center rounded-full bg-black/50 text-white/70 transition-colors hover:bg-red-500/80 hover:text-white" aria-label={`Remove ${player.name}`}>
             <X className="h-3 w-3" />
           </span>
         ) : onClick ? (
@@ -69,18 +83,17 @@ export function PlayerCard({ player, size = 'md', onClick, onRemove, selected, a
         ) : null}
       </div>
 
-      {/* portrait medallion */}
       <div className={`relative mx-auto mt-1.5 grid ${size === 'sm' ? 'h-11 w-11' : 'h-14 w-14'} place-items-center rounded-full bg-black/40 ring-2 ${tone.ring}`}>
         <span className="font-display text-lg text-white/85">{initials(player.name)}</span>
+        {(captain || vice) && <span className={`absolute -left-1.5 -top-1.5 grid h-5 w-5 place-items-center rounded-full text-[10px] font-black ring-2 ring-[#0b0518] ${captain ? 'bg-[#f5c542] text-[#16051f]' : 'bg-white/85 text-[#16051f]'}`}>{captain ? 'C' : 'V'}</span>}
+        {statusTone && <span className="absolute -right-1 -top-1 grid h-4 w-4 place-items-center rounded-full bg-[#0b0518]"><AlertTriangle className={`h-3 w-3 ${statusTone}`} /></span>}
       </div>
 
-      {/* name + club */}
       <div className="relative mt-1.5 text-center">
-        <div className={`truncate font-black uppercase tracking-wide text-white ${nameSize}`}>{player.name}</div>
-        <div className="truncate text-[9px] font-semibold uppercase tracking-wider text-white/45">{player.teamShort}</div>
+        <div className={`truncate font-black uppercase tracking-wide text-white ${nameSize}`}>{lastName(player.name)}</div>
+        <div className="truncate text-[9px] font-semibold uppercase tracking-wider text-white/45">{player.club.short_name ?? player.club.name}</div>
       </div>
 
-      {/* price */}
       <div className="relative mt-1.5 flex items-center justify-center gap-1 rounded-lg bg-black/35 py-1">
         <span className="text-[11px] font-black text-emerald-300">£{player.price.toFixed(1)}m</span>
       </div>
@@ -88,20 +101,14 @@ export function PlayerCard({ player, size = 'md', onClick, onRemove, selected, a
   );
 }
 
-/** Empty pitch slot — tap to add a player of the given position. */
+/** Empty pitch/squad slot — tap to add a player of the given position. */
 export function EmptySlot({ position, onClick, size = 'md' }: { position: FantasyPosition; onClick?: () => void; size?: 'sm' | 'md' }) {
   const tone = POS_TONE[position];
   const dims = size === 'sm' ? 'w-[92px] h-[128px]' : 'w-[112px] h-[152px]';
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`group relative shrink-0 rounded-2xl border-2 border-dashed border-white/20 bg-white/[0.03] transition-all hover:-translate-y-0.5 hover:border-[#f5c542]/60 hover:bg-white/[0.06] ${dims}`}
-    >
+    <button type="button" onClick={onClick} className={`group relative shrink-0 rounded-2xl border-2 border-dashed border-white/20 bg-white/[0.03] transition-all hover:-translate-y-0.5 hover:border-[#f5c542]/60 hover:bg-white/[0.06] ${dims}`}>
       <span className="flex h-full flex-col items-center justify-center gap-2">
-        <span className={`grid h-9 w-9 place-items-center rounded-full ${tone.chip}`}>
-          <Plus className="h-4 w-4" />
-        </span>
+        <span className={`grid h-9 w-9 place-items-center rounded-full ${tone.chip}`}><Plus className="h-4 w-4" /></span>
         <span className="text-[10px] font-black uppercase tracking-widest text-white/50 group-hover:text-white/75">{position}</span>
       </span>
     </button>

--- a/src/components/fantasy/SquadBuilder.tsx
+++ b/src/components/fantasy/SquadBuilder.tsx
@@ -1,90 +1,55 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, Wand2, RotateCcw, Lock, Users2, Coins, ChevronRight } from 'lucide-react';
-import {
-  useFantasyPlayers,
-  type FantasyPlayer,
-  type FantasyPosition,
-} from '@/hooks/useFantasyLeague';
+import { Check, Wand2, RotateCcw, Lock, Users2, Coins, ChevronRight, Star } from 'lucide-react';
+import { useFantasyPlayers, FANTASY_RULES } from '@/hooks/useFantasyLeague';
+import type { FantasyPlayer, FantasyPosition } from '@/types/footy';
 import { PlayerCard, EmptySlot } from './PlayerCard';
 
 const POSITIONS: FantasyPosition[] = ['GK', 'DEF', 'MID', 'FWD'];
 const FILTERS: ('ALL' | FantasyPosition)[] = ['ALL', 'GK', 'DEF', 'MID', 'FWD'];
-
-type Group = { pos: FantasyPosition; count: number };
-
-/** Parse "4-2-3-1" → position capacities + display groups (first=DEF, last=FWD). */
-function parseFormation(formation: string): { caps: Record<FantasyPosition, number>; groups: Group[] } {
-  const nums = formation.split('-').map(Number);
-  const groups: Group[] = nums.map((count, i) => ({
-    pos: i === 0 ? 'DEF' : i === nums.length - 1 ? 'FWD' : 'MID',
-    count,
-  }));
-  const caps: Record<FantasyPosition, number> = { GK: 1, DEF: 0, MID: 0, FWD: 0 };
-  groups.forEach((g) => (caps[g.pos] += g.count));
-  return { caps, groups };
-}
+// Squad-sheet rows, front to back (matches the 2·5·5·3 locked structure).
+const ROWS: FantasyPosition[] = ['FWD', 'MID', 'DEF', 'GK'];
 
 /**
- * SquadBuilder — the interactive "Pick Your Squad" board. Real formation math,
- * a £-budget engine, a max-per-club rule and a filterable player list. Nothing
- * is baked: every card, price and total is React state over the players API.
+ * SquadBuilder — the interactive Pick Squad tool, bound to the locked rules:
+ * 15 players (2 GK / 5 DEF / 5 MID / 3 FWD), £100m budget, max 3 per club,
+ * captain + vice. Pool comes from get-fantasy-players (with typed fallback);
+ * everything is React state over the FantasyPlayer contract — nothing baked.
  */
 export function SquadBuilder() {
   const { data, isLoading } = useFantasyPlayers();
   const players = data?.players ?? [];
-  const rules = data?.rules;
 
-  const [formation, setFormation] = useState(rules?.defaultFormation ?? '4-3-3');
   const [selected, setSelected] = useState<FantasyPlayer[]>([]);
+  const [captainId, setCaptainId] = useState<string | null>(null);
+  const [viceId, setViceId] = useState<string | null>(null);
   const [filter, setFilter] = useState<'ALL' | FantasyPosition>('ALL');
 
-  const { caps, groups } = useMemo(() => parseFormation(formation), [formation]);
-  const budget = rules?.budget ?? 95;
-  const maxPerClub = rules?.maxPerClub ?? 3;
+  const caps = FANTASY_RULES.perPosition;
+  const budget = FANTASY_RULES.budget;
+  const maxPerClub = FANTASY_RULES.maxPerClub;
 
   const spent = selected.reduce((s, p) => s + p.price, 0);
   const remaining = budget - spent;
   const spentPct = Math.min(100, (spent / budget) * 100);
 
   const byPos = (pos: FantasyPosition) => selected.filter((p) => p.position === pos);
-  const clubCount = (team: string) => selected.filter((p) => p.team === team).length;
+  const clubCount = (clubId: string) => selected.filter((p) => p.club.id === clubId).length;
   const isPicked = (id: string) => selected.some((p) => p.id === id);
-
   const posFull = (pos: FantasyPosition) => byPos(pos).length >= caps[pos];
   const canAdd = (p: FantasyPlayer) =>
-    !isPicked(p.id) && !posFull(p.position) && p.price <= remaining + 1e-9 && clubCount(p.team) < maxPerClub;
+    !isPicked(p.id) && !posFull(p.position) && p.price <= remaining + 1e-9 && clubCount(p.club.id) < maxPerClub;
 
-  const addPlayer = (p: FantasyPlayer) => {
-    if (!canAdd(p)) return;
-    setSelected((s) => [...s, p]);
+  const addPlayer = (p: FantasyPlayer) => { if (canAdd(p)) setSelected((s) => [...s, p]); };
+  const removePlayer = (id: string) => {
+    setSelected((s) => s.filter((p) => p.id !== id));
+    if (captainId === id) setCaptainId(null);
+    if (viceId === id) setViceId(null);
   };
-  const removePlayer = (id: string) => setSelected((s) => s.filter((p) => p.id !== id));
+  const clearAll = () => { setSelected([]); setCaptainId(null); setViceId(null); };
 
-  const changeFormation = (f: string) => {
-    const next = parseFormation(f);
-    // trim any position that now has fewer slots (drop last-added of that pos)
-    setSelected((s) => {
-      const keep: FantasyPlayer[] = [];
-      const used: Record<string, number> = { GK: 0, DEF: 0, MID: 0, FWD: 0 };
-      for (const p of s) {
-        if (used[p.position] < next.caps[p.position]) {
-          keep.push(p);
-          used[p.position]++;
-        }
-      }
-      return keep;
-    });
-    setFormation(f);
-  };
-
-  const clearAll = () => setSelected([]);
-
-  /** Guarded-greedy autofill: strongest legal XI that always completes within budget. */
+  /** Guarded-greedy autofill: strongest legal 15 that always completes in budget. */
   const autofill = () => {
-    const need: FantasyPosition[] = [];
-    POSITIONS.forEach((pos) => { for (let i = 0; i < caps[pos]; i++) need.push(pos); });
-    // cheapest price available per position (for budget reservation)
     const cheapest: Record<string, number> = {};
     POSITIONS.forEach((pos) => {
       const ps = players.filter((p) => p.position === pos).map((p) => p.price).sort((a, b) => a - b);
@@ -93,204 +58,158 @@ export function SquadBuilder() {
     const chosen: FantasyPlayer[] = [];
     const clubs: Record<string, number> = {};
     let left = budget;
-    // fill scarcest-first: GK, FWD, then DEF, MID
     const order: FantasyPosition[] = ['GK', 'FWD', 'DEF', 'MID'];
-    const remainingNeed = { ...caps };
+    const need = { ...caps };
     for (const pos of order) {
       for (let i = 0; i < caps[pos]; i++) {
-        remainingNeed[pos]--;
-        // reserve cheapest for every still-unfilled slot (excluding this one)
+        need[pos]--;
         let reserve = 0;
-        POSITIONS.forEach((pp) => { reserve += Math.max(0, remainingNeed[pp]) * cheapest[pp]; });
+        POSITIONS.forEach((pp) => { reserve += Math.max(0, need[pp]) * cheapest[pp]; });
         const cand = players
-          .filter((p) => p.position === pos && !chosen.some((c) => c.id === p.id) && (clubs[p.team] ?? 0) < maxPerClub && p.price <= left - reserve + 1e-9)
-          .sort((a, b) => b.rating - a.rating)[0];
-        if (cand) {
-          chosen.push(cand);
-          clubs[cand.team] = (clubs[cand.team] ?? 0) + 1;
-          left -= cand.price;
-        }
+          .filter((p) => p.position === pos && !chosen.some((c) => c.id === p.id) && (clubs[p.club.id] ?? 0) < maxPerClub && p.price <= left - reserve + 1e-9)
+          .sort((a, b) => b.total_points - a.total_points)[0];
+        if (cand) { chosen.push(cand); clubs[cand.club.id] = (clubs[cand.club.id] ?? 0) + 1; left -= cand.price; }
       }
     }
     setSelected(chosen);
+    const outfield = chosen.filter((p) => p.position !== 'GK').sort((a, b) => b.total_points - a.total_points);
+    setCaptainId(outfield[0]?.id ?? null);
+    setViceId(outfield[1]?.id ?? null);
   };
 
   const list = useMemo(() => {
     const l = filter === 'ALL' ? players : players.filter((p) => p.position === filter);
-    return l.slice().sort((a, b) => b.rating - a.rating);
+    return l.slice().sort((a, b) => b.total_points - a.total_points);
   }, [players, filter]);
 
-  const displayGroups = useMemo(() => [...groups].reverse(), [groups]); // FWD on top → DEF above GK
+  const complete = selected.length === FANTASY_RULES.squadSize;
+  const ready = complete && !!captainId && !!viceId;
 
-  // per-position running index while rendering rows
-  const cursor: Record<string, number> = { GK: 0, DEF: 0, MID: 0, FWD: 0 };
-
-  if (isLoading && !data) {
-    return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
-  }
+  if (isLoading && !data) return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
   return (
     <section id="pick-squad" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(124,58,237,0.7)] md:rounded-[2rem]">
       <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
       <div aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_0%,rgba(124,58,237,0.22),transparent_45%)]" />
 
-      {/* header */}
       <div className="relative flex flex-wrap items-end justify-between gap-3 p-5 md:p-7">
         <div>
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">
-            Pick Your Squad
-          </span>
-          <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">
-            Build Your <span className="text-[#f5c542]">XI</span>. Beat The Gaffer.
-          </h2>
-        </div>
-        {/* formation selector */}
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="mr-1 text-[10px] font-black uppercase tracking-widest text-white/40">Formation</span>
-          {(rules?.formations ?? ['4-3-3']).map((f) => (
-            <button
-              key={f}
-              type="button"
-              onClick={() => changeFormation(f)}
-              className={`rounded-lg px-2.5 py-1.5 text-[12px] font-black tabular-nums transition-colors ${
-                formation === f ? 'bg-[#f5c542] text-[#16051f]' : 'border border-white/12 bg-white/[0.04] text-white/70 hover:border-white/25'
-              }`}
-            >
-              {f}
-            </button>
-          ))}
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">Pick Your Squad</span>
+          <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">Fifteen players. <span className="text-[#f5c542]">£100m</span>. No excuses.</h2>
+          <p className="mt-2 text-sm text-white/55">2 GK · 5 DEF · 5 MID · 3 FWD — max three from any one club.</p>
         </div>
       </div>
 
       <div className="relative grid gap-4 px-4 pb-5 md:px-7 md:pb-7 lg:grid-cols-[300px_1fr]">
         {/* ── left rail: budget + filter + player list ── */}
         <div className="order-2 flex flex-col gap-4 lg:order-1">
-          {/* budget */}
           <div className="rounded-2xl border border-white/10 bg-[#0b0518]/70 p-4">
             <div className="flex items-center justify-between">
               <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-white/50"><Coins className="h-3.5 w-3.5" /> Budget Remaining</span>
-              <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-white/50"><Users2 className="h-3.5 w-3.5" /> {selected.length}/{rules?.squadSize ?? 11}</span>
+              <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-white/50"><Users2 className="h-3.5 w-3.5" /> {selected.length}/{FANTASY_RULES.squadSize}</span>
             </div>
             <div className={`mt-1 font-display text-3xl ${remaining < 0 ? 'text-red-400' : 'text-[#f5c542]'}`}>£{remaining.toFixed(1)}m</div>
             <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
               <div className="h-full rounded-full bg-gradient-to-r from-violet-500 to-[#f5c542] transition-all" style={{ width: `${spentPct}%` }} />
             </div>
-            <div className="mt-1.5 flex justify-between text-[10px] font-semibold text-white/40">
-              <span>£{spent.toFixed(1)}m spent</span>
-              <span>£{budget.toFixed(0)}m cap</span>
+            <div className="mt-1.5 flex justify-between text-[10px] font-semibold text-white/40"><span>£{spent.toFixed(1)}m spent</span><span>£{budget.toFixed(0)}m cap</span></div>
+            {/* per-position progress */}
+            <div className="mt-3 grid grid-cols-4 gap-1.5">
+              {POSITIONS.map((pos) => (
+                <div key={pos} className="rounded-lg border border-white/8 bg-white/[0.03] py-1 text-center">
+                  <div className="text-[9px] font-black uppercase tracking-wide text-white/40">{pos}</div>
+                  <div className={`text-[12px] font-black ${byPos(pos).length === caps[pos] ? 'text-emerald-300' : 'text-white/80'}`}>{byPos(pos).length}/{caps[pos]}</div>
+                </div>
+              ))}
             </div>
             <div className="mt-3 flex gap-2">
-              <button type="button" onClick={autofill} className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-violet-500/20 px-2 py-2 text-[11px] font-black uppercase tracking-wide text-violet-100 transition-colors hover:bg-violet-500/30">
-                <Wand2 className="h-3.5 w-3.5" /> Autofill
-              </button>
-              <button type="button" onClick={clearAll} className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/12 px-2.5 py-2 text-[11px] font-black uppercase tracking-wide text-white/60 transition-colors hover:border-white/25 hover:text-white/90">
-                <RotateCcw className="h-3.5 w-3.5" />
-              </button>
+              <button type="button" onClick={autofill} className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-violet-500/20 px-2 py-2 text-[11px] font-black uppercase tracking-wide text-violet-100 transition-colors hover:bg-violet-500/30"><Wand2 className="h-3.5 w-3.5" /> Autofill</button>
+              <button type="button" onClick={clearAll} className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/12 px-2.5 py-2 text-[11px] font-black uppercase tracking-wide text-white/60 transition-colors hover:border-white/25 hover:text-white/90"><RotateCcw className="h-3.5 w-3.5" /></button>
             </div>
           </div>
 
-          {/* position filter */}
           <div className="flex flex-wrap gap-1.5">
             {FILTERS.map((f) => (
-              <button
-                key={f}
-                type="button"
-                onClick={() => setFilter(f)}
-                className={`rounded-lg px-3 py-1.5 text-[11px] font-black uppercase tracking-wide transition-colors ${
-                  filter === f ? 'bg-white text-[#16051f]' : 'border border-white/12 bg-white/[0.04] text-white/65 hover:border-white/25'
-                }`}
-              >
-                {f === 'ALL' ? 'All' : f}
-              </button>
+              <button key={f} type="button" onClick={() => setFilter(f)} className={`rounded-lg px-3 py-1.5 text-[11px] font-black uppercase tracking-wide transition-colors ${filter === f ? 'bg-white text-[#16051f]' : 'border border-white/12 bg-white/[0.04] text-white/65 hover:border-white/25'}`}>{f === 'ALL' ? 'All' : f}</button>
             ))}
           </div>
 
-          {/* player list */}
-          <div className="max-h-[360px] space-y-1.5 overflow-y-auto pr-1 lg:max-h-[440px]">
+          <div className="max-h-[380px] space-y-1.5 overflow-y-auto pr-1 lg:max-h-[460px]">
             {list.map((p) => {
               const picked = isPicked(p.id);
               const disabled = !picked && !canAdd(p);
               return (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => (picked ? removePlayer(p.id) : addPlayer(p))}
-                  disabled={disabled}
-                  className={`flex w-full items-center gap-2.5 rounded-xl border px-2.5 py-2 text-left transition-all ${
-                    picked
-                      ? 'border-[#f5c542]/50 bg-[#f5c542]/10'
-                      : disabled
-                        ? 'cursor-not-allowed border-white/8 bg-white/[0.02] opacity-45'
-                        : 'border-white/10 bg-white/[0.03] hover:border-violet-400/40 hover:bg-violet-500/10'
-                  }`}
-                >
-                  <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-black/40 font-display text-sm text-[#f8e7a1]">{p.rating}</span>
+                <button key={p.id} type="button" onClick={() => (picked ? removePlayer(p.id) : addPlayer(p))} disabled={disabled} className={`flex w-full items-center gap-2.5 rounded-xl border px-2.5 py-2 text-left transition-all ${picked ? 'border-[#f5c542]/50 bg-[#f5c542]/10' : disabled ? 'cursor-not-allowed border-white/8 bg-white/[0.02] opacity-45' : 'border-white/10 bg-white/[0.03] hover:border-violet-400/40 hover:bg-violet-500/10'}`}>
+                  <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-black/40 font-display text-sm text-[#f8e7a1]">{p.total_points}</span>
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-[13px] font-bold text-white">{p.name}</span>
-                    <span className="block text-[10px] font-semibold uppercase tracking-wide text-white/40">{p.position} · {p.teamShort}</span>
+                    <span className="block text-[10px] font-semibold uppercase tracking-wide text-white/40">{p.position} · {p.club.short_name} {p.status !== 'available' && <span className="text-amber-400">· {p.status}</span>}</span>
                   </span>
                   <span className="text-[12px] font-black text-emerald-300">£{p.price.toFixed(1)}m</span>
-                  <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-full ${picked ? 'bg-[#f5c542] text-[#16051f]' : 'bg-white/10 text-white/60'}`}>
-                    {picked ? <Check className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                  </span>
+                  <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-full ${picked ? 'bg-[#f5c542] text-[#16051f]' : 'bg-white/10 text-white/60'}`}>{picked ? <Check className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}</span>
                 </button>
               );
             })}
           </div>
         </div>
 
-        {/* ── pitch ── */}
+        {/* ── squad sheet (2·5·5·3) ── */}
         <div className="order-1 lg:order-2">
           <div className="relative overflow-hidden rounded-2xl border border-emerald-500/20">
-            {/* pitch turf */}
             <div aria-hidden className="absolute inset-0 bg-[linear-gradient(180deg,#0a3d24,#072a19)]" />
             <div aria-hidden className="absolute inset-0 bg-[repeating-linear-gradient(180deg,rgba(255,255,255,0.05)_0_44px,transparent_44px_88px)]" />
             <div aria-hidden className="pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15" />
-            <div aria-hidden className="pointer-events-none absolute left-1/2 top-0 h-24 w-40 -translate-x-1/2 border-x border-b border-white/15" />
-            <div aria-hidden className="pointer-events-none absolute bottom-0 left-1/2 h-24 w-40 -translate-x-1/2 border-x border-t border-white/15" />
 
             <div className="relative flex flex-col gap-3 px-2 py-5 sm:gap-4 sm:px-4 sm:py-7">
-              {displayGroups.map((g, gi) => {
-                const start = cursor[g.pos];
-                const rowPlayers = byPos(g.pos).slice(start, start + g.count);
-                cursor[g.pos] = start + g.count;
+              {ROWS.map((pos) => {
+                const row = byPos(pos);
                 return (
-                  <div key={`${g.pos}-${gi}`} className="flex flex-wrap items-center justify-center gap-2 sm:gap-3">
-                    {Array.from({ length: g.count }).map((_, i) => {
-                      const p = rowPlayers[i];
+                  <div key={pos} className="flex flex-wrap items-center justify-center gap-2 sm:gap-3">
+                    {Array.from({ length: caps[pos] }).map((_, i) => {
+                      const p = row[i];
                       return p ? (
-                        <PlayerCard key={p.id} player={p} size="sm" onRemove={() => removePlayer(p.id)} />
+                        <PlayerCard key={p.id} player={p} size="sm" captain={captainId === p.id} vice={viceId === p.id} onRemove={() => removePlayer(p.id)} />
                       ) : (
-                        <EmptySlot key={`${g.pos}-${gi}-${i}`} position={g.pos} size="sm" onClick={() => setFilter(g.pos)} />
+                        <EmptySlot key={`${pos}-${i}`} position={pos} size="sm" onClick={() => setFilter(pos)} />
                       );
                     })}
                   </div>
                 );
               })}
-              {/* GK row */}
-              <div className="flex items-center justify-center">
-                {byPos('GK')[0] ? (
-                  <PlayerCard player={byPos('GK')[0]} size="sm" onRemove={() => removePlayer(byPos('GK')[0].id)} />
-                ) : (
-                  <EmptySlot position="GK" size="sm" onClick={() => setFilter('GK')} />
-                )}
-              </div>
             </div>
           </div>
 
-          {/* squad status + save */}
+          {/* captain / vice + save */}
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-2 rounded-xl border border-[#f5c542]/25 bg-[#f5c542]/[0.06] px-3 py-2.5">
+              <Star className="h-4 w-4 shrink-0 fill-[#f5c542] text-[#f5c542]" />
+              <span className="text-[11px] font-black uppercase tracking-wide text-[#f8e7a1]">Captain</span>
+              <select value={captainId ?? ''} onChange={(e) => { setCaptainId(e.target.value || null); if (e.target.value === viceId) setViceId(null); }} className="ml-auto min-w-0 flex-1 rounded-lg border border-white/10 bg-[#0b0518] px-2 py-1.5 text-[12px] font-semibold text-white">
+                <option value="">— pick —</option>
+                {selected.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 rounded-xl border border-violet-400/25 bg-violet-500/[0.06] px-3 py-2.5">
+              <Star className="h-4 w-4 shrink-0 text-violet-300" />
+              <span className="text-[11px] font-black uppercase tracking-wide text-violet-200">Vice</span>
+              <select value={viceId ?? ''} onChange={(e) => { setViceId(e.target.value || null); if (e.target.value === captainId) setCaptainId(null); }} className="ml-auto min-w-0 flex-1 rounded-lg border border-white/10 bg-[#0b0518] px-2 py-1.5 text-[12px] font-semibold text-white">
+                <option value="">— pick —</option>
+                {selected.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </label>
+          </div>
+
           <div className="mt-4 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-[12px] font-semibold text-white/55">
-              {selected.length === (rules?.squadSize ?? 11) ? (
-                <span className="inline-flex items-center gap-1.5 text-emerald-300"><Check className="h-4 w-4" /> Full squad — you’re ready to take on The Gaffer.</span>
+              {ready ? (
+                <span className="inline-flex items-center gap-1.5 text-emerald-300"><Check className="h-4 w-4" /> Squad locked. Now we’ll see what you’re made of.</span>
+              ) : complete ? (
+                <span className="text-[#f8e7a1]">Name a captain &amp; vice to finish.</span>
               ) : (
-                <span>Pick <span className="font-black text-white">{(rules?.squadSize ?? 11) - selected.length}</span> more to complete your XI.</span>
+                <span>Pick <span className="font-black text-white">{FANTASY_RULES.squadSize - selected.length}</span> more to complete your 15.</span>
               )}
             </div>
-            <Link
-              to="/pricing"
-              className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5"
-            >
+            <Link to="/pricing" className={`inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-black uppercase tracking-wide transition-transform hover:-translate-y-0.5 ${ready ? 'bg-gradient-to-r from-amber-300 to-amber-500 text-[#16051f]' : 'bg-gradient-to-r from-amber-300/60 to-amber-500/60 text-[#16051f]/80'}`}>
               <Lock className="h-4 w-4" /> Save Squad &amp; Join
             </Link>
           </div>

--- a/src/hooks/useFantasyLeague.ts
+++ b/src/hooks/useFantasyLeague.ts
@@ -1,216 +1,261 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type {
+  ApiResponse,
+  FantasyPlayer,
+  FantasyPlayersResponse,
+  FantasyPlayersFilters,
+  FantasyTeam,
+  FantasyStandingsResponse,
+  FantasyGameweekResponse,
+  FantasyPrizesResponse,
+  FantasyPosition,
+} from '@/types/footy';
 
 /* ───────────────────────────────────────────────────────────────────────────
- * Fantasy League page — data contracts.
+ * Fantasy data layer — Footy Oracle wrappers over the FPL proxy edge functions.
  *
- * Every hook tries its Footy Oracle wrapper edge function, then falls back to
- * typed sample data (raced against a short timeout) so the page always renders
- * with real HTML/React — never a baked image. Player data, standings, prices,
- * prizes and rules are all live-driven by these shapes.
+ * Every hook calls `supabase.functions.invoke(name, { body })`, unwraps the
+ * ApiResponse envelope, and falls back to typed sample data that matches the
+ * LOCKED contracts in src/types/footy.ts exactly (so the UI works before the
+ * edge functions are synced live). Nothing here redefines a payload interface —
+ * shapes are imported from @/types/footy only.
  * ─────────────────────────────────────────────────────────────────────────── */
 
-export type FantasyPosition = 'GK' | 'DEF' | 'MID' | 'FWD';
+/** Locked squad rules (constants — not a payload interface). */
+export const FANTASY_RULES = {
+  budget: 100,
+  squadSize: 15,
+  starters: 11,
+  bench: 4,
+  perPosition: { GK: 2, DEF: 5, MID: 5, FWD: 3 } as Record<FantasyPosition, number>,
+  maxPerClub: 3,
+  formations: ['4-4-2', '4-3-3', '3-5-2', '3-4-3', '4-5-1', '5-3-2', '5-4-1'],
+  defaultFormation: '4-4-2',
+  registrationOpen: true,
+  seasonStart: '2026-08-01T00:00:00Z',
+} as const;
 
-export type FantasyPlayer = {
-  id: string;
-  name: string;
-  team: string;
-  teamShort: string;
-  position: FantasyPosition;
-  price: number; // £m
-  rating: number; // FUT-style overall
-  points: number; // season fantasy points
-  form: number; // last-5 avg
-};
-
-export type FantasyRules = {
-  budget: number; // £m
-  squadSize: number; // starting XI
-  benchSize: number;
-  formations: string[];
-  defaultFormation: string;
-  maxPerClub: number;
-};
-
-export type FantasyStandingRow = {
-  rank: number;
-  team: string;
-  manager: string;
-  gwPoints: number;
-  total: number;
-  movement: 'up' | 'down' | 'same';
-  isYou?: boolean;
-  isGaffer?: boolean;
-};
-
-export type FantasyPrizeTier = { rank: number; label: string; value: string };
-
-export type FantasyPrize = {
-  id: string;
-  kind: 'grand' | 'standard' | 'fun';
-  title: string;
-  subtitle: string;
-  image: string;
-  tag: string;
-};
-
-export type FantasyLeagueMeta = {
-  season: { name: string; status: string; registrationOpen: boolean; joinUrl: string; deadline: string | null };
-  gameweek: { number: number; label: string; deadline: string | null };
-  entries: number;
-};
-
-/* ── timeout race so a missing/slow edge function never hangs the UI ── */
-async function withFallback<T>(fn: string, fallback: T, valid: (d: unknown) => boolean): Promise<T> {
+/** Race the edge function against a short timeout, unwrap the envelope, else fall back. */
+async function invokeFantasy<T>(name: string, body: unknown, fallback: T, valid: (d: unknown) => boolean): Promise<T> {
   try {
     const timeout = new Promise<null>((r) => setTimeout(() => r(null), 3500));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const invoke = (supabase as any).functions.invoke(fn);
-    const res = await Promise.race([invoke, timeout]);
-    if (!res || res.error || !res.data || !valid(res.data)) return fallback;
-    return res.data as T;
+    const call = supabase.functions.invoke(name, { body: body as Record<string, unknown> });
+    const res = (await Promise.race([call, timeout])) as { data?: ApiResponse<T>; error?: unknown } | null;
+    if (!res || res.error) return fallback;
+    const env = res.data;
+    if (!env || env.ok !== true || !valid(env.data)) return fallback;
+    return env.data;
   } catch {
     return fallback;
   }
 }
 
-/* ───────────────────────────── fallbacks ───────────────────────────── */
+/* ════════════════════════════ fallback data ════════════════════════════ */
 
-export const FANTASY_RULES: FantasyRules = {
-  budget: 95,
-  squadSize: 11,
-  benchSize: 4,
-  formations: ['4-3-3', '4-4-2', '3-5-2', '3-4-3', '5-3-2', '4-2-3-1'],
-  defaultFormation: '4-3-3',
-  maxPerClub: 3,
-};
+const club = (id: string, name: string, short: string) => ({ id, name, short_name: short });
 
-// A believable Premier League–flavoured player pool. Prices/ratings are sample
-// data; the live wrapper replaces these wholesale.
+const P = (
+  id: string, name: string, position: FantasyPosition, c: ReturnType<typeof club>,
+  price: number, total_points: number, form: number, selected_by_percent: number,
+  status: FantasyPlayer['status'] = 'available', next_fixture?: string, news?: string,
+): FantasyPlayer => ({ id, external_id: `fpl_${id}`, name, position, club: c, price, status, selected_by_percent, total_points, gameweek_points: 0, form, next_fixture, news });
+
+const LIV = club('liverpool', 'Liverpool', 'LIV');
+const MCI = club('manchester-city', 'Manchester City', 'MCI');
+const ARS = club('arsenal', 'Arsenal', 'ARS');
+const MUN = club('manchester-united', 'Manchester United', 'MUN');
+const CHE = club('chelsea', 'Chelsea', 'CHE');
+const NEW = club('newcastle-united', 'Newcastle United', 'NEW');
+const AVL = club('aston-villa', 'Aston Villa', 'AVL');
+const TOT = club('tottenham-hotspur', 'Tottenham Hotspur', 'TOT');
+const EVE = club('everton', 'Everton', 'EVE');
+const BHA = club('brighton', 'Brighton', 'BHA');
+
+/** A pool deep enough to build a legal 15-man squad (2·5·5·3) under the club cap. */
 export const FANTASY_PLAYERS: FantasyPlayer[] = [
   // GK
-  { id: 'gk1', name: 'Alisson', team: 'Liverpool', teamShort: 'LIV', position: 'GK', price: 6.0, rating: 90, points: 138, form: 5.2 },
-  { id: 'gk2', name: 'Ederson', team: 'Man City', teamShort: 'MCI', position: 'GK', price: 5.8, rating: 89, points: 132, form: 4.8 },
-  { id: 'gk3', name: 'Raya', team: 'Arsenal', teamShort: 'ARS', position: 'GK', price: 5.6, rating: 87, points: 141, form: 5.5 },
-  { id: 'gk4', name: 'Pickford', team: 'Everton', teamShort: 'EVE', position: 'GK', price: 5.0, rating: 85, points: 119, form: 4.3 },
+  P('gk_alisson', 'Alisson Becker', 'GK', LIV, 6.0, 138, 5.2, 22.1, 'available', 'Wolves (A)'),
+  P('gk_raya', 'David Raya', 'GK', ARS, 5.6, 141, 5.5, 18.4, 'available', 'Spurs (H)'),
+  P('gk_ederson', 'Ederson', 'GK', MCI, 5.5, 132, 4.8, 14.0),
+  P('gk_pickford', 'Jordan Pickford', 'GK', EVE, 5.0, 119, 4.3, 9.2),
+  P('gk_sanchez', 'Robert Sánchez', 'GK', CHE, 4.6, 104, 3.9, 6.1, 'doubtful', 'Villa (A)', 'Knock — assessed'),
   // DEF
-  { id: 'df1', name: 'Van Dijk', team: 'Liverpool', teamShort: 'LIV', position: 'DEF', price: 6.4, rating: 92, points: 152, form: 5.9 },
-  { id: 'df2', name: 'Alexander-Arnold', team: 'Liverpool', teamShort: 'LIV', position: 'DEF', price: 7.2, rating: 90, points: 168, form: 6.4 },
-  { id: 'df3', name: 'Rúben Dias', team: 'Man City', teamShort: 'MCI', position: 'DEF', price: 6.0, rating: 92, points: 144, form: 5.6 },
-  { id: 'df4', name: 'Robertson', team: 'Liverpool', teamShort: 'LIV', position: 'DEF', price: 6.0, rating: 88, points: 149, form: 5.7 },
-  { id: 'df5', name: 'Saliba', team: 'Arsenal', teamShort: 'ARS', position: 'DEF', price: 6.2, rating: 89, points: 156, form: 6.0 },
-  { id: 'df6', name: 'Gvardiol', team: 'Man City', teamShort: 'MCI', position: 'DEF', price: 6.0, rating: 87, points: 147, form: 6.1 },
-  { id: 'df7', name: 'Trippier', team: 'Newcastle', teamShort: 'NEW', position: 'DEF', price: 6.2, rating: 86, points: 151, form: 5.4 },
-  { id: 'df8', name: 'Gabriel', team: 'Arsenal', teamShort: 'ARS', position: 'DEF', price: 6.0, rating: 87, points: 158, form: 6.2 },
+  P('df_vvd', 'Virgil van Dijk', 'DEF', LIV, 6.4, 152, 5.9, 28.3, 'available', 'Wolves (A)'),
+  P('df_saliba', 'William Saliba', 'DEF', ARS, 6.2, 156, 6.0, 24.7),
+  P('df_gabriel', 'Gabriel Magalhães', 'DEF', ARS, 6.0, 158, 6.2, 26.1),
+  P('df_gvardiol', 'Joško Gvardiol', 'DEF', MCI, 6.0, 147, 6.1, 19.8),
+  P('df_trippier', 'Kieran Trippier', 'DEF', NEW, 6.2, 151, 5.4, 12.5),
+  P('df_robertson', 'Andrew Robertson', 'DEF', LIV, 6.0, 149, 5.7, 15.2),
+  P('df_dias', 'Rúben Dias', 'DEF', MCI, 5.6, 144, 5.6, 11.1),
+  P('df_cucurella', 'Marc Cucurella', 'DEF', CHE, 5.2, 133, 5.1, 9.8),
+  P('df_konsa', 'Ezri Konsa', 'DEF', AVL, 4.6, 121, 4.7, 6.3),
+  P('df_burn', 'Dan Burn', 'DEF', NEW, 4.5, 118, 4.5, 5.2),
+  P('df_vanhecke', 'Lewis Dunk', 'DEF', BHA, 4.6, 116, 4.4, 4.9),
   // MID
-  { id: 'md1', name: 'De Bruyne', team: 'Man City', teamShort: 'MCI', position: 'MID', price: 9.6, rating: 96, points: 189, form: 7.1 },
-  { id: 'md2', name: 'Bellingham', team: 'Real Madrid', teamShort: 'RMA', position: 'MID', price: 9.3, rating: 93, points: 184, form: 6.9 },
-  { id: 'md3', name: 'Ødegaard', team: 'Arsenal', teamShort: 'ARS', position: 'MID', price: 8.4, rating: 90, points: 171, form: 6.5 },
-  { id: 'md4', name: 'B. Fernandes', team: 'Man United', teamShort: 'MUN', position: 'MID', price: 8.5, rating: 92, points: 178, form: 6.6 },
-  { id: 'md5', name: 'Saka', team: 'Arsenal', teamShort: 'ARS', position: 'MID', price: 9.8, rating: 90, points: 192, form: 7.0 },
-  { id: 'md6', name: 'Foden', team: 'Man City', teamShort: 'MCI', position: 'MID', price: 8.9, rating: 89, points: 181, form: 6.8 },
-  { id: 'md7', name: 'Palmer', team: 'Chelsea', teamShort: 'CHE', position: 'MID', price: 10.5, rating: 89, points: 204, form: 7.4 },
-  { id: 'md8', name: 'Rice', team: 'Arsenal', teamShort: 'ARS', position: 'MID', price: 6.4, rating: 88, points: 146, form: 5.8 },
+  P('md_saka', 'Bukayo Saka', 'MID', ARS, 10.0, 192, 7.0, 41.2, 'available', 'Spurs (H)'),
+  P('md_palmer', 'Cole Palmer', 'MID', CHE, 10.6, 204, 7.4, 46.8),
+  P('md_foden', 'Phil Foden', 'MID', MCI, 9.0, 181, 6.8, 22.4),
+  P('md_odegaard', 'Martin Ødegaard', 'MID', ARS, 8.4, 171, 6.5, 19.9),
+  P('md_bruno', 'Bruno Fernandes', 'MID', MUN, 8.5, 178, 6.6, 24.1),
+  P('md_son', 'Son Heung-min', 'MID', TOT, 9.8, 186, 6.9, 27.7),
+  P('md_rice', 'Declan Rice', 'MID', ARS, 6.4, 146, 5.8, 12.0),
+  P('md_gordon', 'Anthony Gordon', 'MID', NEW, 7.4, 162, 6.1, 14.3),
+  P('md_mbeumo', 'Bryan Mbeumo', 'MID', MUN, 7.6, 168, 6.4, 17.8),
+  P('md_rogers', 'Morgan Rogers', 'MID', AVL, 5.4, 138, 5.5, 8.1),
+  // MID — budget enablers
+  P('md_mcneil', 'Dwight McNeil', 'MID', EVE, 5.2, 128, 4.8, 4.2),
+  P('md_murphy', 'Jacob Murphy', 'MID', NEW, 5.0, 120, 4.5, 5.0),
+  P('md_sarr', 'Pape Matar Sarr', 'MID', TOT, 5.0, 115, 4.4, 3.5),
+  P('md_baleba', 'Carlos Baleba', 'MID', BHA, 4.8, 108, 4.1, 2.9),
   // FWD
-  { id: 'fw1', name: 'Haaland', team: 'Man City', teamShort: 'MCI', position: 'FWD', price: 14.2, rating: 97, points: 232, form: 8.2 },
-  { id: 'fw2', name: 'Kane', team: 'Bayern', teamShort: 'BAY', position: 'FWD', price: 12.8, rating: 96, points: 221, form: 7.9 },
-  { id: 'fw3', name: 'Salah', team: 'Liverpool', teamShort: 'LIV', position: 'FWD', price: 12.9, rating: 94, points: 226, form: 8.0 },
-  { id: 'fw4', name: 'Watkins', team: 'Aston Villa', teamShort: 'AVL', position: 'FWD', price: 9.0, rating: 86, points: 187, form: 6.9 },
-  { id: 'fw5', name: 'Isak', team: 'Newcastle', teamShort: 'NEW', position: 'FWD', price: 8.7, rating: 87, points: 179, form: 6.7 },
-  { id: 'fw6', name: 'Solanke', team: 'Tottenham', teamShort: 'TOT', position: 'FWD', price: 7.5, rating: 84, points: 162, form: 6.1 },
+  P('fw_haaland', 'Erling Haaland', 'FWD', MCI, 14.2, 232, 8.2, 62.4, 'available', 'Wolves (A)'),
+  P('fw_isak', 'Alexander Isak', 'FWD', NEW, 8.7, 179, 6.7, 21.0),
+  P('fw_watkins', 'Ollie Watkins', 'FWD', AVL, 9.0, 187, 6.9, 23.6),
+  P('fw_jackson', 'Nicolas Jackson', 'FWD', CHE, 7.5, 162, 6.1, 13.4),
+  P('fw_solanke', 'Dominic Solanke', 'FWD', TOT, 7.5, 158, 6.0, 11.2, 'doubtful', 'Arsenal (A)', 'Late fitness test'),
+  P('fw_wood', 'Chris Wood', 'FWD', NEW, 6.6, 151, 5.7, 9.9),
+  P('fw_beto', 'Beto', 'FWD', EVE, 5.4, 118, 4.6, 4.0),
+  P('fw_welbeck', 'Danny Welbeck', 'FWD', BHA, 5.6, 132, 5.0, 5.5),
+  // DEF — budget enablers
+  P('df_mykolenko', 'Vitalii Mykolenko', 'DEF', EVE, 4.4, 98, 3.8, 3.1),
+  P('df_estupinan', 'Pervis Estupiñán', 'DEF', BHA, 4.7, 110, 4.2, 4.0),
 ];
 
-export const FANTASY_STANDINGS: { gameweek: string; rows: FantasyStandingRow[]; champion: string; tiers: FantasyPrizeTier[] } = {
-  gameweek: 'Gameweek 24',
-  champion: '£10,000 Cash',
-  tiers: [
-    { rank: 1, label: '1st', value: '£10,000' },
-    { rank: 2, label: '2nd', value: '£3,000' },
-    { rank: 3, label: '3rd', value: '£1,000' },
+const slot = (id: string, is_starter: boolean, opts: { c?: boolean; v?: boolean; bench?: number } = {}) => {
+  const player = FANTASY_PLAYERS.find((p) => p.id === id)!;
+  return { player: { ...player, gameweek_points: is_starter ? Math.round(player.form * (opts.c ? 2 : 1)) : 0 }, is_starter, is_captain: !!opts.c, is_vice_captain: !!opts.v, bench_order: opts.bench };
+};
+
+/** A full legal fallback squad: 2·5·5·3, XI in a 4-4-2, captain + vice + bench order. */
+export const FANTASY_TEAM: FantasyTeam = {
+  id: 'team_demo', member_id: 'member_demo', league_id: 'main-2025-26', name: 'No Kane No Gain',
+  budget_total: 100, budget_remaining: 1.5, squad_value: 98.5, free_transfers: 1, transfer_hits: 0,
+  updated_at: new Date().toISOString(),
+  slots: [
+    slot('gk_alisson', true),
+    slot('df_vvd', true), slot('df_saliba', true), slot('df_gvardiol', true), slot('df_trippier', true),
+    slot('md_saka', true), slot('md_palmer', true, { v: true }), slot('md_bruno', true), slot('md_gordon', true),
+    slot('fw_haaland', true, { c: true }), slot('fw_isak', true),
+    slot('gk_raya', false, { bench: 1 }), slot('df_robertson', false, { bench: 2 }),
+    slot('md_rice', false, { bench: 3 }), slot('fw_watkins', false, { bench: 4 }),
   ],
+};
+
+const daysAdd = (d: number) => new Date(Date.now() + d * 86400000).toISOString();
+
+export const FANTASY_GAMEWEEK: FantasyGameweekResponse = {
+  season: '2025/26', gameweek: 24, status: 'open', deadline_at: daysAdd(2.35),
+  bonus_rules: [{ key: 'manual_bonus', label: 'Gaffer Bonus', description: 'Optional 0–3 bonus points, awarded by The Gaffer for standout performances.' }],
+  fixtures: [
+    { id: 'fx_1', kickoff_time: daysAdd(2.4), home_team: LIV, away_team: NEW, status: 'scheduled' },
+    { id: 'fx_2', kickoff_time: daysAdd(2.5), home_team: ARS, away_team: TOT, status: 'scheduled' },
+    { id: 'fx_3', kickoff_time: daysAdd(2.6), home_team: MCI, away_team: CHE, status: 'scheduled' },
+    { id: 'fx_4', kickoff_time: daysAdd(3.0), home_team: AVL, away_team: MUN, status: 'scheduled' },
+  ],
+  updated_at: new Date().toISOString(),
+};
+
+export const FANTASY_STANDINGS: FantasyStandingsResponse = {
+  league_id: 'main-2025-26', season: '2025/26', gameweek: 24, status: 'open', updated_at: new Date().toISOString(),
   rows: [
-    { rank: 1, team: 'Net Busters', manager: 'J. Okafor', gwPoints: 78, total: 2685, movement: 'up' },
-    { rank: 2, team: 'Pitch Predators', manager: 'S. Ahmed', gwPoints: 71, total: 2514, movement: 'up' },
-    { rank: 3, team: 'Golden Boot Gang', manager: 'L. Rossi', gwPoints: 69, total: 2431, movement: 'down' },
-    { rank: 4, team: 'Beat the Gaffer', manager: 'The Gaffer', gwPoints: 64, total: 2315, movement: 'same', isGaffer: true },
-    { rank: 5, team: 'Tiki Taka Titans', manager: 'M. Nowak', gwPoints: 62, total: 2198, movement: 'up' },
-    { rank: 6, team: 'Expected Goals', manager: 'D. Byrne', gwPoints: 58, total: 2074, movement: 'down' },
-    { rank: 7, team: 'Grass Cutters FC', manager: 'A. Silva', gwPoints: 55, total: 1958, movement: 'same' },
-    { rank: 8, team: 'Last Min Winners', manager: 'K. Walsh', gwPoints: 51, total: 1842, movement: 'up' },
-    { rank: 9, team: 'Offside Masters', manager: 'P. Novak', gwPoints: 47, total: 1698, movement: 'down' },
-    { rank: 10, team: 'Transfer Twisters', manager: 'R. Hughes', gwPoints: 43, total: 1542, movement: 'down' },
+    { rank: 1, previous_rank: 4, movement: 3, team_id: 'team_001', team_name: 'Net Busters', manager_name: 'J. Okafor', gameweek_points: 78, total_points: 2685, transfers_made: 1, transfer_hits: 0, awards_count: 2 },
+    { rank: 2, previous_rank: 1, movement: -1, team_id: 'team_002', team_name: 'Pitch Predators', manager_name: 'S. Ahmed', gameweek_points: 71, total_points: 2514, transfers_made: 1, transfer_hits: 0 },
+    { rank: 3, previous_rank: 3, movement: 0, team_id: 'team_003', team_name: 'Golden Boot Gang', manager_name: 'L. Rossi', gameweek_points: 69, total_points: 2431, transfers_made: 2, transfer_hits: 4 },
+    { rank: 4, previous_rank: 4, movement: 0, team_id: 'team_gaffer', team_name: 'The Gaffer’s XI', manager_name: 'The Gaffer', gameweek_points: 64, total_points: 2315, transfers_made: 0, transfer_hits: 0 },
+    { rank: 5, previous_rank: 7, movement: 2, team_id: 'team_005', team_name: 'Tiki Taka Titans', manager_name: 'M. Nowak', gameweek_points: 62, total_points: 2198, transfers_made: 1, transfer_hits: 0 },
+    { rank: 6, previous_rank: 5, movement: -1, team_id: 'team_006', team_name: 'Expected Goals', manager_name: 'D. Byrne', gameweek_points: 58, total_points: 2074, transfers_made: 1, transfer_hits: 0 },
+    { rank: 7, previous_rank: 9, movement: 2, team_id: 'team_you', team_name: 'No Kane No Gain', manager_name: 'You', gameweek_points: 55, total_points: 1958, transfers_made: 1, transfer_hits: 0 },
+    { rank: 8, previous_rank: 6, movement: -2, team_id: 'team_008', team_name: 'Last Min Winners', manager_name: 'K. Walsh', gameweek_points: 51, total_points: 1842, transfers_made: 2, transfer_hits: 4 },
+    { rank: 9, previous_rank: 8, movement: -1, team_id: 'team_009', team_name: 'Offside Masters', manager_name: 'P. Novak', gameweek_points: 47, total_points: 1698, transfers_made: 1, transfer_hits: 0 },
+    { rank: 10, previous_rank: 10, movement: 0, team_id: 'team_010', team_name: 'Transfer Twisters', manager_name: 'R. Hughes', gameweek_points: 43, total_points: 1542, transfers_made: 3, transfer_hits: 8 },
   ],
 };
 
-export const FANTASY_PRIZES: { headline: string; sub: string; grand: FantasyPrize; prizes: FantasyPrize[] } = {
-  headline: 'Prizes & Glory',
-  sub: 'Win big. Laugh harder.',
-  grand: {
-    id: 'grand',
-    kind: 'grand',
-    title: 'Tropical Escape',
-    subtitle: 'The ultimate footy getaway for our season champion.',
-    image: '/images/fantasy/prizes/prize-tropical.jpg',
-    tag: 'Grand Prize',
-  },
+export const FANTASY_PRIZES: FantasyPrizesResponse = {
+  season: '2025/26', updated_at: new Date().toISOString(),
   prizes: [
-    { id: 'voucher', kind: 'standard', title: 'Premium Vouchers', subtitle: 'Spend it your way, every month.', image: '/images/fantasy/prizes/prize-voucher.jpg', tag: 'Monthly' },
-    { id: 'villa', kind: 'standard', title: 'Luxury Weekend Away', subtitle: 'Escape in style on the club.', image: '/images/fantasy/prizes/prize-villa.jpg', tag: 'Seasonal' },
-    { id: 'experiences', kind: 'standard', title: 'Football Experiences', subtitle: 'Matchday tickets & money-can’t-buy days.', image: '/images/fantasy/prizes/prize-experiences.jpg', tag: 'Live' },
-    { id: 'donkey', kind: 'fun', title: 'Donkey of the Week', subtitle: 'Finish bottom, wear the ears with pride.', image: '/images/fantasy/prizes/prize-donkey.jpg', tag: 'Wooden Spoon' },
+    { id: 'prize_tropical_holiday', season: '2025/26', title: 'Tropical Escape', description: 'The season headline — a dream holiday for the overall Fantasy League champion.', category: 'seasonal', image_url: '/images/fantasy/prizes/prize-tropical.jpg', enabled: true },
+    { id: 'prize_weekly_cash', season: '2025/26', title: 'Weekly Cash Prize', description: 'Top the gameweek and take home cold, hard cash. Every single week.', category: 'weekly', image_url: '/images/fantasy/prizes/prize-voucher.jpg', enabled: true },
+    { id: 'prize_luxury_weekend', season: '2025/26', title: 'Luxury Weekend Away', description: 'A monthly escape in style, on the club.', category: 'themed', image_url: '/images/fantasy/prizes/prize-villa.jpg', enabled: true },
+    { id: 'prize_football_experiences', season: '2025/26', title: 'Football Experiences', description: "Matchday tickets and money-can't-buy days out.", category: 'themed', image_url: '/images/fantasy/prizes/prize-experiences.jpg', enabled: true },
+    { id: 'prize_xmas_hamper', season: '2025/26', title: '£1,000 Christmas Hamper', description: 'A themed festive giveaway during the Christmas fixture rush.', category: 'themed', starts_at: '2025-11-20T00:00:00Z', ends_at: '2025-12-26T23:59:59Z', enabled: true },
+    { id: 'prize_donkey', season: '2025/26', title: 'Donkey of the Week', description: 'Finish bottom and wear the ears with pride. Fame — of a sort.', category: 'random', image_url: '/images/fantasy/prizes/prize-donkey.jpg', enabled: true },
   ],
 };
 
-const daysAdd = (days: number) => new Date(Date.now() + days * 86400000).toISOString();
+/* ════════════════════════════════ hooks ════════════════════════════════ */
 
-export const FANTASY_META: FantasyLeagueMeta = {
-  season: { name: '2025/26 Season', status: 'live', registrationOpen: true, joinUrl: '/pricing', deadline: daysAdd(30) },
-  gameweek: { number: 24, label: 'Gameweek 24', deadline: daysAdd(2.35) },
-  entries: 4821,
-};
-
-/* ───────────────────────────── hooks ───────────────────────────── */
-
-const PLAYERS_FALLBACK = { players: FANTASY_PLAYERS, rules: FANTASY_RULES };
-
-export function useFantasyPlayers() {
+export function useFantasyGameweek(gameweek?: number) {
   return useQuery({
-    queryKey: ['fantasy_players'],
+    queryKey: ['fantasy_gameweek', gameweek ?? 'current'],
+    staleTime: 1000 * 60 * 2,
+    retry: false,
+    placeholderData: FANTASY_GAMEWEEK,
+    queryFn: () => invokeFantasy<FantasyGameweekResponse>('get-fantasy-gameweek', { gameweek }, FANTASY_GAMEWEEK, (d) => !!(d as FantasyGameweekResponse)?.deadline_at),
+  });
+}
+
+export function useFantasyPlayers(filters?: FantasyPlayersFilters) {
+  return useQuery({
+    queryKey: ['fantasy_players', filters ?? {}],
     staleTime: 1000 * 60 * 10,
     retry: false,
-    // Render fallback instantly, upgrade in-place if a real endpoint responds.
-    placeholderData: PLAYERS_FALLBACK,
-    queryFn: () => withFallback('fantasy-players', PLAYERS_FALLBACK, (d) => !!(d as { players?: unknown[] }).players?.length),
+    placeholderData: { players: FANTASY_PLAYERS, total: FANTASY_PLAYERS.length, filters: filters ?? {}, updated_at: FANTASY_GAMEWEEK.updated_at } as FantasyPlayersResponse,
+    queryFn: () => invokeFantasy<FantasyPlayersResponse>('get-fantasy-players', { filters }, { players: FANTASY_PLAYERS, total: FANTASY_PLAYERS.length, filters: filters ?? {}, updated_at: new Date().toISOString() }, (d) => Array.isArray((d as FantasyPlayersResponse)?.players)),
   });
 }
 
-export function useFantasyStandings() {
+export function useFantasyTeam(teamId?: string, gameweek?: number) {
   return useQuery({
-    queryKey: ['fantasy_standings'],
-    staleTime: 1000 * 60 * 5,
+    queryKey: ['fantasy_team', teamId ?? 'demo', gameweek ?? 'current'],
+    staleTime: 1000 * 60 * 2,
+    retry: false,
+    placeholderData: FANTASY_TEAM,
+    queryFn: () => invokeFantasy<FantasyTeam>('get-fantasy-team', { teamId, gameweek }, FANTASY_TEAM, (d) => Array.isArray((d as FantasyTeam)?.slots)),
+  });
+}
+
+export function useFantasyStandings(leagueId = 'main-2025-26', gameweek?: number) {
+  return useQuery({
+    queryKey: ['fantasy_standings', leagueId, gameweek ?? 'current'],
+    staleTime: 1000 * 60 * 2,
     retry: false,
     placeholderData: FANTASY_STANDINGS,
-    queryFn: () => withFallback('fantasy-standings', FANTASY_STANDINGS, (d) => !!(d as { rows?: unknown[] }).rows?.length),
+    queryFn: () => invokeFantasy<FantasyStandingsResponse>('get-fantasy-standings', { leagueId, gameweek }, FANTASY_STANDINGS, (d) => Array.isArray((d as FantasyStandingsResponse)?.rows)),
   });
 }
 
-export function useFantasyPrizes() {
+export function useFantasyPrizes(season = '2025/26') {
   return useQuery({
-    queryKey: ['fantasy_prizes'],
+    queryKey: ['fantasy_prizes', season],
     staleTime: 1000 * 60 * 30,
     retry: false,
     placeholderData: FANTASY_PRIZES,
-    queryFn: () => withFallback('fantasy-prizes', FANTASY_PRIZES, (d) => !!(d as { grand?: unknown }).grand),
+    queryFn: () => invokeFantasy<FantasyPrizesResponse>('get-fantasy-prizes', { season }, FANTASY_PRIZES, (d) => Array.isArray((d as FantasyPrizesResponse)?.prizes)),
   });
 }
 
-export function useFantasyMeta() {
-  return useQuery({
-    queryKey: ['fantasy_meta'],
-    staleTime: 1000 * 60 * 5,
-    retry: false,
-    placeholderData: FANTASY_META,
-    queryFn: () => withFallback('fantasy-meta', FANTASY_META, (d) => !!(d as { season?: unknown }).season),
-  });
+/**
+ * Derived Gameweek Results — combines the team + gameweek (and, once wired, the
+ * fantasy-scores realtime channel). Per the work order, there is NO
+ * get-fantasy-results endpoint; this is a client-side selector over existing
+ * reads. Captain ×2, bench points and Gaffer Bonus are presentation only.
+ */
+export function useFantasyGameweekResults(teamId?: string, gameweek?: number) {
+  const team = useFantasyTeam(teamId, gameweek);
+  const gw = useFantasyGameweek(gameweek);
+  const slots = team.data?.slots ?? [];
+  const starters = slots.filter((s) => s.is_starter);
+  const captainMultiplier = (s: (typeof slots)[number]) => (s.is_captain ? 2 : 1);
+  const total = starters.reduce((sum, s) => sum + (s.player.gameweek_points ?? 0) * captainMultiplier(s), 0);
+  return {
+    isLoading: team.isLoading || gw.isLoading,
+    team: team.data,
+    gameweek: gw.data,
+    starters,
+    bench: slots.filter((s) => !s.is_starter).sort((a, b) => (a.bench_order ?? 9) - (b.bench_order ?? 9)),
+    total,
+    status: gw.data?.status ?? 'open',
+  };
 }

--- a/supabase/functions/_shared/api.ts
+++ b/supabase/functions/_shared/api.ts
@@ -1,0 +1,35 @@
+// Shared response envelope + CORS for the Footy Oracle fantasy edge functions.
+// Every function returns ApiResponse<T> per docs/DATA_CONTRACTS.md.
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+export function ok<T>(data: T, meta?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ ok: true, data, ...(meta ? { meta } : {}) }), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+export function fail(code: string, message: string, status = 400, details?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ ok: false, error: { code, message, ...(details ? { details } : {}) } }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+/** Handle CORS preflight; returns a Response for OPTIONS, else null. */
+export function preflight(req: Request): Response | null {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  return null;
+}
+
+export async function readBody<T>(req: Request): Promise<T> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return {} as T;
+  }
+}

--- a/supabase/functions/_shared/fpl.ts
+++ b/supabase/functions/_shared/fpl.ts
@@ -1,0 +1,154 @@
+// ============================================================================
+// Footy Oracle — shared FPL proxy layer
+// Fetches the Fantasy Premier League public API server-side (browser CORS is
+// blocked) and maps raw FPL payloads into the LOCKED Footy Oracle contracts in
+// src/types/footy.ts. FPL is invisible plumbing — nothing here leaks to the UI
+// except the mapped Footy Oracle shapes.
+//
+// Contract source of truth: src/types/footy.ts + docs/DATA_CONTRACTS.md.
+// ============================================================================
+import type {
+  FantasyPlayer,
+  FantasyPosition,
+  ClubRef,
+  FantasyFixture,
+  FantasyGameweekStatus,
+  FantasyChip,
+} from "../../../src/types/footy.ts";
+
+export const FPL_BASE = "https://fantasy.premierleague.com/api";
+
+/** Locked squad rules (constants, not payload interfaces). */
+export const FANTASY_RULES = {
+  budget: 100,
+  squadSize: 15,
+  starters: 11,
+  bench: 4,
+  perPosition: { GK: 2, DEF: 5, MID: 5, FWD: 3 } as Record<FantasyPosition, number>,
+  maxPerClub: 3,
+} as const;
+
+const UA = { "User-Agent": "FootyOracle/1.0 (+fantasy proxy)", Accept: "application/json" };
+
+export async function fplGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${FPL_BASE}${path}`, { headers: UA });
+  if (!res.ok) throw new Error(`FPL ${path} → ${res.status}`);
+  return (await res.json()) as T;
+}
+
+/* ── raw FPL shapes (server-only; loosely typed) ─────────────────────────── */
+export interface FplTeam { id: number; name: string; short_name: string; code: number }
+export interface FplElementType { id: number; singular_name_short: string }
+export interface FplElement {
+  id: number; web_name: string; first_name: string; second_name: string;
+  element_type: number; team: number; now_cost: number; status: string; news: string;
+  selected_by_percent: string; total_points: number; event_points: number; form: string;
+}
+export interface FplEvent {
+  id: number; name: string; deadline_time: string; finished: boolean;
+  is_previous: boolean; is_current: boolean; is_next: boolean; data_checked: boolean;
+}
+export interface FplBootstrap { events: FplEvent[]; teams: FplTeam[]; element_types: FplElementType[]; elements: FplElement[] }
+export interface FplFixture {
+  id: number; event: number | null; kickoff_time: string | null; team_h: number; team_a: number;
+  team_h_score: number | null; team_a_score: number | null; started: boolean; finished: boolean;
+  team_h_difficulty: number; team_a_difficulty: number;
+}
+
+/* ── mappers ─────────────────────────────────────────────────────────────── */
+
+export function positionOf(typeId: number, types: FplElementType[]): FantasyPosition {
+  const short = types.find((t) => t.id === typeId)?.singular_name_short ?? "";
+  if (short === "GKP" || short === "GK") return "GK";
+  if (short === "DEF") return "DEF";
+  if (short === "MID") return "MID";
+  return "FWD";
+}
+
+const STATUS_MAP: Record<string, FantasyPlayer["status"]> = {
+  a: "available", i: "injured", s: "suspended", d: "doubtful", u: "unavailable", n: "unavailable",
+};
+export function statusOf(s: string): FantasyPlayer["status"] {
+  return STATUS_MAP[s] ?? "available";
+}
+
+const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+export function clubRef(team: FplTeam): ClubRef {
+  return {
+    id: slug(team.name),
+    name: team.name,
+    short_name: team.short_name,
+    badge_url: `https://resources.premierleague.com/premierleague/badges/50/t${team.code}.png`,
+  };
+}
+
+export function mapPlayer(el: FplElement, teams: FplTeam[], types: FplElementType[]): FantasyPlayer {
+  const team = teams.find((t) => t.id === el.team);
+  return {
+    id: String(el.id),
+    external_id: `fpl_${el.id}`,
+    name: `${el.first_name} ${el.second_name}`.trim() || el.web_name,
+    position: positionOf(el.element_type, types),
+    club: team ? clubRef(team) : { id: "unknown", name: "Unknown", short_name: "UNK" },
+    price: Math.round(el.now_cost) / 10,
+    status: statusOf(el.status),
+    selected_by_percent: Number(el.selected_by_percent) || 0,
+    total_points: el.total_points ?? 0,
+    gameweek_points: el.event_points ?? 0,
+    form: Number(el.form) || 0,
+    news: el.news || undefined,
+  };
+}
+
+/** "2025/26" from the events list (season derived from the first deadline). */
+export function seasonLabel(events: FplEvent[]): string {
+  const first = events.find((e) => e.id === 1) ?? events[0];
+  const y = first ? new Date(first.deadline_time).getUTCFullYear() : new Date().getUTCFullYear();
+  return `${y}/${String((y + 1) % 100).padStart(2, "0")}`;
+}
+
+/** Resolve the target gameweek: explicit → current → next → 1. */
+export function resolveGameweek(events: FplEvent[], requested?: number): FplEvent {
+  if (requested) {
+    const e = events.find((ev) => ev.id === requested);
+    if (e) return e;
+  }
+  return events.find((e) => e.is_current) ?? events.find((e) => e.is_next) ?? events[0];
+}
+
+export function gameweekStatus(event: FplEvent): FantasyGameweekStatus {
+  const now = Date.now();
+  const deadline = new Date(event.deadline_time).getTime();
+  if (event.finished && event.data_checked) return "settled";
+  if (event.is_current || (now >= deadline && !event.finished)) return "live";
+  if (now < deadline && (event.is_next || event.is_current)) return "open";
+  if (now < deadline) return "upcoming";
+  return "live";
+}
+
+export function mapFixture(fx: FplFixture, teams: FplTeam[]): FantasyFixture {
+  const h = teams.find((t) => t.id === fx.team_h);
+  const a = teams.find((t) => t.id === fx.team_a);
+  const status: FantasyFixture["status"] = fx.finished ? "finished" : fx.started ? "live" : fx.kickoff_time ? "scheduled" : "postponed";
+  return {
+    id: `fx_${fx.id}`,
+    kickoff_time: fx.kickoff_time ?? "",
+    home_team: h ? clubRef(h) : { id: "tbd", name: "TBD", short_name: "TBD" },
+    away_team: a ? clubRef(a) : { id: "tbd", name: "TBD", short_name: "TBD" },
+    status,
+    home_score: fx.team_h_score ?? undefined,
+    away_score: fx.team_a_score ?? undefined,
+  };
+}
+
+/** FPL chip code → Footy Oracle chip name. */
+export function mapChip(code?: string | null): FantasyChip | undefined {
+  switch (code) {
+    case "wildcard": return "wildcard";
+    case "bboost": return "bench_boost";
+    case "3xc": return "triple_captain";
+    case "freehit": return "free_hit";
+    default: return undefined;
+  }
+}

--- a/supabase/functions/get-fantasy-gameweek/index.ts
+++ b/supabase/functions/get-fantasy-gameweek/index.ts
@@ -1,0 +1,50 @@
+// ============================================================================
+// Footy Oracle — get-fantasy-gameweek
+// Current (or requested) gameweek: deadline, status, fixtures, bonus rules.
+// Source: FPL /bootstrap-static/ + /fixtures/?event={gw}. Returns
+// FantasyGameweekResponse (src/types/footy.ts). No contract changes.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import {
+  fplGet, resolveGameweek, gameweekStatus, seasonLabel, mapFixture,
+  type FplBootstrap, type FplFixture,
+} from "../_shared/fpl.ts";
+import type { FantasyGameweekResponse, GetFantasyGameweekRequest } from "../../../src/types/footy.ts";
+
+// The Gaffer Bonus is an admin/manual presentation concept in v1 (per contract).
+const BONUS_RULES: FantasyGameweekResponse["bonus_rules"] = [
+  { key: "manual_bonus", label: "Gaffer Bonus", description: "Optional 0–3 bonus points, awarded by The Gaffer for standout performances." },
+];
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { gameweek } = await readBody<GetFantasyGameweekRequest>(req);
+    const boot = await fplGet<FplBootstrap>("/bootstrap-static/");
+    const event = resolveGameweek(boot.events, gameweek);
+    if (!event) return fail("NO_GAMEWEEK", "No gameweek could be resolved from the FPL calendar.", 404);
+
+    let fixtures: FantasyGameweekResponse["fixtures"] = [];
+    try {
+      const raw = await fplGet<FplFixture[]>(`/fixtures/?event=${event.id}`);
+      fixtures = raw.map((fx) => mapFixture(fx, boot.teams));
+    } catch (_) {
+      fixtures = [];
+    }
+
+    const data: FantasyGameweekResponse = {
+      season: seasonLabel(boot.events),
+      gameweek: event.id,
+      status: gameweekStatus(event),
+      deadline_at: event.deadline_time,
+      fixtures,
+      bonus_rules: BONUS_RULES,
+      updated_at: new Date().toISOString(),
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("FPL_UPSTREAM", `Could not load the gameweek: ${(err as Error).message}`, 502);
+  }
+});

--- a/supabase/functions/get-fantasy-players/index.ts
+++ b/supabase/functions/get-fantasy-players/index.ts
@@ -1,0 +1,68 @@
+// ============================================================================
+// Footy Oracle — get-fantasy-players
+// Filterable/sortable player pool for Pick Squad + Transfers.
+// Source: FPL /bootstrap-static/. Returns FantasyPlayersResponse.
+// Supports filters: position, club, min/max price, search, sort, direction,
+// limit, offset. Locked rules (£100m / 15 / 2·5·5·3 / max 3 per club) are
+// enforced client-side + in save-squad; this endpoint is the catalogue.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { fplGet, mapPlayer, type FplBootstrap } from "../_shared/fpl.ts";
+import type {
+  FantasyPlayersResponse, FantasyPlayer, FantasyPlayersFilters, GetFantasyPlayersRequest,
+} from "../../../src/types/footy.ts";
+
+const SORT_KEY: Record<NonNullable<FantasyPlayersFilters["sort"]>, (p: FantasyPlayer) => number | string> = {
+  price: (p) => p.price,
+  total_points: (p) => p.total_points,
+  form: (p) => p.form ?? 0,
+  selected_by_percent: (p) => p.selected_by_percent ?? 0,
+  name: (p) => p.name.toLowerCase(),
+};
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { filters = {} } = await readBody<GetFantasyPlayersRequest>(req);
+    const boot = await fplGet<FplBootstrap>("/bootstrap-static/");
+    let players = boot.elements.map((el) => mapPlayer(el, boot.teams, boot.element_types));
+
+    if (filters.position) players = players.filter((p) => p.position === filters.position);
+    if (filters.club) {
+      const c = filters.club.toLowerCase();
+      players = players.filter((p) => p.club.id === c || p.club.short_name?.toLowerCase() === c);
+    }
+    if (typeof filters.min_price === "number") players = players.filter((p) => p.price >= filters.min_price!);
+    if (typeof filters.max_price === "number") players = players.filter((p) => p.price <= filters.max_price!);
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      players = players.filter((p) => p.name.toLowerCase().includes(q) || p.club.name.toLowerCase().includes(q));
+    }
+
+    const sortBy = filters.sort ?? "total_points";
+    const dir = filters.direction ?? (sortBy === "name" ? "asc" : "desc");
+    const key = SORT_KEY[sortBy];
+    players.sort((a, b) => {
+      const av = key(a), bv = key(b);
+      const cmp = typeof av === "string" ? av.localeCompare(bv as string) : (av as number) - (bv as number);
+      return dir === "asc" ? cmp : -cmp;
+    });
+
+    const total = players.length;
+    const offset = filters.offset ?? 0;
+    const limit = filters.limit ?? 50;
+    const page = players.slice(offset, offset + limit);
+
+    const data: FantasyPlayersResponse = {
+      players: page,
+      total,
+      filters: { ...filters, sort: sortBy, direction: dir, limit, offset },
+      updated_at: new Date().toISOString(),
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("FPL_UPSTREAM", `Could not load players: ${(err as Error).message}`, 502);
+  }
+});

--- a/supabase/functions/get-fantasy-prizes/index.ts
+++ b/supabase/functions/get-fantasy-prizes/index.ts
@@ -1,0 +1,59 @@
+// ============================================================================
+// Footy Oracle — get-fantasy-prizes
+// Admin-set prize config (NOT from FPL). Reads the `fantasy_prizes` table if it
+// exists, otherwise returns a typed fallback. Returns FantasyPrizesResponse.
+//
+// NOTE (contract): FantasyPrize.category is 'weekly' | 'random' | 'themed' |
+// 'seasonal'. The locked prize list also mentions a "monthly" cadence, which the
+// union cannot express. Flagged to add `'monthly'` to the union before use — see
+// the summary. Until then monthly prizes are modelled as 'themed'.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import type { FantasyPrizesResponse, FantasyPrize, GetFantasyPrizesRequest } from "../../../src/types/footy.ts";
+
+function fallbackPrizes(season: string): FantasyPrize[] {
+  const p = (o: Partial<FantasyPrize> & Pick<FantasyPrize, "id" | "title" | "description" | "category">): FantasyPrize => ({
+    season, enabled: true, ...o,
+  });
+  return [
+    p({ id: "prize_tropical_holiday", title: "Tropical Escape", description: "The season headline — a dream holiday for the overall Fantasy League champion.", category: "seasonal", image_url: "/images/fantasy/prizes/prize-tropical.jpg" }),
+    p({ id: "prize_weekly_cash", title: "Weekly Cash Prize", description: "Top the gameweek and take home cold, hard cash. Every single week.", category: "weekly", image_url: "/images/fantasy/prizes/prize-voucher.jpg" }),
+    p({ id: "prize_luxury_weekend", title: "Luxury Weekend Away", description: "A monthly escape in style, on the club.", category: "themed", image_url: "/images/fantasy/prizes/prize-villa.jpg" }),
+    p({ id: "prize_football_experiences", title: "Football Experiences", description: "Matchday tickets and money-can't-buy days out.", category: "themed", image_url: "/images/fantasy/prizes/prize-experiences.jpg" }),
+    p({ id: "prize_xmas_hamper", title: "£1,000 Christmas Hamper", description: "A themed festive giveaway during the Christmas fixture rush.", category: "themed", starts_at: `${season.slice(0, 4)}-11-20T00:00:00Z`, ends_at: `${season.slice(0, 4)}-12-26T23:59:59Z` }),
+    p({ id: "prize_donkey", title: "Donkey of the Week", description: "Finish bottom and wear the ears with pride. Fame — of a sort.", category: "random", image_url: "/images/fantasy/prizes/prize-donkey.jpg" }),
+  ];
+}
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { season } = await readBody<GetFantasyPrizesRequest>(req);
+    const seasonKey = season || "2025/26";
+
+    let prizes: FantasyPrize[] | null = null;
+    try {
+      const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+      const { data, error } = await supabase
+        .from("fantasy_prizes")
+        .select("id, season, title, description, image_url, category, starts_at, ends_at, enabled")
+        .eq("season", seasonKey)
+        .eq("enabled", true);
+      if (!error && data && data.length) prizes = data as FantasyPrize[];
+    } catch (_) {
+      prizes = null;
+    }
+
+    const data: FantasyPrizesResponse = {
+      season: seasonKey,
+      prizes: prizes ?? fallbackPrizes(seasonKey),
+      updated_at: new Date().toISOString(),
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("PRIZES_ERROR", `Could not load prizes: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/functions/get-fantasy-standings/index.ts
+++ b/supabase/functions/get-fantasy-standings/index.ts
@@ -1,0 +1,59 @@
+// ============================================================================
+// Footy Oracle — get-fantasy-standings
+// Mini-league leaderboard with rank movement.
+// Source: FPL /leagues-classic/{league_id}/standings/ (+ /bootstrap-static/ for
+// season + current gameweek). Returns FantasyStandingsResponse.
+// The Footy Oracle leagueId slug maps to an FPL numeric id via FPL_LEAGUE_ID.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { fplGet, resolveGameweek, gameweekStatus, seasonLabel, type FplBootstrap } from "../_shared/fpl.ts";
+import type { FantasyStandingsResponse, FantasyStandingRow, GetFantasyStandingsRequest } from "../../../src/types/footy.ts";
+
+interface FplStandRow {
+  id: number; entry: number; entry_name: string; player_name: string;
+  rank: number; last_rank: number; total: number; event_total: number;
+}
+interface FplLeague { league: { id: number; name: string }; standings: { results: FplStandRow[]; has_next: boolean } }
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { leagueId, gameweek } = await readBody<GetFantasyStandingsRequest>(req);
+    // Footy Oracle slug → FPL numeric league id (env-configured for the real league).
+    const fplLeagueId = /^\d+$/.test(String(leagueId)) ? String(leagueId) : Deno.env.get("FPL_LEAGUE_ID");
+    if (!fplLeagueId) return fail("LEAGUE_NOT_CONFIGURED", "No FPL league id configured for this league.", 404);
+
+    const [boot, league] = await Promise.all([
+      fplGet<FplBootstrap>("/bootstrap-static/"),
+      fplGet<FplLeague>(`/leagues-classic/${fplLeagueId}/standings/`),
+    ]);
+    const event = resolveGameweek(boot.events, gameweek);
+
+    const rows: FantasyStandingRow[] = league.standings.results.map((r) => ({
+      rank: r.rank,
+      previous_rank: r.last_rank > 0 ? r.last_rank : undefined,
+      movement: r.last_rank > 0 ? r.last_rank - r.rank : 0,
+      team_id: String(r.entry),
+      team_name: r.entry_name,
+      manager_name: r.player_name,
+      gameweek_points: r.event_total,
+      total_points: r.total,
+      transfers_made: 0,
+      transfer_hits: 0,
+    }));
+
+    const data: FantasyStandingsResponse = {
+      league_id: String(leagueId ?? fplLeagueId),
+      season: seasonLabel(boot.events),
+      gameweek: event.id,
+      status: gameweekStatus(event),
+      rows,
+      updated_at: new Date().toISOString(),
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("FPL_UPSTREAM", `Could not load standings: ${(err as Error).message}`, 502);
+  }
+});

--- a/supabase/functions/get-fantasy-team/index.ts
+++ b/supabase/functions/get-fantasy-team/index.ts
@@ -1,0 +1,74 @@
+// ============================================================================
+// Footy Oracle — get-fantasy-team
+// A manager's 15-player squad: starters/bench, captain, vice, chip, budget.
+// Sources: FPL /entry/{id}/, /entry/{id}/event/{gw}/picks/, /bootstrap-static/.
+// Returns FantasyTeam (src/types/footy.ts).
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import {
+  fplGet, mapPlayer, mapChip, resolveGameweek, FANTASY_RULES,
+  type FplBootstrap,
+} from "../_shared/fpl.ts";
+import type { FantasyTeam, FantasyTeamSlot, GetFantasyTeamRequest } from "../../../src/types/footy.ts";
+
+interface FplPick { element: number; position: number; is_captain: boolean; is_vice_captain: boolean; multiplier: number }
+interface FplPicks {
+  active_chip: string | null;
+  entry_history: { bank: number; value: number; event_transfers: number; event_transfers_cost: number };
+  picks: FplPick[];
+}
+interface FplEntry { name: string; player_first_name: string; player_last_name: string }
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { teamId, gameweek } = await readBody<GetFantasyTeamRequest>(req);
+    if (!teamId) return fail("MISSING_TEAM_ID", "A teamId is required to load a fantasy team.");
+
+    const boot = await fplGet<FplBootstrap>("/bootstrap-static/");
+    const gw = resolveGameweek(boot.events, gameweek).id;
+
+    let entry: FplEntry;
+    let picks: FplPicks;
+    try {
+      [entry, picks] = await Promise.all([
+        fplGet<FplEntry>(`/entry/${teamId}/`),
+        fplGet<FplPicks>(`/entry/${teamId}/event/${gw}/picks/`),
+      ]);
+    } catch (_) {
+      return fail("TEAM_NOT_FOUND", `No squad found for team ${teamId} in gameweek ${gw}.`, 404);
+    }
+
+    const slots: FantasyTeamSlot[] = picks.picks.map((pk) => {
+      const el = boot.elements.find((e) => e.id === pk.element)!;
+      return {
+        player: mapPlayer(el, boot.teams, boot.element_types),
+        is_starter: pk.position <= FANTASY_RULES.starters,
+        bench_order: pk.position > FANTASY_RULES.starters ? pk.position - FANTASY_RULES.starters : undefined,
+        is_captain: pk.is_captain,
+        is_vice_captain: pk.is_vice_captain,
+      };
+    });
+
+    const squadValue = (picks.entry_history?.value ?? 1000) / 10;
+    const data: FantasyTeam = {
+      id: String(teamId),
+      member_id: `fpl_entry_${teamId}`,
+      league_id: Deno.env.get("FPL_LEAGUE_ID") ?? "main",
+      name: entry.name,
+      budget_total: FANTASY_RULES.budget,
+      budget_remaining: (picks.entry_history?.bank ?? 0) / 10,
+      squad_value: squadValue,
+      free_transfers: 1,
+      transfer_hits: picks.entry_history?.event_transfers_cost ?? 0,
+      active_chip: mapChip(picks.active_chip),
+      slots,
+      updated_at: new Date().toISOString(),
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("FPL_UPSTREAM", `Could not load the team: ${(err as Error).message}`, 502);
+  }
+});


### PR DESCRIPTION
## What

Executes STEPS 1–4 of the Fantasy master work order: wires the **read layer** to the FPL public API through Supabase Edge Functions and **rebinds the `/fantasy-league` page** to the locked contracts. No contract changes — all shapes come from `src/types/footy.ts`.

### Read proxies (Deno — FPL is invisible plumbing, mapped to `footy.ts`, `{ ok, data }` envelope)
- `_shared/fpl.ts` — FPL client + mappers (players, clubs, positions, fixtures, gameweek status, chips) + locked squad rules.
- `_shared/api.ts` — envelope + CORS helpers.
- `get-fantasy-gameweek` — current/requested GW, deadline, fixtures, bonus rules (`/bootstrap-static/` + `/fixtures/`).
- `get-fantasy-players` — filterable/sortable pool: position, club, price, search, sort, direction, limit, offset.
- `get-fantasy-team` — 15-man squad, starters/bench, captain/vice, chip, budget (`/entry/*`).
- `get-fantasy-standings` — mini-league table with rank movement (`/leagues-classic/*`).
- `get-fantasy-prizes` — admin-set config (Supabase `fantasy_prizes` table + typed fallback; **not** FPL).

### Frontend data layer (`src/hooks/useFantasyLeague.ts`)
- `useFantasyGameweek / Players / Team / Standings / Prizes` — call `supabase.functions.invoke`, unwrap the envelope, fall back to typed data matching the contracts exactly (`placeholderData` for instant render, timeout race so a missing function never hangs).
- `useFantasyGameweekResults` — client-side selector over team + gameweek. **No `get-fantasy-results` endpoint added**, per the work order.

### Page rebind (STEP 4)
Every fantasy component now imports `@/types/footy` and the wrapper hooks. The squad builder evolves from the old **11-player / £95m** sample logic to the locked model: **15 players, £100m, 2·5·5·3, max 3 per club, captain + vice**. FUT cards headline the real fantasy points (the contract has no `rating`, so nothing is fabricated).

### Notes / flag
- **Contract gap flagged (not patched):** `FantasyPrize.category` is `weekly | random | themed | seasonal`, but the locked prize list also names a **monthly** cadence. That can't be expressed today — proposing a one-line addition of `'monthly'` to the union before use. Monthly prizes are modelled as `themed` in the meantime.
- Edge functions only go live once Lovable syncs; until then the typed fallbacks render the page correctly.
- Mutations (save-squad, transfers, captain/vice, chip) and realtime channels follow in the next PR, per the work order's ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer fantasy league views, including current gameweek details, standings, prize information, and team lineups.
  * Improved player cards with clearer point totals, availability status, and captain/vice-captain badges.
  * Updated the squad builder to better support fixed squad rules and automatic captain/vice selection.

* **Bug Fixes**
  * Standings and league highlights now display more accurate movement and scoring information.
  * Prize and leaderboard sections now show more consistent, up-to-date data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->