### PR TITLE
wrangler.toml for Cloudflare Workers static-assets deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,10 @@
+# Cloudflare Workers static-site deploy for the Vite build output.
+# `npm run build` produces ./dist; wrangler deploys it as static assets with
+# single-page-application fallback so client-side routes (e.g. /fantasy-league)
+# resolve to index.html instead of 404ing.
+name = "golden-bet-ai"
+compatibility_date = "2025-01-01"
+
+[assets]
+directory = "./dist"
+not_found_handling = "single-page-application"


### PR DESCRIPTION
Adds `wrangler.toml` so the Cloudflare Workers build deploys the Vite `./dist` output as static assets with SPA fallback (`not_found_handling=single-page-application`). Pairs with build command `npm run build` and deploy command `npx wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_