### PR TITLE
Fantasy prizes: non-cash, admin-driven, flexible categories + triggers

### DIFF
--- a/docs/DATA_CONTRACTS.md
+++ b/docs/DATA_CONTRACTS.md
@@ -303,6 +303,29 @@ Sample response:
 
 Purpose: fantasy prize page / hub prize tiles.
 
+**Prizes are admin-driven and NON-CASH only.** The UI never hard-codes a reward or a
+fixed value — it renders exactly what this endpoint returns. Use the language of
+prizes, rewards, vouchers, trips, experiences and specials; never cash, payout,
+winnings or money.
+
+Each prize carries an optional `trigger` (how it's won) and `tone`
+(`serious` leaderboard reward vs `fun` engagement reward), so the model supports
+both serious rewards and funny rewards for managers who aren't doing well:
+
+- `gameweek_top` — highest scorer of the week
+- `monthly_top` — monthly winner
+- `season_top` — season winner
+- `rank_climber` — biggest rank climber
+- `best_bench` — best bench points
+- `worst_captain` — worst captain pick (fun)
+- `wooden_spoon` — Donkey of the Week (fun)
+- `themed` — holiday / calendar special
+- `manual` — admin-defined, any criteria
+
+`category` (`weekly | monthly | seasonal | themed | random`) groups prizes for
+display; `reward_type` (`voucher | trip | experience | merch | special | other`)
+is the non-cash reward kind.
+
 Request:
 
 ```json
@@ -327,23 +350,39 @@ Sample response:
     "updated_at": "2025-08-01T09:00:00Z",
     "prizes": [
       {
-        "id": "prize_dream_holiday",
+        "id": "prize_season_trip",
         "season": "2025/26",
-        "title": "Dream Holiday",
-        "description": "Season headline prize for the overall Fantasy League Champion.",
-        "image_url": "/assets/homepage/prize-dream-holiday.png",
+        "title": "Tropical Escape",
+        "description": "The season champion's grand reward — a dream footy getaway.",
+        "image_url": "/images/fantasy/prizes/prize-tropical.jpg",
         "category": "seasonal",
+        "trigger": "season_top",
+        "tone": "serious",
+        "reward_type": "trip",
         "enabled": true
       },
       {
-        "id": "prize_christmas_hamper",
+        "id": "prize_gw_experience",
         "season": "2025/26",
-        "title": "£1,000 Christmas Hamper Giveaway",
-        "description": "A themed festive prize event during the Christmas football rush.",
-        "image_url": "/assets/homepage/prize-christmas-hamper.png",
-        "category": "themed",
-        "starts_at": "2025-11-20T00:00:00Z",
-        "ends_at": "2025-12-20T23:59:59Z",
+        "title": "Matchday Experience",
+        "description": "Highest scorer of the gameweek bags an exclusive day out.",
+        "image_url": "/images/fantasy/prizes/prize-experiences.jpg",
+        "category": "weekly",
+        "trigger": "gameweek_top",
+        "tone": "serious",
+        "reward_type": "experience",
+        "enabled": true
+      },
+      {
+        "id": "prize_donkey",
+        "season": "2025/26",
+        "title": "Donkey of the Week",
+        "description": "Finish bottom and claim the ears — a badge of dishonour and a little something.",
+        "image_url": "/images/fantasy/prizes/prize-donkey.jpg",
+        "category": "random",
+        "trigger": "wooden_spoon",
+        "tone": "fun",
+        "reward_type": "merch",
         "enabled": true
       }
     ]

--- a/src/components/fantasy/FantasyPageHero.tsx
+++ b/src/components/fantasy/FantasyPageHero.tsx
@@ -53,7 +53,7 @@ export function FantasyPageHero() {
 
           <p className="mt-4 max-w-md text-sm leading-relaxed text-white/70 md:text-base">
             Build your dream squad on a <span className="font-bold text-[#f8e7a1]">£{FANTASY_RULES.budget}m</span> budget —
-            {' '}<span className="font-bold text-white">{FANTASY_RULES.squadSize} players</span>, climb the leaderboard and chase real cash. Outscore The Gaffer and the bragging rights are yours.
+            {' '}<span className="font-bold text-white">{FANTASY_RULES.squadSize} players</span>, climb the leaderboard and chase real rewards. Outscore The Gaffer and the bragging rights are yours.
           </p>
 
           <div className="mt-6 inline-flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0b0518]/70 p-4 backdrop-blur sm:flex-row sm:items-center sm:gap-5">

--- a/src/components/fantasy/FantasyPrizes.tsx
+++ b/src/components/fantasy/FantasyPrizes.tsx
@@ -1,22 +1,36 @@
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Gift, Plane, ChevronRight, Sparkles } from 'lucide-react';
+import { Gift, Plane, Ticket, Sparkles, ChevronRight, PartyPopper } from 'lucide-react';
 import { useFantasyPrizes } from '@/hooks/useFantasyLeague';
-import type { FantasyPrize } from '@/types/footy';
+import type { FantasyPrize, FantasyPrizeCategory, FantasyPrizeTrigger, FantasyRewardType } from '@/types/footy';
 
 const GAFFER = '/images/gaffer/gaffer-celebrating.png';
 
-const CATEGORY_LABEL: Record<FantasyPrize['category'], string> = {
-  seasonal: 'Season', weekly: 'Weekly', themed: 'Special', random: 'Wooden Spoon',
+const CAT_LABEL: Record<FantasyPrizeCategory, string> = {
+  weekly: 'Weekly', monthly: 'Monthly', seasonal: 'Season', themed: 'Specials', random: 'Fun',
 };
+const TRIGGER_LABEL: Partial<Record<FantasyPrizeTrigger, string>> = {
+  season_top: 'Season winner', monthly_top: 'Monthly winner', gameweek_top: 'Weekly top scorer',
+  rank_climber: 'Biggest climber', best_bench: 'Best bench', worst_captain: 'Worst captain', wooden_spoon: 'Donkey of the week', themed: 'Special',
+};
+const REWARD_ICON = (t?: FantasyRewardType) => (t === 'trip' ? Plane : t === 'experience' ? Ticket : t === 'voucher' ? Gift : PartyPopper);
+const tagOf = (p: FantasyPrize) => (p.trigger && TRIGGER_LABEL[p.trigger]) || CAT_LABEL[p.category];
 
 function PrizeTile({ p }: { p: FantasyPrize }) {
-  const fun = p.category === 'random';
+  const fun = p.tone === 'fun';
+  const Icon = REWARD_ICON(p.reward_type);
   return (
     <div className={`group relative overflow-hidden rounded-2xl border bg-[#0b0518]/70 transition-all hover:-translate-y-1 ${fun ? 'border-amber-400/30 hover:border-amber-400/60 hover:shadow-[0_0_34px_-10px_rgba(245,197,66,0.7)]' : 'border-violet-400/25 hover:border-violet-400/55 hover:shadow-[0_0_34px_-10px_rgba(139,92,246,0.7)]'}`}>
       <div className="relative h-28 overflow-hidden bg-[#160a24]">
-        {p.image_url && <img src={p.image_url} alt={p.title} loading="lazy" draggable={false} className={`h-full w-full object-cover transition-transform duration-500 group-hover:scale-105 ${fun ? 'group-hover:-rotate-1' : ''}`} />}
+        {p.image_url ? (
+          <img src={p.image_url} alt={p.title} loading="lazy" draggable={false} className={`h-full w-full object-cover transition-transform duration-500 group-hover:scale-105 ${fun ? 'group-hover:-rotate-1' : ''}`} />
+        ) : (
+          <div className={`grid h-full w-full place-items-center ${fun ? 'bg-[radial-gradient(circle_at_50%_30%,rgba(245,197,66,0.18),transparent_70%)]' : 'bg-[radial-gradient(circle_at_50%_30%,rgba(139,92,246,0.22),transparent_70%)]'}`}>
+            <Icon className={`h-9 w-9 ${fun ? 'text-[#f5c542]' : 'text-violet-300'}`} />
+          </div>
+        )}
         <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-[#0b0518] via-transparent to-transparent" />
-        <span className="absolute right-2 top-2 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-white/80 backdrop-blur">{CATEGORY_LABEL[p.category]}</span>
+        <span className="absolute right-2 top-2 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-white/80 backdrop-blur">{tagOf(p)}</span>
       </div>
       <div className="p-3.5">
         <div className="text-[13px] font-black uppercase tracking-wide text-white">{p.title}</div>
@@ -27,17 +41,22 @@ function PrizeTile({ p }: { p: FantasyPrize }) {
 }
 
 /**
- * FantasyPrizes — "Prizes & Glory" from the prizes contract. The seasonal
- * headline gets the hero; the rest tile out. Photos are decorative; titles and
- * descriptions are live HTML.
+ * FantasyPrizes — "Prizes & Glory". Fully admin-driven and NON-CASH: renders
+ * exactly what get-fantasy-prizes returns. Category tabs filter the tiles; the
+ * season reward gets the hero. Serious leaderboard rewards and funny engagement
+ * rewards live side by side.
  */
 export function FantasyPrizes() {
   const { data, isLoading } = useFantasyPrizes();
-  if (isLoading && !data) return <div className="h-[460px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
+  const [tab, setTab] = useState<'all' | FantasyPrizeCategory>('all');
 
-  const prizes = data?.prizes ?? [];
-  const grand = prizes.find((p) => p.category === 'seasonal') ?? prizes[0];
-  const tiles = prizes.filter((p) => p.id !== grand?.id).slice(0, 4);
+  const prizes = useMemo(() => (data?.prizes ?? []).filter((p) => p.enabled), [data]);
+  const grand = prizes.find((p) => p.trigger === 'season_top') ?? prizes.find((p) => p.category === 'seasonal');
+  const rest = prizes.filter((p) => p.id !== grand?.id);
+  const cats = useMemo(() => Array.from(new Set(rest.map((p) => p.category))), [rest]);
+  const tiles = tab === 'all' ? rest : rest.filter((p) => p.category === tab);
+
+  if (isLoading && !data) return <div className="h-[460px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
   return (
     <section id="prizes" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(124,58,237,0.7)] md:rounded-[2rem]">
@@ -47,25 +66,36 @@ export function FantasyPrizes() {
 
       <div className="relative z-[1] p-5 md:p-7">
         <div className="max-w-xl">
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]"><Sparkles className="h-3.5 w-3.5" /> Prizes &amp; Glory</span>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]"><Sparkles className="h-3.5 w-3.5" /> Prizes &amp; Rewards</span>
           <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl"><span className="text-[#f5c542]">Win big.</span> Laugh harder.</h2>
-          <p className="mt-2 text-sm text-white/60">Real cash, real getaways, and the odd pair of donkey ears.</p>
+          <p className="mt-2 text-sm text-white/60">Trips, experiences, vouchers and specials — for the table-toppers and the strugglers alike.</p>
         </div>
 
-        <div className="mt-6 grid gap-4 lg:grid-cols-[1.15fr_1fr]">
-          {grand && (
+        {/* category tabs */}
+        {cats.length > 1 && (
+          <div className="mt-5 flex flex-wrap gap-1.5">
+            {(['all', ...cats] as const).map((c) => (
+              <button key={c} type="button" onClick={() => setTab(c)} className={`rounded-lg px-3 py-1.5 text-[11px] font-black uppercase tracking-wide transition-colors ${tab === c ? 'bg-white text-[#16051f]' : 'border border-white/12 bg-white/[0.04] text-white/65 hover:border-white/25'}`}>
+                {c === 'all' ? 'All' : CAT_LABEL[c]}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-5 grid gap-4 lg:grid-cols-[1.15fr_1fr]">
+          {grand && (tab === 'all' || tab === grand.category) ? (
             <div className="group relative overflow-hidden rounded-2xl border border-[#f5c542]/35 bg-[#160a24] shadow-[0_0_44px_-16px_rgba(245,197,66,0.8)]">
               {grand.image_url && <img src={grand.image_url} alt={grand.title} loading="lazy" draggable={false} className="h-full min-h-[240px] w-full object-cover transition-transform duration-700 group-hover:scale-105" />}
               <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-[#05020b] via-[#05020b]/40 to-transparent" />
-              <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-black/50 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-[#f8e7a1] backdrop-blur"><Plane className="h-3.5 w-3.5" /> Grand Prize</span>
+              <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-black/50 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-[#f8e7a1] backdrop-blur"><Plane className="h-3.5 w-3.5" /> {grand.trigger ? TRIGGER_LABEL[grand.trigger] : 'Season'}</span>
               <div className="absolute inset-x-0 bottom-0 p-5">
                 <div className="font-display text-4xl uppercase leading-none text-white md:text-5xl">{grand.title}</div>
                 <p className="mt-1.5 max-w-sm text-sm text-white/70">{grand.description}</p>
               </div>
             </div>
-          )}
-          <div className="grid grid-cols-2 gap-4">
-            {tiles.map((p) => <PrizeTile key={p.id} p={p} />)}
+          ) : <div className="hidden lg:block" />}
+          <div className="grid grid-cols-2 gap-4 self-start">
+            {tiles.slice(0, 6).map((p) => <PrizeTile key={p.id} p={p} />)}
           </div>
         </div>
 
@@ -73,7 +103,7 @@ export function FantasyPrizes() {
           <div className="flex items-center gap-3">
             <span className="grid h-11 w-11 place-items-center rounded-xl border border-[#f5c542]/30 bg-[#f5c542]/10 text-[#f5c542]"><Gift className="h-5 w-5" /></span>
             <div className="leading-tight">
-              <div className="text-[13px] font-black uppercase tracking-wide text-white">All prizes included with membership</div>
+              <div className="text-[13px] font-black uppercase tracking-wide text-white">All rewards included with membership</div>
               <div className="text-[12px] text-white/55">One league. Weekly rewards. Season-long glory.</div>
             </div>
           </div>

--- a/src/components/fantasy/LeagueStandings.tsx
+++ b/src/components/fantasy/LeagueStandings.tsx
@@ -1,17 +1,24 @@
 import { Link } from 'react-router-dom';
-import { Crown, TrendingUp, TrendingDown, Minus, Trophy, ChevronRight, Award } from 'lucide-react';
-import { useFantasyStandings, useFantasyRealtimeStandings } from '@/hooks/useFantasyLeague';
-import type { FantasyStandingRow } from '@/types/footy';
+import { Crown, TrendingUp, TrendingDown, Minus, Trophy, ChevronRight, Award, Gift, Plane, Ticket, Sparkles } from 'lucide-react';
+import { useFantasyStandings, useFantasyRealtimeStandings, useFantasyPrizes } from '@/hooks/useFantasyLeague';
+import type { FantasyStandingRow, FantasyPrize, FantasyPrizeTrigger, FantasyRewardType } from '@/types/footy';
 
 const GAFFER = '/images/gaffer/gaffer-arms-crossed.png';
 
-// Cash rail is product/marketing copy (admin-set), not an FPL field.
-const CHAMPION = '£10,000 Cash';
-const TIERS = [
-  { rank: 1, label: '1st', value: '£10,000' },
-  { rank: 2, label: '2nd', value: '£3,000' },
-  { rank: 3, label: '3rd', value: '£1,000' },
-];
+// How each trigger reads on the leaderboard (admin-driven — never a cash value).
+const TRIGGER_LABEL: Partial<Record<FantasyPrizeTrigger, string>> = {
+  season_top: 'Season winner',
+  monthly_top: 'Monthly winner',
+  gameweek_top: 'Weekly top scorer',
+  rank_climber: 'Biggest climber',
+  best_bench: 'Best bench',
+  worst_captain: 'Worst captain',
+  wooden_spoon: 'Donkey of the week',
+};
+const REWARD_ICON = (t?: FantasyRewardType) =>
+  t === 'trip' ? Plane : t === 'experience' ? Ticket : t === 'voucher' ? Gift : Sparkles;
+// Leaderboard rewards shown on the standings rail, in priority order.
+const RAIL_TRIGGERS: FantasyPrizeTrigger[] = ['season_top', 'monthly_top', 'gameweek_top', 'rank_climber', 'best_bench'];
 
 const isGaffer = (r: FantasyStandingRow) => /gaffer/i.test(r.manager_name) || /gaffer/i.test(r.team_name);
 const isYou = (r: FantasyStandingRow) => /^you$/i.test(r.manager_name);
@@ -27,14 +34,19 @@ const RANK_TONE = (rank: number) => rank === 1 ? 'bg-[#f5c542] text-[#16051f]' :
 /**
  * LeagueStandings — the live "Beat the Gaffer" leaderboard from the standings
  * contract. Rank movement, GW + total points, the Gaffer and your own row
- * highlighted, plus the cash prize rail.
+ * highlighted, plus the admin-driven (non-cash) reward rail.
  */
 export function LeagueStandings() {
   const { data, isLoading } = useFantasyStandings();
+  const { data: prizeData } = useFantasyPrizes();
   useFantasyRealtimeStandings(); // live re-rank on the standings channel
   if (isLoading && !data) return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
 
   const rows = data?.rows ?? [];
+  const prizes = prizeData?.prizes.filter((p) => p.enabled) ?? [];
+  const seasonPrize = prizes.find((p) => p.trigger === 'season_top') ?? prizes.find((p) => p.category === 'seasonal');
+  const railPrizes = RAIL_TRIGGERS.map((t) => prizes.find((p) => p.trigger === t)).filter(Boolean) as FantasyPrize[];
+  const funPrizes = prizes.filter((p) => p.tone === 'fun');
 
   return (
     <section id="standings" className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(245,197,66,0.6)] md:rounded-[2rem]">
@@ -49,13 +61,15 @@ export function LeagueStandings() {
             <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">League <span className="text-[#f5c542]">Standings</span></h2>
             <p className="mt-2 text-sm text-white/55">The table doesn’t lie. Climb it, hold it, or get bragged at.</p>
           </div>
-          <div className="flex items-center gap-3 rounded-2xl border border-[#f5c542]/30 bg-[#f5c542]/10 px-4 py-3">
-            <Trophy className="h-8 w-8 fill-[#f5c542] text-[#f5c542]" />
-            <div className="leading-tight">
-              <div className="text-[10px] font-black uppercase tracking-widest text-[#f8e7a1]">Champion’s Prize</div>
-              <div className="font-display text-2xl text-white">{CHAMPION}</div>
+          {seasonPrize && (
+            <div className="flex items-center gap-3 rounded-2xl border border-[#f5c542]/30 bg-[#f5c542]/10 px-4 py-3">
+              <Trophy className="h-8 w-8 fill-[#f5c542] text-[#f5c542]" />
+              <div className="leading-tight">
+                <div className="text-[10px] font-black uppercase tracking-widest text-[#f8e7a1]">Season Winner’s Reward</div>
+                <div className="font-display text-2xl text-white">{seasonPrize.title}</div>
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_240px]">
@@ -91,16 +105,26 @@ export function LeagueStandings() {
 
           <div className="flex flex-col gap-3">
             <div className="rounded-2xl border border-white/10 bg-[#0b0518]/60 p-4">
-              <div className="text-[10px] font-black uppercase tracking-widest text-white/45">Top 3 Prizes</div>
+              <div className="text-[10px] font-black uppercase tracking-widest text-white/45">Rewards on offer</div>
               <ul className="mt-2 space-y-2">
-                {TIERS.map((t) => (
-                  <li key={t.rank} className="flex items-center gap-3">
-                    <span className={`grid h-8 w-8 place-items-center rounded-lg text-[12px] font-black ${RANK_TONE(t.rank)}`}>{t.rank}</span>
-                    <span className="flex-1 text-[12px] font-bold uppercase tracking-wide text-white/60">{t.label}</span>
-                    <span className="font-display text-lg text-white">{t.value}</span>
-                  </li>
-                ))}
+                {railPrizes.map((p) => {
+                  const Icon = REWARD_ICON(p.reward_type);
+                  return (
+                    <li key={p.id} className="flex items-center gap-2.5">
+                      <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-[#f5c542]/25 bg-[#f5c542]/10 text-[#f5c542]"><Icon className="h-4 w-4" /></span>
+                      <span className="min-w-0 leading-tight">
+                        <span className="block truncate text-[12px] font-bold text-white">{p.title}</span>
+                        <span className="block text-[10px] font-semibold uppercase tracking-wide text-white/40">{p.trigger ? TRIGGER_LABEL[p.trigger] : 'Reward'}</span>
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
+              {funPrizes.length > 0 && (
+                <p className="mt-3 border-t border-white/10 pt-2.5 text-[11px] leading-snug text-white/45">
+                  Having a nightmare? There’s something in it even for the strugglers — {funPrizes.map((p) => p.title).join(' & ')}.
+                </p>
+              )}
             </div>
             <Link to="/pricing" className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-5 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Join &amp; Climb <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" /></Link>
           </div>

--- a/src/hooks/useFantasyLeague.ts
+++ b/src/hooks/useFantasyLeague.ts
@@ -184,15 +184,23 @@ export const FANTASY_STANDINGS: FantasyStandingsResponse = {
   ],
 };
 
+// Prizes are admin-driven and NON-CASH only. This is illustrative fallback
+// config (matches the contract) until the fantasy_prizes table is populated —
+// never hard-code cash or fixed reward logic in the UI.
 export const FANTASY_PRIZES: FantasyPrizesResponse = {
   season: '2025/26', updated_at: new Date().toISOString(),
   prizes: [
-    { id: 'prize_tropical_holiday', season: '2025/26', title: 'Tropical Escape', description: 'The season headline — a dream holiday for the overall Fantasy League champion.', category: 'seasonal', image_url: '/images/fantasy/prizes/prize-tropical.jpg', enabled: true },
-    { id: 'prize_weekly_cash', season: '2025/26', title: 'Weekly Cash Prize', description: 'Top the gameweek and take home cold, hard cash. Every single week.', category: 'weekly', image_url: '/images/fantasy/prizes/prize-voucher.jpg', enabled: true },
-    { id: 'prize_luxury_weekend', season: '2025/26', title: 'Luxury Weekend Away', description: 'A monthly escape in style, on the club.', category: 'themed', image_url: '/images/fantasy/prizes/prize-villa.jpg', enabled: true },
-    { id: 'prize_football_experiences', season: '2025/26', title: 'Football Experiences', description: "Matchday tickets and money-can't-buy days out.", category: 'themed', image_url: '/images/fantasy/prizes/prize-experiences.jpg', enabled: true },
-    { id: 'prize_xmas_hamper', season: '2025/26', title: '£1,000 Christmas Hamper', description: 'A themed festive giveaway during the Christmas fixture rush.', category: 'themed', starts_at: '2025-11-20T00:00:00Z', ends_at: '2025-12-26T23:59:59Z', enabled: true },
-    { id: 'prize_donkey', season: '2025/26', title: 'Donkey of the Week', description: 'Finish bottom and wear the ears with pride. Fame — of a sort.', category: 'random', image_url: '/images/fantasy/prizes/prize-donkey.jpg', enabled: true },
+    // serious leaderboard rewards
+    { id: 'prize_season_trip', season: '2025/26', title: 'Tropical Escape', description: "The season champion's grand reward — a dream footy getaway.", category: 'seasonal', trigger: 'season_top', tone: 'serious', reward_type: 'trip', image_url: '/images/fantasy/prizes/prize-tropical.jpg', enabled: true },
+    { id: 'prize_monthly_trip', season: '2025/26', title: 'Luxury Weekend Away', description: 'Top the monthly standings for an escape in style.', category: 'monthly', trigger: 'monthly_top', tone: 'serious', reward_type: 'trip', image_url: '/images/fantasy/prizes/prize-villa.jpg', enabled: true },
+    { id: 'prize_gw_experience', season: '2025/26', title: 'Matchday Experience', description: "Highest scorer of the gameweek bags an exclusive day out.", category: 'weekly', trigger: 'gameweek_top', tone: 'serious', reward_type: 'experience', image_url: '/images/fantasy/prizes/prize-experiences.jpg', enabled: true },
+    { id: 'prize_climber_voucher', season: '2025/26', title: "Climber's Reward", description: 'The biggest rank climber of the week earns a Footy Oracle voucher.', category: 'weekly', trigger: 'rank_climber', tone: 'serious', reward_type: 'voucher', image_url: '/images/fantasy/prizes/prize-voucher.jpg', enabled: true },
+    { id: 'prize_best_bench', season: '2025/26', title: 'Super Sub Special', description: 'Best bench points of the week — reward for the ones you left out.', category: 'weekly', trigger: 'best_bench', tone: 'serious', reward_type: 'merch', enabled: true },
+    // funny engagement rewards (for managers having a nightmare)
+    { id: 'prize_worst_captain', season: '2025/26', title: 'Captain Calamity', description: "Pick the week's worst captain and claim a consolation special. Ouch.", category: 'random', trigger: 'worst_captain', tone: 'fun', reward_type: 'special', enabled: true },
+    { id: 'prize_donkey', season: '2025/26', title: 'Donkey of the Week', description: 'Finish bottom and claim the ears — a badge of dishonour and a little something.', category: 'random', trigger: 'wooden_spoon', tone: 'fun', reward_type: 'merch', image_url: '/images/fantasy/prizes/prize-donkey.jpg', enabled: true },
+    // themed calendar special
+    { id: 'prize_festive_hamper', season: '2025/26', title: 'Festive Hamper Special', description: 'A themed hamper giveaway during the Christmas fixture rush.', category: 'themed', trigger: 'themed', tone: 'serious', reward_type: 'special', starts_at: '2025-11-20T00:00:00Z', ends_at: '2025-12-26T23:59:59Z', enabled: true },
   ],
 };
 

--- a/src/types/footy.ts
+++ b/src/types/footy.ts
@@ -134,13 +134,43 @@ export interface FantasyGameweekResponse {
   updated_at: ISODateTime;
 }
 
+/**
+ * Prizes are admin-driven and NON-CASH only. Never hard-code a reward in the UI
+ * — render exactly what get-fantasy-prizes returns.
+ *
+ * `category` groups prizes for display; `trigger` describes how a prize is won
+ * (serious leaderboard rewards and funny engagement rewards alike); `tone`
+ * separates the two for styling; `reward_type` is the kind of non-cash reward.
+ */
+export type FantasyPrizeCategory = 'weekly' | 'monthly' | 'seasonal' | 'themed' | 'random';
+
+export type FantasyPrizeTrigger =
+  | 'gameweek_top'    // highest scorer of the week
+  | 'monthly_top'     // monthly winner
+  | 'season_top'      // season winner
+  | 'rank_climber'    // biggest rank climber
+  | 'best_bench'      // best bench points
+  | 'worst_captain'   // worst captain pick (fun)
+  | 'wooden_spoon'    // Donkey of the Week (fun)
+  | 'themed'          // holiday / calendar special
+  | 'manual';         // admin-defined, any criteria
+
+/** Non-cash reward kinds only — never money. */
+export type FantasyRewardType = 'voucher' | 'trip' | 'experience' | 'merch' | 'special' | 'other';
+
 export interface FantasyPrize {
   id: string;
   season: string;
   title: string;
   description: string;
   image_url?: string;
-  category: 'weekly' | 'random' | 'themed' | 'seasonal';
+  category: FantasyPrizeCategory;
+  /** How the prize is won. Omit for purely decorative/manual specials. */
+  trigger?: FantasyPrizeTrigger;
+  /** Serious leaderboard reward vs funny engagement reward. */
+  tone?: 'serious' | 'fun';
+  /** Non-cash reward kind. */
+  reward_type?: FantasyRewardType;
   starts_at?: ISODateTime;
   ends_at?: ISODateTime;
   enabled: boolean;

--- a/supabase/functions/get-fantasy-prizes/index.ts
+++ b/supabase/functions/get-fantasy-prizes/index.ts
@@ -3,10 +3,9 @@
 // Admin-set prize config (NOT from FPL). Reads the `fantasy_prizes` table if it
 // exists, otherwise returns a typed fallback. Returns FantasyPrizesResponse.
 //
-// NOTE (contract): FantasyPrize.category is 'weekly' | 'random' | 'themed' |
-// 'seasonal'. The locked prize list also mentions a "monthly" cadence, which the
-// union cannot express. Flagged to add `'monthly'` to the union before use — see
-// the summary. Until then monthly prizes are modelled as 'themed'.
+// Prizes are admin-driven and NON-CASH only. This fallback is illustrative
+// sample config used until the `fantasy_prizes` table is populated; the real
+// prizes come from Supabase. Never hard-code cash or fixed reward logic.
 // ============================================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
@@ -17,13 +16,19 @@ function fallbackPrizes(season: string): FantasyPrize[] {
   const p = (o: Partial<FantasyPrize> & Pick<FantasyPrize, "id" | "title" | "description" | "category">): FantasyPrize => ({
     season, enabled: true, ...o,
   });
+  const yr = season.slice(0, 4);
   return [
-    p({ id: "prize_tropical_holiday", title: "Tropical Escape", description: "The season headline — a dream holiday for the overall Fantasy League champion.", category: "seasonal", image_url: "/images/fantasy/prizes/prize-tropical.jpg" }),
-    p({ id: "prize_weekly_cash", title: "Weekly Cash Prize", description: "Top the gameweek and take home cold, hard cash. Every single week.", category: "weekly", image_url: "/images/fantasy/prizes/prize-voucher.jpg" }),
-    p({ id: "prize_luxury_weekend", title: "Luxury Weekend Away", description: "A monthly escape in style, on the club.", category: "themed", image_url: "/images/fantasy/prizes/prize-villa.jpg" }),
-    p({ id: "prize_football_experiences", title: "Football Experiences", description: "Matchday tickets and money-can't-buy days out.", category: "themed", image_url: "/images/fantasy/prizes/prize-experiences.jpg" }),
-    p({ id: "prize_xmas_hamper", title: "£1,000 Christmas Hamper", description: "A themed festive giveaway during the Christmas fixture rush.", category: "themed", starts_at: `${season.slice(0, 4)}-11-20T00:00:00Z`, ends_at: `${season.slice(0, 4)}-12-26T23:59:59Z` }),
-    p({ id: "prize_donkey", title: "Donkey of the Week", description: "Finish bottom and wear the ears with pride. Fame — of a sort.", category: "random", image_url: "/images/fantasy/prizes/prize-donkey.jpg" }),
+    // ── serious leaderboard rewards ──
+    p({ id: "prize_season_trip", title: "Tropical Escape", description: "The season champion's grand reward — a dream footy getaway.", category: "seasonal", trigger: "season_top", tone: "serious", reward_type: "trip", image_url: "/images/fantasy/prizes/prize-tropical.jpg" }),
+    p({ id: "prize_monthly_trip", title: "Luxury Weekend Away", description: "Top the monthly standings for an escape in style.", category: "monthly", trigger: "monthly_top", tone: "serious", reward_type: "trip", image_url: "/images/fantasy/prizes/prize-villa.jpg" }),
+    p({ id: "prize_gw_experience", title: "Matchday Experience", description: "Highest scorer of the gameweek bags an exclusive day out.", category: "weekly", trigger: "gameweek_top", tone: "serious", reward_type: "experience", image_url: "/images/fantasy/prizes/prize-experiences.jpg" }),
+    p({ id: "prize_climber_voucher", title: "Climber's Reward", description: "The biggest rank climber of the week earns a Footy Oracle voucher.", category: "weekly", trigger: "rank_climber", tone: "serious", reward_type: "voucher", image_url: "/images/fantasy/prizes/prize-voucher.jpg" }),
+    p({ id: "prize_best_bench", title: "Super Sub Special", description: "Best bench points of the week — reward for the ones you left out.", category: "weekly", trigger: "best_bench", tone: "serious", reward_type: "merch" }),
+    // ── funny engagement rewards (for managers having a nightmare) ──
+    p({ id: "prize_worst_captain", title: "Captain Calamity", description: "Pick the week's worst captain and claim a consolation special. Ouch.", category: "random", trigger: "worst_captain", tone: "fun", reward_type: "special" }),
+    p({ id: "prize_donkey", title: "Donkey of the Week", description: "Finish bottom and claim the ears — a badge of dishonour and a little something.", category: "random", trigger: "wooden_spoon", tone: "fun", reward_type: "merch", image_url: "/images/fantasy/prizes/prize-donkey.jpg" }),
+    // ── themed calendar special ──
+    p({ id: "prize_festive_hamper", title: "Festive Hamper Special", description: "A themed hamper giveaway during the Christmas fixture rush.", category: "themed", trigger: "themed", tone: "serious", reward_type: "special", starts_at: `${yr}-11-20T00:00:00Z`, ends_at: `${yr}-12-26T23:59:59Z` }),
   ];
 }
 
@@ -39,7 +44,7 @@ serve(async (req) => {
       const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
       const { data, error } = await supabase
         .from("fantasy_prizes")
-        .select("id, season, title, description, image_url, category, starts_at, ends_at, enabled")
+        .select("id, season, title, description, image_url, category, trigger, tone, reward_type, starts_at, ends_at, enabled")
         .eq("season", seasonKey)
         .eq("enabled", true);
       if (!error && data && data.length) prizes = data as FantasyPrize[];


### PR DESCRIPTION
## What

Reworks the fantasy prize model so it **never hard-codes cash or fixed prize logic**. Prizes are fully admin-driven through `get-fantasy-prizes` / Supabase config, **non-cash only**, and the UI renders exactly what the API returns.

### Prize model (additive contract change — non-breaking, product-authorised)
`FantasyPrize` in `src/types/footy.ts` gains:
- `'monthly'` added to `category` (`weekly | monthly | seasonal | themed | random`)
- optional `trigger` — how a prize is won: `gameweek_top`, `monthly_top`, `season_top`, `rank_climber`, `best_bench`, `worst_captain`, `wooden_spoon`, `themed`, `manual`
- optional `tone` — `'serious'` (leaderboard reward) vs `'fun'` (engagement reward for managers doing badly)
- optional `reward_type` — non-cash kinds: `voucher | trip | experience | merch | special | other`

`docs/DATA_CONTRACTS.md` updated with the non-cash rule, the trigger list, and a non-cash sample.

### UI
- **LeagueStandings** — removed the hard-coded £10k/£3k/£1k cash rail. The season reward and the "Rewards on offer" list are derived from `get-fantasy-prizes` by trigger, plus a line that surfaces the **fun rewards for strugglers** (Captain Calamity & Donkey of the Week).
- **FantasyPrizes** — category tabs (All/Monthly/Weekly/Fun/Specials), trigger-tagged tiles, tone-aware styling, an icon fallback for image-less rewards, and non-cash copy ("Trips, experiences, vouchers and specials — for the table-toppers and the strugglers alike").
- **Hero** — "chase real rewards" (was "cash").
- Fallback prize config (edge function + hook) rewritten to non-cash examples spanning every trigger. Nothing hard-codes a reward unless the API returns it.

### Verified
Type-checks clean; page renders; automated check confirms **zero** cash/payout/winnings/£-value language on the page. `£100m` remains only as the squad **budget** (the game), not a reward.

Language throughout: prizes, rewards, vouchers, trips, experiences, specials — never cash, payout, winnings or money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_