### PR TITLE
Fantasy engine: mutations + realtime (STEP 5 + 6)

### DIFF
--- a/src/components/fantasy/LeagueStandings.tsx
+++ b/src/components/fantasy/LeagueStandings.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Crown, TrendingUp, TrendingDown, Minus, Trophy, ChevronRight, Award } from 'lucide-react';
-import { useFantasyStandings } from '@/hooks/useFantasyLeague';
+import { useFantasyStandings, useFantasyRealtimeStandings } from '@/hooks/useFantasyLeague';
 import type { FantasyStandingRow } from '@/types/footy';
 
 const GAFFER = '/images/gaffer/gaffer-arms-crossed.png';
@@ -31,6 +31,7 @@ const RANK_TONE = (rank: number) => rank === 1 ? 'bg-[#f5c542] text-[#16051f]' :
  */
 export function LeagueStandings() {
   const { data, isLoading } = useFantasyStandings();
+  useFantasyRealtimeStandings(); // live re-rank on the standings channel
   if (isLoading && !data) return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
   const rows = data?.rows ?? [];

--- a/src/hooks/useFantasyLeague.ts
+++ b/src/hooks/useFantasyLeague.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import type {
   ApiResponse,
@@ -10,6 +11,17 @@ import type {
   FantasyGameweekResponse,
   FantasyPrizesResponse,
   FantasyPosition,
+  SaveSquadRequest,
+  SaveSquadResponse,
+  SubmitTransfersRequest,
+  SubmitTransfersResponse,
+  SetCaptainRequest,
+  SetViceRequest,
+  CaptainMutationResponse,
+  PlayChipRequest,
+  PlayChipResponse,
+  FantasyScoreRealtimePayload,
+  FantasyStandingsRealtimePayload,
 } from '@/types/footy';
 
 /* ───────────────────────────────────────────────────────────────────────────
@@ -258,4 +270,105 @@ export function useFantasyGameweekResults(teamId?: string, gameweek?: number) {
     total,
     status: gw.data?.status ?? 'open',
   };
+}
+
+/* ════════════════════════════════ mutations ════════════════════════════════ */
+
+/** Invoke a mutation wrapper, unwrap the envelope, throw the typed error on failure. */
+async function mutateFantasy<T>(name: string, body: unknown): Promise<T> {
+  const { data, error } = await supabase.functions.invoke(name, { body: body as Record<string, unknown> });
+  if (error) throw new Error(error.message ?? 'Request failed');
+  const env = data as ApiResponse<T>;
+  if (!env || env.ok !== true) throw new Error(env?.error?.message ?? 'Something went wrong. Give it another go.');
+  return env.data;
+}
+
+/** Invalidate the team + standings queries after a squad-changing mutation. */
+function useFantasyInvalidate() {
+  const qc = useQueryClient();
+  return () => {
+    qc.invalidateQueries({ queryKey: ['fantasy_team'] });
+    qc.invalidateQueries({ queryKey: ['fantasy_standings'] });
+  };
+}
+
+export function useSaveSquad() {
+  const invalidate = useFantasyInvalidate();
+  return useMutation({
+    mutationFn: (req: SaveSquadRequest) => mutateFantasy<SaveSquadResponse>('save-squad', req),
+    onSuccess: invalidate,
+  });
+}
+
+export function useSubmitTransfers() {
+  const invalidate = useFantasyInvalidate();
+  return useMutation({
+    mutationFn: (req: SubmitTransfersRequest) => mutateFantasy<SubmitTransfersResponse>('submit-transfers', req),
+    onSuccess: invalidate,
+  });
+}
+
+export function useSetCaptain() {
+  const invalidate = useFantasyInvalidate();
+  return useMutation({
+    mutationFn: (req: SetCaptainRequest) => mutateFantasy<CaptainMutationResponse>('set-captain', req),
+    onSuccess: invalidate,
+  });
+}
+
+export function useSetVice() {
+  const invalidate = useFantasyInvalidate();
+  return useMutation({
+    mutationFn: (req: SetViceRequest) => mutateFantasy<CaptainMutationResponse>('set-vice', req),
+    onSuccess: invalidate,
+  });
+}
+
+export function usePlayChip() {
+  const invalidate = useFantasyInvalidate();
+  return useMutation({
+    mutationFn: (req: PlayChipRequest) => mutateFantasy<PlayChipResponse>('play-chip', req),
+    onSuccess: invalidate,
+  });
+}
+
+/* ════════════════════════════════ realtime ════════════════════════════════ */
+
+/**
+ * Subscribe to the `fantasy-scores` channel. Fires `onScore` with each typed
+ * payload and refreshes the team query so live points flow into the UI. No-op
+ * until the channel is broadcasting.
+ */
+export function useFantasyRealtimeScores(onScore?: (p: FantasyScoreRealtimePayload) => void) {
+  const qc = useQueryClient();
+  useEffect(() => {
+    const channel = supabase
+      .channel('fantasy-scores')
+      .on('broadcast', { event: 'fantasy-score-updated' }, ({ payload }) => {
+        onScore?.(payload as FantasyScoreRealtimePayload);
+        qc.invalidateQueries({ queryKey: ['fantasy_team'] });
+      })
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+/**
+ * Subscribe to the `standings` channel. Fires `onStanding` with each typed
+ * payload and refreshes the standings query so the leaderboard re-ranks live.
+ */
+export function useFantasyRealtimeStandings(onStanding?: (p: FantasyStandingsRealtimePayload) => void) {
+  const qc = useQueryClient();
+  useEffect(() => {
+    const channel = supabase
+      .channel('standings')
+      .on('broadcast', { event: 'standings-updated' }, ({ payload }) => {
+        onStanding?.(payload as FantasyStandingsRealtimePayload);
+        qc.invalidateQueries({ queryKey: ['fantasy_standings'] });
+      })
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }

--- a/supabase/functions/_shared/fantasyRules.ts
+++ b/supabase/functions/_shared/fantasyRules.ts
@@ -1,0 +1,81 @@
+// ============================================================================
+// Footy Oracle — fantasy squad validation engine (shared)
+// Enforces the LOCKED rules: £100m, 15 players (2 GK / 5 DEF / 5 MID / 3 FWD),
+// max 3 per club, a legal starting XI, a 4-man bench (1 GK + 3), and a valid
+// captain/vice. Returns FantasyValidationResult + typed error codes used by the
+// mutation functions. Pure — no I/O.
+// ============================================================================
+import type { FantasyPlayer, FantasyPosition, FantasyValidationResult } from "../../../src/types/footy.ts";
+
+export const RULES = {
+  budget: 100,
+  squadSize: 15,
+  starters: 11,
+  bench: 4,
+  squad: { GK: 2, DEF: 5, MID: 5, FWD: 3 } as Record<FantasyPosition, number>,
+  // starting XI bounds (GK is always 1)
+  xi: { DEF: [3, 5], MID: [2, 5], FWD: [1, 3] } as Record<string, [number, number]>,
+  maxPerClub: 3,
+} as const;
+
+export type ValidationCode =
+  | "INVALID_SQUAD_SIZE" | "INVALID_POSITION_BALANCE" | "BUDGET_EXCEEDED"
+  | "MAX_CLUB_PLAYERS_EXCEEDED" | "INVALID_FORMATION" | "INVALID_BENCH" | "INVALID_CAPTAIN";
+
+const countByPos = (ps: FantasyPlayer[]) => ps.reduce((m, p) => { m[p.position] = (m[p.position] ?? 0) + 1; return m; }, {} as Record<FantasyPosition, number>);
+
+/** Validate the full 15-man squad (size, position quota, budget, club cap). */
+export function validateSquad(players: FantasyPlayer[]): FantasyValidationResult & { code?: ValidationCode } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let code: ValidationCode | undefined;
+
+  const ids = new Set(players.map((p) => p.id));
+  if (players.length !== RULES.squadSize || ids.size !== RULES.squadSize) {
+    errors.push(`Your squad must contain exactly ${RULES.squadSize} unique players.`); code ??= "INVALID_SQUAD_SIZE";
+  }
+  const pos = countByPos(players);
+  (Object.keys(RULES.squad) as FantasyPosition[]).forEach((k) => {
+    if ((pos[k] ?? 0) !== RULES.squad[k]) { errors.push(`You need exactly ${RULES.squad[k]} ${k}.`); code ??= "INVALID_POSITION_BALANCE"; }
+  });
+  const spend = players.reduce((s, p) => s + p.price, 0);
+  if (spend > RULES.budget + 1e-9) { errors.push(`You're £${(spend - RULES.budget).toFixed(1)}m over the £${RULES.budget}m budget.`); code ??= "BUDGET_EXCEEDED"; }
+
+  const perClub = players.reduce((m, p) => { m[p.club.id] = (m[p.club.id] ?? 0) + 1; return m; }, {} as Record<string, number>);
+  const overClub = Object.entries(perClub).find(([, n]) => n > RULES.maxPerClub);
+  if (overClub) { errors.push(`Max ${RULES.maxPerClub} players from one club — you have ${overClub[1]}.`); code ??= "MAX_CLUB_PLAYERS_EXCEEDED"; }
+
+  players.filter((p) => p.status !== "available").forEach((p) => warnings.push(`${p.name} is ${p.status}.`));
+
+  return { valid: errors.length === 0, errors, warnings, code };
+}
+
+/** Validate the starting XI + bench + captain/vice against the squad. */
+export function validateLineup(
+  players: FantasyPlayer[], starters: string[], bench: string[], captainId: string, viceId: string,
+): FantasyValidationResult & { code?: ValidationCode } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let code: ValidationCode | undefined;
+  const byId = new Map(players.map((p) => [p.id, p]));
+
+  if (starters.length !== RULES.starters) { errors.push(`Your starting line-up must be ${RULES.starters} players.`); code ??= "INVALID_FORMATION"; }
+  if (bench.length !== RULES.bench) { errors.push(`Your bench must be ${RULES.bench} players.`); code ??= "INVALID_BENCH"; }
+
+  const startPlayers = starters.map((id) => byId.get(id)).filter(Boolean) as FantasyPlayer[];
+  const sp = countByPos(startPlayers);
+  if ((sp.GK ?? 0) !== 1) { errors.push("Start exactly one goalkeeper."); code ??= "INVALID_FORMATION"; }
+  (["DEF", "MID", "FWD"] as const).forEach((k) => {
+    const [min, max] = RULES.xi[k];
+    if ((sp[k] ?? 0) < min || (sp[k] ?? 0) > max) { errors.push(`Start between ${min} and ${max} ${k}.`); code ??= "INVALID_FORMATION"; }
+  });
+
+  const benchPlayers = bench.map((id) => byId.get(id)).filter(Boolean) as FantasyPlayer[];
+  if (benchPlayers.filter((p) => p.position === "GK").length !== 1) { errors.push("Your bench must include exactly one goalkeeper."); code ??= "INVALID_BENCH"; }
+
+  if (!starters.includes(captainId)) { errors.push("Your captain must be in the starting XI."); code ??= "INVALID_CAPTAIN"; }
+  if (!starters.includes(viceId)) { errors.push("Your vice-captain must be in the starting XI."); code ??= "INVALID_CAPTAIN"; }
+  if (captainId && captainId === viceId) { errors.push("Captain and vice-captain must be different players."); code ??= "INVALID_CAPTAIN"; }
+
+  return { valid: errors.length === 0, errors, warnings, code };
+}

--- a/supabase/functions/_shared/fantasyStore.ts
+++ b/supabase/functions/_shared/fantasyStore.ts
@@ -1,0 +1,44 @@
+// ============================================================================
+// Footy Oracle — fantasy squad store (shared)
+// User squads live in OUR database (FPL is read-only), stored as the full
+// FantasyTeam contract in a `fantasy_teams` table:
+//
+//   create table fantasy_teams (
+//     id text primary key,            -- team id
+//     member_id text,
+//     league_id text,
+//     data jsonb not null,            -- the FantasyTeam payload
+//     updated_at timestamptz default now()
+//   );
+//
+// Helpers return null when the store is unavailable (table not yet created by
+// Lovable), so mutation functions can fail cleanly with STORE_UNAVAILABLE.
+// ============================================================================
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import type { FantasyTeam } from "../../../src/types/footy.ts";
+
+export function serviceClient(): SupabaseClient {
+  return createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+}
+
+export async function loadTeam(sb: SupabaseClient, teamId: string): Promise<FantasyTeam | null> {
+  try {
+    const { data, error } = await sb.from("fantasy_teams").select("data").eq("id", teamId).maybeSingle();
+    if (error || !data) return null;
+    return (data as { data: FantasyTeam }).data;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the team (best-effort). Returns true on success. */
+export async function saveTeam(sb: SupabaseClient, team: FantasyTeam): Promise<boolean> {
+  try {
+    const { error } = await sb.from("fantasy_teams").upsert({
+      id: team.id, member_id: team.member_id, league_id: team.league_id, data: team, updated_at: new Date().toISOString(),
+    });
+    return !error;
+  } catch {
+    return false;
+  }
+}

--- a/supabase/functions/play-chip/index.ts
+++ b/supabase/functions/play-chip/index.ts
@@ -1,0 +1,38 @@
+// ============================================================================
+// Footy Oracle — play-chip
+// Activate a chip for a gameweek. Chips are RESERVED in the v1 schema
+// (wildcard, bench_boost, triple_captain, free_hit): this records the choice on
+// the stored squad; full scoring effects land after the core loop.
+// Returns ApiResponse<PlayChipResponse>.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { serviceClient, loadTeam, saveTeam } from "../_shared/fantasyStore.ts";
+import type { PlayChipRequest, PlayChipResponse, FantasyChip } from "../../../src/types/footy.ts";
+
+const CHIPS: FantasyChip[] = ["wildcard", "bench_boost", "triple_captain", "free_hit"];
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { teamId, chip, gameweek } = await readBody<PlayChipRequest>(req);
+    if (!teamId || !chip) return fail("BAD_REQUEST", "A teamId and chip are required.");
+    if (!CHIPS.includes(chip)) return fail("INVALID_CHIP", `Unknown chip "${chip}".`, 422);
+
+    const sb = serviceClient();
+    const team = await loadTeam(sb, teamId);
+    if (!team) return fail("STORE_UNAVAILABLE", "No saved squad found for this team.", 404);
+    if (team.active_chip) return fail("CHIP_ALREADY_ACTIVE", `You already have ${team.active_chip} active this gameweek.`, 422);
+
+    team.active_chip = chip;
+    const activated_at = new Date().toISOString();
+    team.updated_at = activated_at;
+    await saveTeam(sb, team);
+
+    const data: PlayChipResponse = { team, chip, gameweek, activated_at };
+    return ok(data);
+  } catch (err) {
+    return fail("CHIP_FAILED", `Could not play the chip: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/functions/save-squad/index.ts
+++ b/supabase/functions/save-squad/index.ts
@@ -1,0 +1,70 @@
+// ============================================================================
+// Footy Oracle — save-squad
+// Validate a draft squad against the locked rules and persist it.
+// Returns ApiResponse<SaveSquadResponse>. Errors use typed codes
+// (INVALID_POSITION_BALANCE, BUDGET_EXCEEDED, MAX_CLUB_PLAYERS_EXCEEDED,
+// INVALID_FORMATION, …).
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { fplGet, mapPlayer, FANTASY_RULES, type FplBootstrap } from "../_shared/fpl.ts";
+import { validateSquad, validateLineup } from "../_shared/fantasyRules.ts";
+import { serviceClient, loadTeam, saveTeam } from "../_shared/fantasyStore.ts";
+import type { SaveSquadRequest, SaveSquadResponse, FantasyTeam, FantasyTeamSlot } from "../../../src/types/footy.ts";
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const body = await readBody<SaveSquadRequest>(req);
+    const { teamId, playerIds, starters, bench, captainId, viceCaptainId } = body;
+    if (!teamId || !Array.isArray(playerIds)) return fail("BAD_REQUEST", "A teamId and playerIds are required.");
+
+    const boot = await fplGet<FplBootstrap>("/bootstrap-static/");
+    const byId = new Map(boot.elements.map((e) => [String(e.id), e]));
+    const players = playerIds.map((id) => {
+      const el = byId.get(id);
+      return el ? mapPlayer(el, boot.teams, boot.element_types) : null;
+    });
+    if (players.some((p) => !p)) return fail("PLAYER_UNAVAILABLE", "One or more selected players could not be found.");
+    const squad = players as NonNullable<(typeof players)[number]>[];
+
+    const sV = validateSquad(squad);
+    if (!sV.valid) return fail(sV.code ?? "INVALID_SQUAD", sV.errors[0], 422, { errors: sV.errors });
+    const lV = validateLineup(squad, starters, bench, captainId, viceCaptainId);
+    if (!lV.valid) return fail(lV.code ?? "INVALID_FORMATION", lV.errors[0], 422, { errors: lV.errors });
+
+    const sb = serviceClient();
+    const existing = await loadTeam(sb, teamId);
+    const spend = squad.reduce((s, p) => s + p.price, 0);
+    const slots: FantasyTeamSlot[] = squad.map((player) => ({
+      player,
+      is_starter: starters.includes(player.id),
+      bench_order: bench.includes(player.id) ? bench.indexOf(player.id) + 1 : undefined,
+      is_captain: player.id === captainId,
+      is_vice_captain: player.id === viceCaptainId,
+    }));
+
+    const team: FantasyTeam = {
+      id: teamId,
+      member_id: existing?.member_id ?? `member_${teamId}`,
+      league_id: existing?.league_id ?? Deno.env.get("FPL_LEAGUE_ID") ?? "main-2025-26",
+      name: existing?.name ?? "My Team",
+      avatar_url: existing?.avatar_url,
+      budget_total: FANTASY_RULES.budget,
+      budget_remaining: Math.round((FANTASY_RULES.budget - spend) * 10) / 10,
+      squad_value: Math.round(spend * 10) / 10,
+      free_transfers: existing?.free_transfers ?? 1,
+      transfer_hits: existing?.transfer_hits ?? 0,
+      active_chip: existing?.active_chip,
+      slots,
+      updated_at: new Date().toISOString(),
+    };
+    await saveTeam(sb, team);
+
+    const data: SaveSquadResponse = { team, validation: { valid: true, errors: [], warnings: [...sV.warnings, ...lV.warnings] } };
+    return ok(data);
+  } catch (err) {
+    return fail("SAVE_FAILED", `Could not save the squad: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/functions/set-captain/index.ts
+++ b/supabase/functions/set-captain/index.ts
@@ -1,0 +1,39 @@
+// ============================================================================
+// Footy Oracle — set-captain
+// Set the captain on a stored squad. Returns ApiResponse<CaptainMutationResponse>.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { serviceClient, loadTeam, saveTeam } from "../_shared/fantasyStore.ts";
+import type { SetCaptainRequest, CaptainMutationResponse } from "../../../src/types/footy.ts";
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { teamId, playerId } = await readBody<SetCaptainRequest>(req);
+    if (!teamId || !playerId) return fail("BAD_REQUEST", "A teamId and playerId are required.");
+
+    const sb = serviceClient();
+    const team = await loadTeam(sb, teamId);
+    if (!team) return fail("STORE_UNAVAILABLE", "No saved squad found for this team.", 404);
+
+    const target = team.slots.find((s) => s.player.id === playerId);
+    if (!target) return fail("PLAYER_NOT_IN_SQUAD", "That player is not in your squad.", 422);
+    if (!target.is_starter) return fail("INVALID_CAPTAIN", "Your captain must be in the starting XI.", 422);
+
+    team.slots = team.slots.map((s) => ({
+      ...s,
+      is_captain: s.player.id === playerId,
+      // captain can't also be vice
+      is_vice_captain: s.player.id === playerId ? false : s.is_vice_captain,
+    }));
+    team.updated_at = new Date().toISOString();
+    await saveTeam(sb, team);
+
+    const data: CaptainMutationResponse = { team, updated_at: team.updated_at };
+    return ok(data);
+  } catch (err) {
+    return fail("CAPTAIN_FAILED", `Could not set the captain: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/functions/set-vice/index.ts
+++ b/supabase/functions/set-vice/index.ts
@@ -1,0 +1,38 @@
+// ============================================================================
+// Footy Oracle — set-vice
+// Set the vice-captain on a stored squad. Returns ApiResponse<CaptainMutationResponse>.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { serviceClient, loadTeam, saveTeam } from "../_shared/fantasyStore.ts";
+import type { SetViceRequest, CaptainMutationResponse } from "../../../src/types/footy.ts";
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { teamId, playerId } = await readBody<SetViceRequest>(req);
+    if (!teamId || !playerId) return fail("BAD_REQUEST", "A teamId and playerId are required.");
+
+    const sb = serviceClient();
+    const team = await loadTeam(sb, teamId);
+    if (!team) return fail("STORE_UNAVAILABLE", "No saved squad found for this team.", 404);
+
+    const target = team.slots.find((s) => s.player.id === playerId);
+    if (!target) return fail("PLAYER_NOT_IN_SQUAD", "That player is not in your squad.", 422);
+    if (!target.is_starter) return fail("INVALID_VICE", "Your vice-captain must be in the starting XI.", 422);
+
+    team.slots = team.slots.map((s) => ({
+      ...s,
+      is_vice_captain: s.player.id === playerId,
+      is_captain: s.player.id === playerId ? false : s.is_captain,
+    }));
+    team.updated_at = new Date().toISOString();
+    await saveTeam(sb, team);
+
+    const data: CaptainMutationResponse = { team, updated_at: team.updated_at };
+    return ok(data);
+  } catch (err) {
+    return fail("VICE_FAILED", `Could not set the vice-captain: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/functions/submit-transfers/index.ts
+++ b/supabase/functions/submit-transfers/index.ts
@@ -1,0 +1,78 @@
+// ============================================================================
+// Footy Oracle — submit-transfers
+// Swap players out/in with free-transfer + points-hit accounting and a deadline
+// gate. Returns ApiResponse<SubmitTransfersResponse>. Errors: DEADLINE_PASSED,
+// PLAYER_UNAVAILABLE, BUDGET_EXCEEDED, MAX_CLUB_PLAYERS_EXCEEDED,
+// INVALID_POSITION_BALANCE.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+import { fplGet, mapPlayer, resolveGameweek, FANTASY_RULES, type FplBootstrap } from "../_shared/fpl.ts";
+import { validateSquad } from "../_shared/fantasyRules.ts";
+import { serviceClient, loadTeam, saveTeam } from "../_shared/fantasyStore.ts";
+import type { SubmitTransfersRequest, SubmitTransfersResponse, FantasyTeamSlot } from "../../../src/types/footy.ts";
+
+const HIT = 4;
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { teamId, gameweek, outPlayerIds, inPlayerIds } = await readBody<SubmitTransfersRequest>(req);
+    if (!teamId || !Array.isArray(outPlayerIds) || !Array.isArray(inPlayerIds)) return fail("BAD_REQUEST", "teamId, outPlayerIds and inPlayerIds are required.");
+    if (outPlayerIds.length !== inPlayerIds.length) return fail("BAD_REQUEST", "You must bring in as many players as you ship out.");
+
+    const boot = await fplGet<FplBootstrap>("/bootstrap-static/");
+    const event = resolveGameweek(boot.events, gameweek);
+    if (Date.now() > new Date(event.deadline_time).getTime()) return fail("DEADLINE_PASSED", "The gameweek deadline has passed. Doors are shut till next week.", 422);
+
+    const sb = serviceClient();
+    const team = await loadTeam(sb, teamId);
+    if (!team) return fail("STORE_UNAVAILABLE", "No saved squad found for this team.", 404);
+
+    // ensure all outgoing are in the squad
+    if (!outPlayerIds.every((id) => team.slots.some((s) => s.player.id === id))) return fail("PLAYER_NOT_IN_SQUAD", "You can only transfer out players in your squad.", 422);
+
+    // map incoming from FPL
+    const byId = new Map(boot.elements.map((e) => [String(e.id), e]));
+    const incoming = inPlayerIds.map((id) => { const el = byId.get(id); return el ? mapPlayer(el, boot.teams, boot.element_types) : null; });
+    if (incoming.some((p) => !p)) return fail("PLAYER_UNAVAILABLE", "One or more incoming players could not be found.", 422);
+    const inPlayers = incoming as NonNullable<(typeof incoming)[number]>[];
+    const unavailable = inPlayers.find((p) => p.status === "injured" || p.status === "suspended" || p.status === "unavailable");
+    if (unavailable) return fail("PLAYER_UNAVAILABLE", `${unavailable.name} is ${unavailable.status} and can't be brought in.`, 422);
+
+    // build the post-transfer squad (like-for-like by index preserves lineup role)
+    const newSlots: FantasyTeamSlot[] = team.slots.map((s) => {
+      const idx = outPlayerIds.indexOf(s.player.id);
+      if (idx === -1) return s;
+      return { ...s, player: inPlayers[idx] };
+    });
+
+    const squad = newSlots.map((s) => s.player);
+    const v = validateSquad(squad);
+    if (!v.valid) return fail(v.code ?? "INVALID_SQUAD", v.errors[0], 422, { errors: v.errors });
+
+    const spend = squad.reduce((sum, p) => sum + p.price, 0);
+    if (spend > FANTASY_RULES.budget + 1e-9) return fail("BUDGET_EXCEEDED", `That leaves you £${(spend - FANTASY_RULES.budget).toFixed(1)}m over budget.`, 422);
+
+    const count = outPlayerIds.length;
+    const freeUsed = Math.min(count, team.free_transfers);
+    const hitPoints = Math.max(0, count - team.free_transfers) * HIT;
+
+    team.slots = newSlots;
+    team.squad_value = Math.round(spend * 10) / 10;
+    team.budget_remaining = Math.round((FANTASY_RULES.budget - spend) * 10) / 10;
+    team.free_transfers = Math.max(0, team.free_transfers - freeUsed);
+    team.transfer_hits = (team.transfer_hits ?? 0) + hitPoints;
+    team.updated_at = new Date().toISOString();
+    await saveTeam(sb, team);
+
+    const data: SubmitTransfersResponse = {
+      team, free_transfers_used: freeUsed, hit_points: hitPoints, applies_to_gameweek: event.id,
+      validation: { valid: true, errors: [], warnings: v.warnings },
+    };
+    return ok(data);
+  } catch (err) {
+    return fail("TRANSFERS_FAILED", `Could not submit transfers: ${(err as Error).message}`, 500);
+  }
+});


### PR DESCRIPTION
## What

Completes the Fantasy work order: the **five mutation edge functions** and the **realtime data layer**. No contract changes — all shapes from `src/types/footy.ts`.

### Mutations (Deno; user squads live in our DB — FPL is read-only)
- `_shared/fantasyRules.ts` — pure validation engine: £100m, 15 players (2·5·5·3), max 3 per club, legal starting XI, 4-man bench (1 GK), captain/vice, with typed error codes (`BUDGET_EXCEEDED`, `MAX_CLUB_PLAYERS_EXCEEDED`, `INVALID_POSITION_BALANCE`, `INVALID_FORMATION`, …).
- `_shared/fantasyStore.ts` — load/save the `FantasyTeam` from a `fantasy_teams` table (best-effort; clean `STORE_UNAVAILABLE` until the table is provisioned).
- `save-squad` — validate + persist → `{ team, validation }`.
- `set-captain` / `set-vice` — patch the stored lineup (must be a starter; C ≠ V).
- `submit-transfers` — free-transfer + −4 hit accounting, deadline gate, budget/position/club re-validation → `hit_points`, `applies_to_gameweek`.
- `play-chip` — records the reserved v1 chip (wildcard / bench_boost / triple_captain / free_hit); scoring effects deferred.

### Frontend data layer (`src/hooks/useFantasyLeague.ts`)
- Mutation hooks: `useSaveSquad` / `useSubmitTransfers` / `useSetCaptain` / `useSetVice` / `usePlayChip` — invoke, unwrap the envelope, throw the typed error, invalidate queries.
- Realtime: `useFantasyRealtimeScores('fantasy-scores')` and `useFantasyRealtimeStandings('standings')` with the typed payloads; the standings channel is wired into the live leaderboard so ranks re-order on updates.

### Notes
- Mutations persist to a `fantasy_teams` table (id, member_id, league_id, `data jsonb`, updated_at) — the shape is documented in `fantasyStore.ts`. Until Lovable provisions it, mutations return a clean `STORE_UNAVAILABLE`; `save-squad` still validates and computes the team.
- Edge functions go live on the next Lovable sync. Verified: frontend type-checks clean, page renders with zero runtime errors, standings realtime subscription is a no-op until broadcasting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_