### PR TITLE
Fix in-play hiding teams; vibrant community image bands

### DIFF
--- a/src/components/homepage/CommunityFeatureCard.tsx
+++ b/src/components/homepage/CommunityFeatureCard.tsx
@@ -3,21 +3,19 @@ import { FeaturePanel, Accent } from './FeaturePanel';
 import { HOMEPAGE_BACKGROUNDS } from './assets';
 import { COMMUNITY_CARDS, COMMUNITY_STRIP, SOCIAL_LINKS } from './content';
 
-// Per-channel imagery + brand accent for the image-led tiles.
-const NET: Record<string, { icon: typeof Facebook; href: string; join: string; img: string; wash: string; ring: string }> = {
+// Per-channel imagery + brand tint. Images run full-strength in a top band.
+const NET: Record<string, { icon: typeof Facebook; href: string; join: string; img: string; wash: string; pos: string }> = {
   facebook: {
     icon: Facebook, href: SOCIAL_LINKS.facebook, join: 'Join on Facebook',
-    img: '/images/hero-features/community.jpg',
-    wash: 'from-blue-600/50 via-blue-600/10', ring: 'group-hover/c:border-blue-400/60',
+    img: '/images/backgrounds/bg-crowd.jpg', wash: 'from-blue-600/25', pos: 'object-center',
   },
   telegram: {
     icon: Send, href: SOCIAL_LINKS.telegram, join: 'Join on Telegram',
-    img: '/images/backgrounds/bg-crowd.jpg',
-    wash: 'from-sky-500/50 via-sky-500/10', ring: 'group-hover/c:border-sky-400/60',
+    img: '/images/backgrounds/bg-stadium.jpg', wash: 'from-sky-500/25', pos: 'object-[center_38%]',
   },
 };
 
-/** Community — image-led channel tiles: full-bleed photo, brand wash, join baked in. */
+/** Community — vibrant image-band channel tiles with clean content + join baked in. */
 export function CommunityFeatureCard() {
   return (
     <FeaturePanel
@@ -39,35 +37,36 @@ export function CommunityFeatureCard() {
                 href={meta.href}
                 target="_blank"
                 rel="noreferrer"
-                className={`group/c relative flex min-h-[220px] flex-col justify-end overflow-hidden rounded-2xl border border-white/12 p-4 shadow-[0_18px_44px_-24px_rgba(0,0,0,0.9)] transition-all hover:-translate-y-0.5 ${meta.ring}`}
+                className="group/c flex flex-col overflow-hidden rounded-2xl border border-white/12 bg-[#0b0714] shadow-[0_18px_44px_-24px_rgba(0,0,0,0.9)] transition-all hover:-translate-y-0.5 hover:border-white/25"
               >
-                {/* full-bleed photo */}
-                <img
-                  src={meta.img}
-                  alt=""
-                  loading="lazy"
-                  draggable={false}
-                  className="pointer-events-none absolute inset-0 h-full w-full select-none object-cover opacity-45 transition-all duration-500 group-hover/c:scale-105 group-hover/c:opacity-60"
-                />
-                {/* darken bottom for text + brand wash */}
-                <div aria-hidden className="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#08040f] via-[#08040f]/80 to-transparent" />
-                <div aria-hidden className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${meta.wash} to-transparent`} />
+                {/* vibrant image band (full strength) */}
+                <div className="relative h-32 overflow-hidden md:h-36">
+                  <img
+                    src={meta.img}
+                    alt=""
+                    loading="lazy"
+                    draggable={false}
+                    className={`h-full w-full select-none object-cover ${meta.pos} transition-transform duration-500 group-hover/c:scale-105`}
+                  />
+                  {/* fade only the bottom edge into the card; keep the photo bright */}
+                  <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-[#0b0714] via-transparent to-transparent" />
+                  <div aria-hidden className={`absolute inset-0 bg-gradient-to-tr ${meta.wash} to-transparent mix-blend-soft-light`} />
+                  <span className="absolute left-3 top-3 grid h-9 w-9 place-items-center rounded-xl border border-white/25 bg-black/45 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.25)] backdrop-blur-sm">
+                    <NetIcon className="h-4 w-4" />
+                  </span>
+                </div>
 
-                <div className="relative">
-                  <div className="mb-2.5 flex items-center gap-2">
-                    <span className="grid h-9 w-9 place-items-center rounded-xl border border-white/25 bg-white/15 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.25)] backdrop-blur-sm">
-                      <NetIcon className="h-4 w-4" />
-                    </span>
-                    <span className="font-display text-base uppercase tracking-tight text-white text-emboss">{c.heading}</span>
-                  </div>
-                  <ul className="space-y-1">
+                {/* content */}
+                <div className="flex flex-1 flex-col p-4">
+                  <span className="font-display text-base uppercase tracking-tight text-white text-emboss">{c.heading}</span>
+                  <ul className="mt-2 space-y-1">
                     {c.points.slice(0, 4).map((p) => (
-                      <li key={p} className="flex items-center gap-1.5 text-[11px] font-medium text-white/80">
+                      <li key={p} className="flex items-center gap-1.5 text-[11px] font-medium text-white/70">
                         <Check className="h-3 w-3 shrink-0 text-sky-300" /> {p}
                       </li>
                     ))}
                   </ul>
-                  <span className="mt-3.5 inline-flex items-center gap-1.5 rounded-full bg-white/95 px-3.5 py-1.5 text-[11px] font-black uppercase tracking-wide text-[#0a0613] transition-transform group-hover/c:translate-x-0.5">
+                  <span className="mt-3.5 inline-flex w-fit items-center gap-1.5 rounded-full bg-white px-3.5 py-1.5 text-[11px] font-black uppercase tracking-wide text-[#0a0613] transition-transform group-hover/c:translate-x-0.5">
                     {meta.join} <ArrowRight className="h-3.5 w-3.5" />
                   </span>
                 </div>

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -396,7 +396,7 @@ function SecondaryRow({ leg, ip }: { leg: Leg; ip?: InPlayState }) {
           {li
             ? <span className={`inline-flex shrink-0 items-center gap-1 font-black uppercase tracking-wide ${li.landed ? 'text-emerald-300' : 'text-rose-300'}`}><span className={`h-1.5 w-1.5 rounded-full ${li.landed ? 'bg-emerald-400' : 'bg-rose-400'} [animation:pulse_1.4s_ease-in-out_infinite]`} />{li.text}</span>
             : <span className="inline-flex shrink-0 items-center gap-0.5 font-black text-[#f8e7a1]"><Clock className="h-3 w-3" />{leg.time}</span>}
-          {!li && <span className="truncate">{leg.home.name} v {leg.away.name}</span>}
+          <span className="truncate text-white/45">{leg.home.name} v {leg.away.name}</span>
         </div>
       </div>
       {/* odds + edge */}


### PR DESCRIPTION
Two fixes:

**In-play hid the teams** — on the treble rows, when a game went live the "In Play" label *replaced* the teams, so you couldn't tell which game it was. Now the teams always show alongside the live status.

**Community tiles looked muddy** — rebuilt with **full-strength image bands** (`bg-crowd` for Facebook, `bg-stadium` for Telegram) shown bright in a top band with only a bottom-edge fade, and clean content + join button below. No more washed-out 45%-opacity overlay.

`tsc --noEmit -p tsconfig.app.json` clean. Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_