### PR TITLE
Revert treble to top value games; guarantee no overlap with the double

### DIFF
--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -544,8 +544,14 @@ export function GafferValueBoardSection() {
 
   const tips: Leg[] = bet.type === 'none' ? [] : (bet.legs as Leg[]);
   const tipIds = new Set(tips.map((l) => l.fixtureId));
-  // Value watch (NOT tips) — best-value fixtures for the fallback/rail.
-  const valueWatch = getValueFixtures().filter((p) => !tipIds.has(p.fixtureId));
+  // The treble must NEVER repeat a game from the double. Exclude by fixture id
+  // AND by team matchup — the live double can carry a different id scheme, so
+  // id-only matching could let a duplicate slip through.
+  const matchupKey = (h: string, a: string) => [norm(h), norm(a)].sort().join('|');
+  const tipMatchups = new Set(tips.map((l) => matchupKey(l.home.name, l.away.name)));
+  const valueWatch = getValueFixtures().filter(
+    (p) => !tipIds.has(p.fixtureId) && !tipMatchups.has(matchupKey(p.home.name, p.away.name)),
+  );
 
   // Featured card takes the full slip — all tip legs if we have tips, otherwise
   // the single best value pick as a "top value" callout.
@@ -556,11 +562,8 @@ export function GafferValueBoardSection() {
 
   // The Treble — the next 3 value games after the double, one £10 punt that gives
   // the P&L a bigger swing. Only when we actually have an official double + 3 more.
-  // Treble features UPCOMING value games only — skip anything already in play or
-  // finished, so it stays clean (and never shows a stale in-play row).
-  const trebleLegs: Leg[] = featuredIsTip
-    ? valueWatch.filter((l) => matchPhase(l.time) === 'pre').slice(0, 3).map((l) => withLogos(l))
-    : [];
+  // Treble = the next 3 best value games (already excludes the double's games).
+  const trebleLegs: Leg[] = featuredIsTip ? valueWatch.slice(0, 3).map((l) => withLogos(l)) : [];
   const hasTreble = trebleLegs.length === 3;
 
   // Live in-play state for every selection on the board (double + treble).


### PR DESCRIPTION
Live scores confirmed working, so the treble goes back to the next 3 best value games (removing the temporary "upcoming only" filter).

Hardened the **"treble never repeats a double game"** rule: value fixtures are now excluded by **fixture id AND team matchup** — the live double can carry a different id scheme, so id-only matching could let a duplicate through. Now it can't.

Deployed to Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_