### PR TITLE
Treble features upcoming value games only

### DIFF
--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -556,7 +556,11 @@ export function GafferValueBoardSection() {
 
   // The Treble — the next 3 value games after the double, one £10 punt that gives
   // the P&L a bigger swing. Only when we actually have an official double + 3 more.
-  const trebleLegs: Leg[] = featuredIsTip ? valueWatch.slice(0, 3).map((l) => withLogos(l)) : [];
+  // Treble features UPCOMING value games only — skip anything already in play or
+  // finished, so it stays clean (and never shows a stale in-play row).
+  const trebleLegs: Leg[] = featuredIsTip
+    ? valueWatch.filter((l) => matchPhase(l.time) === 'pre').slice(0, 3).map((l) => withLogos(l))
+    : [];
   const hasTreble = trebleLegs.length === 3;
 
   // Live in-play state for every selection on the board (double + treble).


### PR DESCRIPTION
Filters the treble source to pre-kickoff fixtures, so it never shows an already-in-play (or finished) row while live tracking is being sorted — it fills with the next upcoming value games instead. Still a £10 treble; just skips games already started.

Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the featured treble selection so it only includes upcoming fixtures, avoiding matches that are already in play or finished.
  * Kept treble legs empty when the featured tip option is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->