### PR TITLE
Convert wrangler.toml to Cloudflare Pages config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,6 @@
-# Cloudflare Workers static-site deploy for the Vite build output.
-# `npm run build` produces ./dist; wrangler deploys it as static assets with
-# single-page-application fallback so client-side routes (e.g. /fantasy-league)
-# resolve to index.html instead of 404ing.
+# Cloudflare Pages config. The site is a static Vite SPA: `npm run build`
+# emits ./dist, which Pages serves. SPA routing (deep links like
+# /fantasy-league) is handled by public/_redirects (/* -> /index.html 200).
 name = "golden-bet-ai"
+pages_build_output_dir = "./dist"
 compatibility_date = "2025-01-01"
-
-[assets]
-directory = "./dist"
-not_found_handling = "single-page-application"


### PR DESCRIPTION
Site is now deployed on Cloudflare Pages (`golden-bet-ai.pages.dev`). Replaces the Workers `[assets]` stanza with `pages_build_output_dir = "./dist"` so `wrangler pages deploy` runs without the config warning. SPA routing stays handled by `public/_redirects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_