### PR TITLE
Drop the "live games tick over as they play" filler line

### DIFF
--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -327,7 +327,7 @@ function ValueHeading({ selection }: { selection: string }) {
     <div className="mb-4">
       <h2 className="font-display text-2xl uppercase tracking-tight text-white md:text-3xl">Best Value · <span className="text-emerald-400">{selection}</span></h2>
       <p className="mt-1 max-w-2xl text-sm leading-relaxed text-white/55">
-        The Gaffer's crunched every fixture so you don't have to — the biggest-value games for this market, juiciest edge first. <span className="text-white/75">His numbers, not a calculator's.</span> Live games tick over as they play.
+        The Gaffer's crunched every fixture so you don't have to — the biggest-value games for this market, juiciest edge first. <span className="text-white/75">His numbers, not a calculator's.</span>
       </p>
     </div>
   );


### PR DESCRIPTION
Removes the throwaway "Live games tick over as they play." sentence from the value-board intro copy.

Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_