### PR TITLE
Remove Form Tables section from homepage

### DIFF
--- a/src/pages/PreviewHome.tsx
+++ b/src/pages/PreviewHome.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { HomepageNav } from '@/components/homepage/HomepageNav';
 import { HeroBanner } from '@/components/homepage/HeroBanner';
 
-import { FormTablesSection } from '@/components/homepage/FormTablesSection';
 import { FantasyLeagueSellItSection } from '@/components/homepage/FantasyLeagueSellItSection';
 import { LatestArticlesSection } from '@/components/homepage/LatestArticlesSection';
 import { TipOfTheDayCard } from '@/components/homepage/TipOfTheDayCard';
@@ -37,11 +36,8 @@ export default function PreviewHome() {
         </div>
       </HomepageScene>
 
-      <HomepageScene tone="emerald" eyebrow="02 · Form & Fantasy">
-        <FormTablesSection />
-        <div className="mt-3 md:mt-4">
-          <FantasyLeagueSellItSection />
-        </div>
+      <HomepageScene tone="emerald" eyebrow="02 · Fantasy">
+        <FantasyLeagueSellItSection />
       </HomepageScene>
 
       <HomepageScene tone="editorial" eyebrow="03 · The Newsroom">


### PR DESCRIPTION
Removes `FormTablesSection` from the homepage and its unused import. The "02" scene now hosts only the Fantasy teaser and is relabelled "02 · Fantasy".

Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_