### PR TITLE
Remove Donkey of the Week section from homepage

### DIFF
--- a/src/pages/PreviewHome.tsx
+++ b/src/pages/PreviewHome.tsx
@@ -8,7 +8,6 @@ import { LatestArticlesSection } from '@/components/homepage/LatestArticlesSecti
 import { TipOfTheDayCard } from '@/components/homepage/TipOfTheDayCard';
 import { WeeklyPrizesFeatureCard } from '@/components/homepage/WeeklyPrizesFeatureCard';
 import { GafferStoryCard } from '@/components/homepage/GafferStoryCard';
-import { DonkeyOfTheWeekFeatureCard } from '@/components/homepage/DonkeyOfTheWeekFeatureCard';
 import { CommunityFeatureCard } from '@/components/homepage/CommunityFeatureCard';
 import { FinalCallToActionBanner } from '@/components/homepage/FinalCallToActionBanner';
 import { FooterNavigation } from '@/components/homepage/FooterNavigation';
@@ -52,10 +51,6 @@ export default function PreviewHome() {
           <WeeklyPrizesFeatureCard />
           <GafferStoryCard />
         </div>
-      </HomepageScene>
-
-      <HomepageScene tone="violet" eyebrow="04 · Donkey of the Week">
-        <DonkeyOfTheWeekFeatureCard />
       </HomepageScene>
 
       <HomepageScene tone="crowd" eyebrow="05 · The Community">


### PR DESCRIPTION
Removes the "04 · Donkey of the Week" homepage section (the `HomepageScene` wrapper + `DonkeyOfTheWeekFeatureCard`) and its now-unused import from `PreviewHome`. No longer required.

Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the homepage preview layout to remove the “Donkey of the Week” card.
  * The page now flows directly into the “The Community” section, creating a more streamlined browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->