### PR TITLE
Fantasy: My Team, Transfers, Gameweek Results pages + mobile hero fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ const MembersDashboard = lazy(() => import("./pages/MembersDashboard"));
 const ComingSoon = lazy(() => import("./pages/ComingSoon"));
 const FormTables = lazy(() => import("./pages/FormTables"));
 const FantasyLeague = lazy(() => import("./pages/FantasyLeague"));
+const FantasyMyTeam = lazy(() => import("./pages/FantasyMyTeam"));
+const FantasyTransfers = lazy(() => import("./pages/FantasyTransfers"));
+const FantasyResults = lazy(() => import("./pages/FantasyResults"));
 const Pnl = lazy(() => import("./pages/Pnl"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -60,6 +63,9 @@ const App = () => {
 
                 {/* Placeholder shells — to be rebuilt from scratch */}
                 <Route path="/fantasy-league" element={<FantasyLeague />} />
+                <Route path="/fantasy-league/my-team" element={<FantasyMyTeam />} />
+                <Route path="/fantasy-league/transfers" element={<FantasyTransfers />} />
+                <Route path="/fantasy-league/results" element={<FantasyResults />} />
                 <Route path="/form-tables" element={<FormTables />} />
                 <Route path="/fixtures" element={<ComingSoon title="Today's Fixtures" eyebrow="In Build" />} />
                 <Route path="/tips" element={<ComingSoon title="Daily Tips" eyebrow="In Build" />} />

--- a/src/components/fantasy/FantasyPageHero.tsx
+++ b/src/components/fantasy/FantasyPageHero.tsx
@@ -87,7 +87,8 @@ export function FantasyPageHero() {
               ))}
             </div>
 
-            <div className="absolute -right-1 top-2 z-20 w-[220px] rounded-2xl border border-[#f5c542]/25 bg-[#0b0518]/90 p-3 shadow-[0_20px_50px_-18px_rgba(0,0,0,0.9)] backdrop-blur-md sm:right-0 md:w-[240px]">
+            {/* leaderboard — stacks below the Gaffer on mobile (off his face), floats top-right on desktop */}
+            <div className="relative z-20 mx-auto mt-8 w-full max-w-[300px] rounded-2xl border border-[#f5c542]/25 bg-[#0b0518]/90 p-3 shadow-[0_20px_50px_-18px_rgba(0,0,0,0.9)] backdrop-blur-md lg:absolute lg:-right-1 lg:top-2 lg:mt-0 lg:w-[240px] lg:max-w-none">
               <div className="flex items-center gap-1.5 border-b border-white/10 pb-2">
                 <Crown className="h-3.5 w-3.5 fill-[#f5c542] text-[#f5c542]" />
                 <span className="text-[10px] font-black uppercase tracking-[0.18em] text-[#f8e7a1]">The Gaffer League</span>

--- a/src/components/fantasy/FantasySubNav.tsx
+++ b/src/components/fantasy/FantasySubNav.tsx
@@ -1,0 +1,29 @@
+import { Link, useLocation } from 'react-router-dom';
+import { LayoutGrid, Users, ArrowLeftRight, ListOrdered, Gift } from 'lucide-react';
+
+const TABS = [
+  { to: '/fantasy-league', label: 'Overview', icon: LayoutGrid, exact: true },
+  { to: '/fantasy-league/my-team', label: 'My Team', icon: Users },
+  { to: '/fantasy-league/transfers', label: 'Transfers', icon: ArrowLeftRight },
+  { to: '/fantasy-league/results', label: 'Results', icon: ListOrdered },
+  { to: '/fantasy-league#prizes', label: 'Prizes', icon: Gift },
+];
+
+/** Sub-navigation tab bar shared across the Fantasy pages. */
+export function FantasySubNav() {
+  const { pathname } = useLocation();
+  return (
+    <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6">
+      <nav className="flex gap-1 overflow-x-auto rounded-2xl border border-white/10 bg-[#0b0518]/70 p-1.5 [scrollbar-width:none]">
+        {TABS.map((t) => {
+          const active = t.exact ? pathname === t.to : pathname.startsWith(t.to.split('#')[0]) && t.to !== '/fantasy-league';
+          return (
+            <Link key={t.to} to={t.to} className={`inline-flex shrink-0 items-center gap-1.5 rounded-xl px-3.5 py-2 text-[12px] font-black uppercase tracking-wide transition-colors ${active ? 'bg-[#f5c542] text-[#16051f]' : 'text-white/65 hover:bg-white/[0.06] hover:text-white'}`}>
+              <t.icon className="h-3.5 w-3.5" /> {t.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/fantasy/GameweekResultsView.tsx
+++ b/src/components/fantasy/GameweekResultsView.tsx
@@ -1,0 +1,86 @@
+import { ListOrdered, Star, Sparkles, Activity } from 'lucide-react';
+import { useFantasyGameweekResults, useFantasyRealtimeScores } from '@/hooks/useFantasyLeague';
+import type { FantasyTeamSlot } from '@/types/footy';
+
+const STATUS_LABEL: Record<string, { label: string; tone: string }> = {
+  upcoming: { label: 'Not started', tone: 'text-white/50' },
+  open: { label: 'Not started', tone: 'text-white/50' },
+  locked: { label: 'Locked', tone: 'text-amber-300' },
+  live: { label: 'Live', tone: 'text-emerald-300' },
+  settled: { label: 'Final', tone: 'text-violet-300' },
+};
+
+function PointsRow({ s, bench }: { s: FantasyTeamSlot; bench?: boolean }) {
+  const base = s.player.gameweek_points ?? 0;
+  const mult = s.is_captain ? 2 : 1;
+  const eff = base * mult;
+  return (
+    <li className={`flex items-center gap-2.5 px-3 py-2.5 ${bench ? 'opacity-55' : ''}`}>
+      <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-[11px] font-black ${s.is_captain ? 'bg-[#f5c542] text-[#16051f]' : 'bg-black/40 text-[#f8e7a1]'}`}>{s.player.position}</span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1.5 truncate text-[13px] font-bold text-white">
+          {s.player.name}
+          {s.is_captain && <span className="inline-flex items-center gap-0.5 rounded bg-[#f5c542]/20 px-1 text-[9px] font-black text-[#f8e7a1]"><Star className="h-2.5 w-2.5 fill-current" />×2</span>}
+          {s.is_vice_captain && <span className="rounded bg-white/15 px-1 text-[9px] font-black text-white/70">V</span>}
+        </span>
+        <span className="block truncate text-[10px] font-semibold uppercase tracking-wide text-white/40">{s.player.club.short_name}{bench ? ' · bench' : ''}</span>
+      </span>
+      {s.is_captain && <span className="text-[11px] font-semibold text-white/35 tabular-nums">{base}×2</span>}
+      <span className={`w-10 text-right font-display text-lg tabular-nums ${eff > 0 ? 'text-[#f5c542]' : 'text-white/40'}`}>{eff}</span>
+    </li>
+  );
+}
+
+/**
+ * GameweekResultsView — per-player points for a gameweek, captain double and
+ * the running total. Derived client-side from get-fantasy-team + get-fantasy-
+ * gameweek (no dedicated results endpoint), live via the fantasy-scores channel.
+ */
+export function GameweekResultsView() {
+  const { isLoading, gameweek, starters, bench, total, status } = useFantasyGameweekResults();
+  useFantasyRealtimeScores();
+
+  if (isLoading) return <div className="h-[520px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
+  const st = STATUS_LABEL[status] ?? STATUS_LABEL.open;
+  const notStarted = status === 'open' || status === 'upcoming';
+
+  return (
+    <section className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(245,197,66,0.6)] md:rounded-[2rem]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="relative p-5 md:p-7">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]"><ListOrdered className="h-3.5 w-3.5" /> Gameweek {gameweek?.gameweek ?? ''} Results</span>
+            <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">How’d your lot get on?</h2>
+            <p className="mt-2 text-sm text-white/55">Goals, assists, bonus and the captain’s double — every point accounted for.</p>
+          </div>
+          <div className="flex items-center gap-3 rounded-2xl border border-[#f5c542]/30 bg-[#f5c542]/10 px-5 py-3">
+            <Activity className="h-7 w-7 text-[#f5c542]" />
+            <div className="leading-tight">
+              <div className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest"><span className={st.tone}>{st.label}</span></div>
+              <div className="font-display text-3xl text-white">{total} <span className="text-base text-white/50">pts</span></div>
+            </div>
+          </div>
+        </div>
+
+        {notStarted ? (
+          <div className="mt-6 grid place-items-center rounded-2xl border border-dashed border-white/15 py-14 text-center">
+            <Sparkles className="h-7 w-7 text-white/30" />
+            <p className="mt-3 text-sm text-white/50">Kick-off’s not here yet. Points light up live once the whistle blows.</p>
+          </div>
+        ) : (
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0b0518]/60">
+              <div className="border-b border-white/10 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white/45">Starting XI</div>
+              <ul className="divide-y divide-white/[0.06]">{starters.map((s) => <PointsRow key={s.player.id} s={s} />)}</ul>
+            </div>
+            <div className="self-start overflow-hidden rounded-2xl border border-white/10 bg-[#0b0518]/60">
+              <div className="border-b border-white/10 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white/45">Bench <span className="text-white/30">— not counted</span></div>
+              <ul className="divide-y divide-white/[0.06]">{bench.map((s) => <PointsRow key={s.player.id} s={s} bench />)}</ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/fantasy/MyTeamView.tsx
+++ b/src/components/fantasy/MyTeamView.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Star, Zap, ArrowLeftRight, ShieldQuestion, Activity } from 'lucide-react';
+import { useFantasyTeam, useFantasyGameweek, useSetCaptain, useSetVice, useFantasyRealtimeScores } from '@/hooks/useFantasyLeague';
+import type { FantasyChip } from '@/types/footy';
+import { PitchView } from './PitchView';
+import { Countdown } from './Countdown';
+
+const CHIPS: { key: FantasyChip; label: string }[] = [
+  { key: 'wildcard', label: 'Wildcard' },
+  { key: 'bench_boost', label: 'Bench Boost' },
+  { key: 'triple_captain', label: 'Triple Captain' },
+  { key: 'free_hit', label: 'Free Hit' },
+];
+
+/**
+ * MyTeamView — the manager's saved XI. Pitch + bench, captain/vice selection,
+ * the (reserved) chip tray and a live gameweek total via the fantasy-scores
+ * channel. Bound to useFantasyTeam; captain/vice call the mutations (optimistic).
+ */
+export function MyTeamView() {
+  const { data: team, isLoading } = useFantasyTeam();
+  const { data: gw } = useFantasyGameweek();
+  const setCaptain = useSetCaptain();
+  const setVice = useSetVice();
+  useFantasyRealtimeScores();
+
+  const [capOverride, setCap] = useState<string | null>(null);
+  const [viceOverride, setViceState] = useState<string | null>(null);
+
+  if (isLoading && !team) return <div className="h-[560px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
+  if (!team) return null;
+
+  const currentCaptain = team.slots.find((s) => s.is_captain)?.player.id ?? null;
+  const currentVice = team.slots.find((s) => s.is_vice_captain)?.player.id ?? null;
+  const captainId = capOverride ?? currentCaptain;
+  const viceId = viceOverride ?? currentVice;
+
+  const renderTeam = { ...team, slots: team.slots.map((s) => ({ ...s, is_captain: s.player.id === captainId, is_vice_captain: s.player.id === viceId })) };
+  const starters = team.slots.filter((s) => s.is_starter);
+  const liveTotal = renderTeam.slots.filter((s) => s.is_starter).reduce((sum, s) => sum + (s.player.gameweek_points ?? 0) * (s.is_captain ? 2 : 1), 0);
+  const live = gw?.status === 'live';
+
+  const chooseCaptain = (id: string) => { setCap(id); if (id === viceId) setViceState(''); setCaptain.mutate({ teamId: team.id, playerId: id }); };
+  const chooseVice = (id: string) => { setViceState(id); if (id === captainId) setCap(''); setVice.mutate({ teamId: team.id, playerId: id }); };
+
+  return (
+    <section className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(124,58,237,0.7)] md:rounded-[2rem]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="relative grid gap-4 p-5 md:p-7 lg:grid-cols-[1fr_300px]">
+        {/* pitch */}
+        <div className="order-2 lg:order-1">
+          <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]">My Team</span>
+              <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">{team.name}</h2>
+            </div>
+            <Link to="/fantasy-league/transfers" className="inline-flex items-center gap-2 rounded-xl border border-violet-400/45 bg-violet-500/[0.08] px-5 py-3 text-sm font-black uppercase tracking-wide text-violet-100 transition-all hover:-translate-y-0.5 hover:bg-violet-500/15"><ArrowLeftRight className="h-4 w-4" /> Transfers</Link>
+          </div>
+          <PitchView team={renderTeam} metric={live ? 'gameweek' : 'total'} />
+        </div>
+
+        {/* controls */}
+        <div className="order-1 flex flex-col gap-4 lg:order-2">
+          <div className="rounded-2xl border border-[#f5c542]/25 bg-[#f5c542]/[0.06] p-4">
+            <div className="flex items-center justify-between">
+              <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-white/50"><Activity className="h-3.5 w-3.5" /> Gameweek total</span>
+              {live && <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/20 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-emerald-300"><span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" /> Live</span>}
+            </div>
+            <div className="mt-1 font-display text-4xl text-[#f5c542]">{liveTotal} <span className="text-lg text-white/50">pts</span></div>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[#0b0518]/60 p-4">
+            <div className="text-[10px] font-black uppercase tracking-widest text-white/45">Deadline</div>
+            <div className="mt-2"><Countdown deadline={gw?.deadline_at ?? null} /></div>
+          </div>
+
+          <div className="grid gap-3">
+            <label className="flex items-center gap-2 rounded-xl border border-[#f5c542]/25 bg-[#f5c542]/[0.06] px-3 py-2.5">
+              <Star className="h-4 w-4 shrink-0 fill-[#f5c542] text-[#f5c542]" />
+              <span className="text-[11px] font-black uppercase tracking-wide text-[#f8e7a1]">Captain</span>
+              <select value={captainId ?? ''} onChange={(e) => chooseCaptain(e.target.value)} className="ml-auto min-w-0 flex-1 rounded-lg border border-white/10 bg-[#0b0518] px-2 py-1.5 text-[12px] font-semibold text-white">
+                {starters.map((s) => <option key={s.player.id} value={s.player.id}>{s.player.name}</option>)}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 rounded-xl border border-violet-400/25 bg-violet-500/[0.06] px-3 py-2.5">
+              <Star className="h-4 w-4 shrink-0 text-violet-300" />
+              <span className="text-[11px] font-black uppercase tracking-wide text-violet-200">Vice</span>
+              <select value={viceId ?? ''} onChange={(e) => chooseVice(e.target.value)} className="ml-auto min-w-0 flex-1 rounded-lg border border-white/10 bg-[#0b0518] px-2 py-1.5 text-[12px] font-semibold text-white">
+                {starters.map((s) => <option key={s.player.id} value={s.player.id}>{s.player.name}</option>)}
+              </select>
+            </label>
+            <p className="text-[11px] leading-snug text-white/45">Your captain scores double. Vice steps in if the captain doesn’t start.</p>
+          </div>
+
+          <div className="rounded-2xl border border-violet-400/20 bg-violet-500/[0.05] p-4">
+            <div className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-violet-200"><Zap className="h-3.5 w-3.5" /> Chips</div>
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              {CHIPS.map((c) => (
+                <button key={c.key} type="button" disabled className="cursor-not-allowed rounded-lg border border-white/10 bg-white/[0.03] px-2 py-2 text-[11px] font-black uppercase tracking-wide text-white/40">{c.label}</button>
+              ))}
+            </div>
+            <p className="mt-2 inline-flex items-center gap-1.5 text-[11px] text-white/45"><ShieldQuestion className="h-3.5 w-3.5" /> Locked in the armoury — coming soon.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/fantasy/PitchView.tsx
+++ b/src/components/fantasy/PitchView.tsx
@@ -1,0 +1,47 @@
+import type { FantasyTeam, FantasyPosition } from '@/types/footy';
+import { PlayerCard } from './PlayerCard';
+
+// Rows front-to-back to match the pitch (attackers on top, keeper at the base).
+const ROWS: FantasyPosition[] = ['FWD', 'MID', 'DEF', 'GK'];
+
+/**
+ * PitchView — renders a FantasyTeam's starting XI on the turf plus the bench.
+ * Shared by My Team and Gameweek Results. Display-only; `metric` chooses whether
+ * cards headline season points or this gameweek's points.
+ */
+export function PitchView({ team, metric = 'total' }: { team: FantasyTeam; metric?: 'total' | 'gameweek' }) {
+  const starters = team.slots.filter((s) => s.is_starter);
+  const bench = team.slots.filter((s) => !s.is_starter).sort((a, b) => (a.bench_order ?? 9) - (b.bench_order ?? 9));
+  const byPos = (pos: FantasyPosition) => starters.filter((s) => s.player.position === pos);
+
+  return (
+    <div>
+      <div className="relative overflow-hidden rounded-2xl border border-emerald-500/20">
+        <div aria-hidden className="absolute inset-0 bg-[linear-gradient(180deg,#0a3d24,#072a19)]" />
+        <div aria-hidden className="absolute inset-0 bg-[repeating-linear-gradient(180deg,rgba(255,255,255,0.05)_0_44px,transparent_44px_88px)]" />
+        <div aria-hidden className="pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15" />
+        <div className="relative flex flex-col gap-3 px-2 py-5 sm:gap-4 sm:px-4 sm:py-7">
+          {ROWS.map((pos) => (
+            <div key={pos} className="flex flex-wrap items-center justify-center gap-2 sm:gap-3">
+              {byPos(pos).map((s) => (
+                <PlayerCard key={s.player.id} player={s.player} size="sm" metric={metric} captain={s.is_captain} vice={s.is_vice_captain} />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-2xl border border-white/10 bg-[#0b0518]/60 p-3">
+        <div className="mb-2 text-[10px] font-black uppercase tracking-widest text-white/45">Bench</div>
+        <div className="flex flex-wrap justify-center gap-2 sm:justify-start sm:gap-3">
+          {bench.map((s) => (
+            <div key={s.player.id} className="relative">
+              {s.bench_order && <span className="absolute -left-1 -top-1 z-10 grid h-4 w-4 place-items-center rounded-full bg-white/85 text-[9px] font-black text-[#16051f]">{s.bench_order}</span>}
+              <PlayerCard player={s.player} size="sm" metric={metric} captain={s.is_captain} vice={s.is_vice_captain} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fantasy/TransfersView.tsx
+++ b/src/components/fantasy/TransfersView.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from 'react';
+import { ArrowLeftRight, Coins, Check, X, AlertTriangle, Minus } from 'lucide-react';
+import { useFantasyTeam, useFantasyPlayers, useFantasyGameweek, useSubmitTransfers } from '@/hooks/useFantasyLeague';
+import type { FantasyPosition } from '@/types/footy';
+
+const HIT = 4;
+const POS_ORDER: FantasyPosition[] = ['GK', 'DEF', 'MID', 'FWD'];
+
+/**
+ * TransfersView — swap players out and in with free-transfer + points-hit
+ * accounting and a deadline gate. Bound to useFantasyTeam + useFantasyPlayers;
+ * confirm calls submit-transfers. Budget/position/club are re-validated live.
+ */
+export function TransfersView() {
+  const { data: team, isLoading } = useFantasyTeam();
+  const { data: playersData } = useFantasyPlayers();
+  const { data: gw } = useFantasyGameweek();
+  const submit = useSubmitTransfers();
+
+  const [outIds, setOutIds] = useState<Set<string>>(new Set());
+  const [reps, setReps] = useState<Record<string, string>>({});
+
+  const pool = playersData?.players ?? [];
+  const poolById = useMemo(() => new Map(pool.map((p) => [p.id, p])), [pool]);
+
+  if (isLoading && !team) return <div className="h-[560px] animate-pulse rounded-[1.6rem] border border-white/10 bg-white/[0.03]" />;
+  if (!team) return null;
+
+  const squadIds = new Set(team.slots.map((s) => s.player.id));
+  const outList = team.slots.filter((s) => outIds.has(s.player.id)).map((s) => s.player);
+  const chosenIns = Object.entries(reps).filter(([outId]) => outIds.has(outId)).map(([, inId]) => inId).filter(Boolean);
+  const freed = outList.reduce((a, p) => a + p.price, 0);
+  const incoming = chosenIns.reduce((a, id) => a + (poolById.get(id)?.price ?? 0), 0);
+  const remainingAfter = team.budget_remaining + freed - incoming;
+  const count = outIds.size;
+  const free = team.free_transfers;
+  const hits = Math.max(0, count - free) * HIT;
+  const allPaired = outList.every((p) => reps[p.id]);
+  const deadlinePassed = gw?.deadline_at ? Date.now() > new Date(gw.deadline_at).getTime() : false;
+  const canConfirm = count > 0 && allPaired && remainingAfter >= -1e-9 && !deadlinePassed && !submit.isPending;
+
+  const toggleOut = (id: string) => {
+    setOutIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) { next.delete(id); setReps((r) => { const c = { ...r }; delete c[id]; return c; }); }
+      else next.add(id);
+      return next;
+    });
+  };
+  const eligibleFor = (pos: FantasyPosition) => pool.filter((p) => p.position === pos && !squadIds.has(p.id) && !chosenIns.includes(p.id)).sort((a, b) => b.total_points - a.total_points);
+
+  const confirm = () => {
+    if (!canConfirm || !gw) return;
+    submit.mutate({ teamId: team.id, gameweek: gw.gameweek, outPlayerIds: [...outIds], inPlayerIds: outList.map((p) => reps[p.id]) });
+  };
+
+  return (
+    <section className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#070312] shadow-[0_0_60px_-24px_rgba(124,58,237,0.7)] md:rounded-[2rem]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="relative p-5 md:p-7">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-[#f8e7a1]"><ArrowLeftRight className="h-3.5 w-3.5" /> Transfers</span>
+            <h2 className="mt-3 font-display text-4xl uppercase leading-none text-white md:text-5xl">Wheel and deal.</h2>
+            <p className="mt-2 text-sm text-white/55">One free transfer a week. Each extra costs −{HIT} points. Gamble responsibly.</p>
+          </div>
+          {/* summary */}
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-xl border border-white/10 bg-[#0b0518]/60 px-3 py-2"><div className="text-[9px] font-black uppercase tracking-widest text-white/40">Free</div><div className="font-display text-xl text-white">{free}</div></div>
+            <div className="rounded-xl border border-white/10 bg-[#0b0518]/60 px-3 py-2"><div className="text-[9px] font-black uppercase tracking-widest text-white/40">Hit</div><div className={`font-display text-xl ${hits > 0 ? 'text-red-400' : 'text-white'}`}>{hits ? `−${hits}` : '0'}</div></div>
+            <div className="rounded-xl border border-white/10 bg-[#0b0518]/60 px-3 py-2"><div className="text-[9px] font-black uppercase tracking-widest text-white/40">Budget</div><div className={`font-display text-xl ${remainingAfter < 0 ? 'text-red-400' : 'text-[#f5c542]'}`}>£{remainingAfter.toFixed(1)}m</div></div>
+          </div>
+        </div>
+
+        {deadlinePassed && (
+          <div className="mt-4 inline-flex items-center gap-2 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] font-bold text-red-300"><AlertTriangle className="h-4 w-4" /> Deadline’s gone — doors are shut till next week.</div>
+        )}
+
+        <div className="mt-6 grid gap-5 lg:grid-cols-2">
+          {/* your squad */}
+          <div>
+            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-black uppercase tracking-widest text-white/50"><Minus className="h-3.5 w-3.5 text-red-400" /> Ship out — tap to select</div>
+            <div className="space-y-3">
+              {POS_ORDER.map((pos) => {
+                const rows = team.slots.filter((s) => s.player.position === pos);
+                return (
+                  <div key={pos}>
+                    <div className="mb-1 text-[9px] font-black uppercase tracking-widest text-white/30">{pos}</div>
+                    <div className="grid gap-1.5">
+                      {rows.map((s) => {
+                        const out = outIds.has(s.player.id);
+                        return (
+                          <button key={s.player.id} type="button" onClick={() => toggleOut(s.player.id)} className={`flex items-center gap-2.5 rounded-xl border px-2.5 py-2 text-left transition-all ${out ? 'border-red-400/50 bg-red-500/10' : 'border-white/10 bg-white/[0.03] hover:border-white/25'}`}>
+                            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-black/40 font-display text-sm text-[#f8e7a1]">{s.player.total_points}</span>
+                            <span className="min-w-0 flex-1"><span className="block truncate text-[13px] font-bold text-white">{s.player.name}</span><span className="block text-[10px] font-semibold uppercase tracking-wide text-white/40">{s.player.position} · {s.player.club.short_name}</span></span>
+                            <span className="text-[12px] font-black text-emerald-300">£{s.player.price.toFixed(1)}m</span>
+                            <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-full ${out ? 'bg-red-500 text-white' : 'bg-white/10 text-white/50'}`}>{out ? <X className="h-3.5 w-3.5" /> : <Minus className="h-3.5 w-3.5" />}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* replacements */}
+          <div>
+            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-black uppercase tracking-widest text-white/50"><ArrowLeftRight className="h-3.5 w-3.5 text-[#f5c542]" /> Bring in</div>
+            {outList.length === 0 ? (
+              <div className="grid h-40 place-items-center rounded-2xl border border-dashed border-white/15 text-center text-sm text-white/40">Select players to ship out, then pick their replacements here.</div>
+            ) : (
+              <div className="space-y-2.5">
+                {outList.map((p) => (
+                  <div key={p.id} className="rounded-2xl border border-white/10 bg-[#0b0518]/60 p-3">
+                    <div className="mb-2 flex items-center gap-2 text-[12px] text-white/60"><span className="font-bold text-red-300">OUT</span> {p.name} <span className="text-white/30">·</span> £{p.price.toFixed(1)}m</div>
+                    <select value={reps[p.id] ?? ''} onChange={(e) => setReps((r) => ({ ...r, [p.id]: e.target.value }))} className="w-full rounded-lg border border-white/12 bg-[#120726] px-2.5 py-2 text-[13px] font-semibold text-white">
+                      <option value="">Choose a {p.position} to bring in…</option>
+                      {eligibleFor(p.position).slice(0, 30).map((c) => <option key={c.id} value={c.id}>{c.name} — {c.club.short_name} — £{c.price.toFixed(1)}m — {c.total_points}pts</option>)}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <button type="button" onClick={confirm} disabled={!canConfirm} className={`mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-black uppercase tracking-wide transition-transform ${canConfirm ? 'bg-gradient-to-r from-amber-300 to-amber-500 text-[#16051f] hover:-translate-y-0.5' : 'cursor-not-allowed bg-white/10 text-white/40'}`}>
+              {submit.isPending ? 'Confirming…' : hits > 0 ? `Confirm — take the −${hits} hit` : 'Confirm Transfers'}
+            </button>
+            {submit.isSuccess && <p className="mt-2 inline-flex items-center gap-1.5 text-[12px] font-bold text-emerald-300"><Check className="h-4 w-4" /> Done and dusted. Fresh legs incoming.</p>}
+            {submit.isError && <p className="mt-2 inline-flex items-center gap-1.5 text-[12px] text-white/50"><Coins className="h-4 w-4" /> Transfers will lock in once your squad’s saved to the league.</p>}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useFantasyLeague.ts
+++ b/src/hooks/useFantasyLeague.ts
@@ -136,7 +136,8 @@ export const FANTASY_PLAYERS: FantasyPlayer[] = [
 
 const slot = (id: string, is_starter: boolean, opts: { c?: boolean; v?: boolean; bench?: number } = {}) => {
   const player = FANTASY_PLAYERS.find((p) => p.id === id)!;
-  return { player: { ...player, gameweek_points: is_starter ? Math.round(player.form * (opts.c ? 2 : 1)) : 0 }, is_starter, is_captain: !!opts.c, is_vice_captain: !!opts.v, bench_order: opts.bench };
+  // Base gameweek points only — the captain ×2 is applied at display, never baked.
+  return { player: { ...player, gameweek_points: is_starter ? Math.round(player.form) : 0 }, is_starter, is_captain: !!opts.c, is_vice_captain: !!opts.v, bench_order: opts.bench };
 };
 
 /** A full legal fallback squad: 2·5·5·3, XI in a 4-4-2, captain + vice + bench order. */
@@ -157,7 +158,9 @@ export const FANTASY_TEAM: FantasyTeam = {
 const daysAdd = (d: number) => new Date(Date.now() + d * 86400000).toISOString();
 
 export const FANTASY_GAMEWEEK: FantasyGameweekResponse = {
-  season: '2025/26', gameweek: 24, status: 'open', deadline_at: daysAdd(2.35),
+  // Sample state: a gameweek in play (so Results + live totals render). Real FPL
+  // data drives status/deadline live; the countdown reads the next deadline.
+  season: '2025/26', gameweek: 24, status: 'live', deadline_at: daysAdd(2.35),
   bonus_rules: [{ key: 'manual_bonus', label: 'Gaffer Bonus', description: 'Optional 0–3 bonus points, awarded by The Gaffer for standout performances.' }],
   fixtures: [
     { id: 'fx_1', kickoff_time: daysAdd(2.4), home_team: LIV, away_team: NEW, status: 'scheduled' },

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { HomepageNav } from '@/components/homepage/HomepageNav';
 import { FooterNavigation } from '@/components/homepage/FooterNavigation';
 import { HomepageScene } from '@/components/homepage/HomepageScene';
+import { FantasySubNav } from '@/components/fantasy/FantasySubNav';
 import { FantasyPageHero } from '@/components/fantasy/FantasyPageHero';
 import { SquadBuilder } from '@/components/fantasy/SquadBuilder';
 import { LeagueStandings } from '@/components/fantasy/LeagueStandings';
@@ -23,6 +24,8 @@ export default function FantasyLeague() {
       <HomepageNav />
 
       <FantasyPageHero />
+
+      <div className="relative z-10 -mt-4 pb-2"><FantasySubNav /></div>
 
       <HomepageScene tone="violet" eyebrow="01 · Pick Your Squad">
         <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6">

--- a/src/pages/FantasyMyTeam.tsx
+++ b/src/pages/FantasyMyTeam.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { FooterNavigation } from '@/components/homepage/FooterNavigation';
+import { HomepageScene } from '@/components/homepage/HomepageScene';
+import { FantasySubNav } from '@/components/fantasy/FantasySubNav';
+import { MyTeamView } from '@/components/fantasy/MyTeamView';
+
+export default function FantasyMyTeam() {
+  useEffect(() => { document.title = 'My Team — Footy Oracle Fantasy'; }, []);
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#05020b] text-white">
+      <HomepageNav />
+      <div className="pt-6"><FantasySubNav /></div>
+      <HomepageScene tone="violet">
+        <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6"><MyTeamView /></div>
+      </HomepageScene>
+      <div className="mx-auto max-w-7xl px-3 pb-8 sm:px-4 md:px-6"><FooterNavigation /></div>
+    </div>
+  );
+}

--- a/src/pages/FantasyResults.tsx
+++ b/src/pages/FantasyResults.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { FooterNavigation } from '@/components/homepage/FooterNavigation';
+import { HomepageScene } from '@/components/homepage/HomepageScene';
+import { FantasySubNav } from '@/components/fantasy/FantasySubNav';
+import { GameweekResultsView } from '@/components/fantasy/GameweekResultsView';
+
+export default function FantasyResults() {
+  useEffect(() => { document.title = 'Gameweek Results — Footy Oracle Fantasy'; }, []);
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#05020b] text-white">
+      <HomepageNav />
+      <div className="pt-6"><FantasySubNav /></div>
+      <HomepageScene tone="finale">
+        <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6"><GameweekResultsView /></div>
+      </HomepageScene>
+      <div className="mx-auto max-w-7xl px-3 pb-8 sm:px-4 md:px-6"><FooterNavigation /></div>
+    </div>
+  );
+}

--- a/src/pages/FantasyTransfers.tsx
+++ b/src/pages/FantasyTransfers.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { FooterNavigation } from '@/components/homepage/FooterNavigation';
+import { HomepageScene } from '@/components/homepage/HomepageScene';
+import { FantasySubNav } from '@/components/fantasy/FantasySubNav';
+import { TransfersView } from '@/components/fantasy/TransfersView';
+
+export default function FantasyTransfers() {
+  useEffect(() => { document.title = 'Transfers — Footy Oracle Fantasy'; }, []);
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#05020b] text-white">
+      <HomepageNav />
+      <div className="pt-6"><FantasySubNav /></div>
+      <HomepageScene tone="violet">
+        <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6"><TransfersView /></div>
+      </HomepageScene>
+      <div className="mx-auto max-w-7xl px-3 pb-8 sm:px-4 md:px-6"><FooterNavigation /></div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Builds out the remaining Fantasy pages against the existing hooks/contracts, and fixes the mobile hero overlap you flagged.

### Mobile hero fix
The "Gaffer League" mini-leaderboard box was sitting over the Gaffer's face on mobile. It now **stacks below him on mobile** and floats top-right **only on desktop** — his face is clear.

### New pages (routes under `/fantasy-league/*`, with a shared `FantasySubNav` tab bar)
- **My Team** (`/fantasy-league/my-team`) — pitch view of the saved XI + bench (with order badges), captain/vice selectors (call `set-captain` / `set-vice`), live gameweek total via the `fantasy-scores` channel, deadline countdown, and the reserved chip tray.
- **Transfers** (`/fantasy-league/transfers`) — out/in shuttle grouped by position, **free-transfer + −4 hit accounting**, live budget re-validation, deadline gate, `submit-transfers`.
- **Gameweek Results** (`/fantasy-league/results`) — per-player points, **captain ×2**, bench-not-counted, live/settled status. Derived client-side (`get-fantasy-team` + `get-fantasy-gameweek` + `fantasy-scores`) — **no new endpoint**, per the work order.

### Shared
- `PitchView` (renders a `FantasyTeam`'s XI + bench) reused by My Team and Results.
- `FantasySubNav` added to all fantasy pages including the hub.

### Fallback fixes
- Fixed captain points being pre-doubled in sample data — the ×2 is now applied at **display only** (Results total sums correctly, e.g. Haaland `8×2 → 16`).
- Sample gameweek set to a live state so Results + live totals render in the demo; real FPL data drives status/deadline live.

### Verified
`tsc --noEmit -p tsconfig.app.json` → **exit 0**. All pages render with zero runtime errors (desktop + mobile screenshots).

Note: mutations (captain/vice/transfers) call the real edge functions and will persist once the `fantasy_teams` table is provisioned; until then they no-op gracefully and the UI stays interactive via local state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Fantasy League sections for **My Team**, **Transfers**, and **Gameweek Results**.
  * Introduced a fantasy sub-navigation for easier movement between league pages.
  * Added live team, transfer, and results views with countdowns, totals, captain/vice selection, and matchweek status displays.

* **Bug Fixes**
  * Improved fantasy leaderboard positioning and responsiveness across mobile and desktop.
  * Updated live fantasy scoring behavior so current gameweek views reflect ongoing match activity more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->