### PR TITLE
Node 20 for free static deploys from main (bypass Lovable)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@
   status = 200
 
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Why
The live site is published only by Lovable, which requires credits and doesn't rebuild from commits it didn't author — so changes pushed to `main` never go live. This makes `main` deployable for free on a standard static host instead.

## What
- The repo already ships `netlify.toml` and `vercel.json` (SPA redirects, `npm run build`, `dist` output). Verified a clean `npm run build`.
- Bumps Netlify's pinned Node from 18 (EOL) to 20 so the first build doesn't fail.

No app code changes. The Supabase backend config (URL + public anon key) is baked into `vite.config.ts`, so the build needs no secrets in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_