### PR TITLE
Fantasy waitlist: capture "Notify me" signups

### DIFF
--- a/src/components/homepage/FantasyLeagueSellItSection.tsx
+++ b/src/components/homepage/FantasyLeagueSellItSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Bell, ArrowRight, Check } from 'lucide-react';
 import { Countdown } from '@/components/fantasy/Countdown';
+import { supabase } from '@/integrations/supabase/client';
 
 const POSTER = '/images/fantasy/fantasy-coming-soon.jpg';
 // Registration target for the coming-soon countdown (season opens Aug 2026).
@@ -19,9 +20,12 @@ export function FantasyLeagueSellItSection() {
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email.trim()) return;
-    try { localStorage.setItem('fantasy_waitlist_email', email.trim()); } catch { /* ignore */ }
-    setDone(true);
+    const clean = email.trim();
+    if (!clean) return;
+    setDone(true); // optimistic — don't make them wait on the network
+    try { localStorage.setItem('fantasy_waitlist_email', clean); } catch { /* ignore */ }
+    // Persist to the waitlist (fire-and-forget; localStorage is the fallback).
+    void supabase.functions.invoke('fantasy-waitlist', { body: { email: clean, source: 'homepage' } }).catch(() => {});
   };
 
   return (

--- a/supabase/functions/fantasy-waitlist/index.ts
+++ b/supabase/functions/fantasy-waitlist/index.ts
@@ -1,0 +1,32 @@
+// ============================================================================
+// Footy Oracle — fantasy-waitlist
+// Captures a "Notify me" email for the coming-soon Fantasy league.
+// POST { email, source? } → ApiResponse<{ subscribed: true }>. Dedupes by email.
+// ============================================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { ok, fail, preflight, readBody } from "../_shared/api.ts";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+serve(async (req) => {
+  const pf = preflight(req);
+  if (pf) return pf;
+  try {
+    const { email, source } = await readBody<{ email?: string; source?: string }>(req);
+    const clean = (email ?? "").trim().toLowerCase();
+    if (!clean || clean.length > 254 || !EMAIL_RE.test(clean)) {
+      return fail("INVALID_EMAIL", "Enter a valid email address.", 422);
+    }
+
+    const sb = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const { error } = await sb
+      .from("fantasy_waitlist")
+      .upsert({ email: clean, source: source ?? "homepage" }, { onConflict: "email", ignoreDuplicates: true });
+    if (error) return fail("WAITLIST_INSERT_FAILED", error.message, 500);
+
+    return ok({ subscribed: true });
+  } catch (err) {
+    return fail("WAITLIST_ERROR", `Could not join the waitlist: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/migrations/20260704120000_fantasy_waitlist.sql
+++ b/supabase/migrations/20260704120000_fantasy_waitlist.sql
@@ -1,0 +1,12 @@
+-- Fantasy waitlist — captures "Notify me" signups for the coming-soon league.
+create table if not exists public.fantasy_waitlist (
+  id uuid primary key default gen_random_uuid(),
+  email text not null unique,      -- stored lowercased by the edge function
+  source text,                     -- e.g. 'homepage'
+  created_at timestamptz not null default now()
+);
+
+-- RLS on, no public policies: rows are written only by the fantasy-waitlist
+-- edge function (service role bypasses RLS) and are not readable by anon/auth
+-- clients — the email list stays private.
+alter table public.fantasy_waitlist enable row level security;


### PR DESCRIPTION
## What

Turns the fantasy "Notify me" form into a real waitlist so coming-soon signups are actually saved (not just localStorage).

- **Migration** `public.fantasy_waitlist` — `email` (unique), `source`, `created_at`. RLS on with **no public policies**, so the list is private (written only via the service-role edge function, not readable by anon/auth clients).
- **Edge function** `fantasy-waitlist` — validates the email, upserts with dedupe by email, returns the standard `{ ok, data }` envelope.
- **Homepage form** now POSTs to `fantasy-waitlist` (fire-and-forget, optimistic success); localStorage stays as a fallback.

Deploys through the same GitHub → Lovable sync. After Lovable pulls, the table + function need to be applied (Lovable/Supabase runs the migration on sync).

Verified: `tsc -p tsconfig.app.json` exit 0, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Fantasy League waitlist signup flow on the homepage.
  * Submitted emails are now sent to a backend service and saved for follow-up.

* **Bug Fixes**
  * Improved email handling by trimming and normalizing entries before submission.
  * Added validation to reject clearly invalid email addresses.

* **Backend**
  * Added secure server-side storage for waitlist signups with duplicate protection and private access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->