### PR TITLE
Live scores + menu + timezone fixes, and auto-deploy to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to Cloudflare Pages
+
+# Every push to main builds the site and deploys it to the Cloudflare Pages
+# project "golden-bet-ai" on the production (main) branch — which is what the
+# custom domain thefootyoracle.com serves. Also runnable manually from the
+# Actions tab (workflow_dispatch).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Prevent overlapping deploys from racing; a newer push cancels an in-flight one.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit -p tsconfig.app.json
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Account ID is not a secret (it appears in dashboard URLs), so it's
+          # inline here — the only repo secret you need is CLOUDFLARE_API_TOKEN.
+          accountId: 964cd8ee33ecf4e58a581f4806cd0cb5
+          command: pages deploy dist --project-name=golden-bet-ai --branch=main

--- a/functions/api/live.ts
+++ b/functions/api/live.ts
@@ -1,36 +1,69 @@
 // Cloudflare Pages Function — live scores from API-Football.
 // GET /api/live  ->  { ok, data: [ { home, away, gh, ga, elapsed, status } ] }
 //
-// One upstream call returns every live fixture worldwide. Free tier is 100
-// req/day, so we cache the upstream response hard at the edge (cf.cacheTtl)
-// and the client only polls while a pick is actually in its match window —
-// which keeps real usage far under the cap.
+// API-Football free tier is 100 req/day, so we must cache hard — BUT we must
+// never cache an empty/failed upstream response (that used to get pinned at the
+// edge for 15 min, so some page loads saw scores and some saw nothing). Instead
+// we keep the last GOOD payload in the edge Cache API and:
+//   • serve it straight back while it's fresh (< FRESH_MS) — no upstream call;
+//   • refresh from upstream when stale, and only overwrite the cache on success;
+//   • if upstream is empty/rate-limited/errors, serve the last-good data (even
+//     if a little stale) rather than an empty list.
 interface Env {
   APIFOOTBALL_KEY: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
+type LiveRow = { home: string; away: string; gh: number; ga: number; elapsed: number | null; status: string };
+
+const FRESH_MS = 120_000; // treat cached scores as fresh for 2 min (no upstream call)
+const KEEP_S = 3600;      // keep last-good in the edge cache up to 1h for fallback
+
+const jsonHeaders = (cacheControl: string) => ({
+  "content-type": "application/json",
+  "access-control-allow-origin": "*",
+  "cache-control": cacheControl,
+});
 
 export const onRequest: PagesFunction<Env> = async (context) => {
-  const headers = {
-    "content-type": "application/json",
-    "access-control-allow-origin": "*",
-    "cache-control": "public, max-age=120",
-  };
   const key = context.env.APIFOOTBALL_KEY;
   if (!key) {
-    return new Response(JSON.stringify({ ok: false, error: "missing_key" }), { status: 500, headers });
+    return new Response(JSON.stringify({ ok: false, error: "missing_key" }), {
+      status: 500,
+      headers: jsonHeaders("no-store"),
+    });
   }
 
+  const cache = (caches as Any).default;
+  // Single global-ish key (per edge location). We do our own freshness check via
+  // the embedded timestamp, so store with a long max-age for fallback reuse.
+  const cacheKey = new Request("https://footyoracle.internal/api/live-scores-v1");
+  const now = Date.now();
+
+  // 1. Last stored GOOD payload (may be stale).
+  let stored: { ts: number; data: LiveRow[] } | null = null;
+  try {
+    const hit = await cache.match(cacheKey);
+    if (hit) stored = (await hit.json()) as { ts: number; data: LiveRow[] };
+  } catch {
+    stored = null;
+  }
+
+  // 2. Fresh enough → serve immediately, no upstream call.
+  if (stored && now - stored.ts < FRESH_MS) {
+    return new Response(JSON.stringify({ ok: true, data: stored.data }), {
+      headers: jsonHeaders("public, max-age=60"),
+    });
+  }
+
+  // 3. Refresh from upstream.
   try {
     const res = await fetch("https://v3.football.api-sports.io/fixtures?live=all", {
       headers: { "x-apisports-key": key },
-      // Cache the (expensive, rate-limited) upstream call at the edge for 15 min.
-      cf: { cacheTtl: 900, cacheEverything: true },
-    } as RequestInit);
+    });
     const body = (await res.json()) as { response?: Any[] };
-    const data = (body.response || []).map((f: Any) => ({
+    const data: LiveRow[] = (body.response || []).map((f: Any) => ({
       home: f?.teams?.home?.name ?? "",
       away: f?.teams?.away?.name ?? "",
       gh: f?.goals?.home ?? 0,
@@ -38,8 +71,30 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       elapsed: f?.fixture?.status?.elapsed ?? null,
       status: f?.fixture?.status?.short ?? "",
     }));
-    return new Response(JSON.stringify({ ok: true, data }), { headers });
+
+    if (res.ok && data.length > 0) {
+      // Only ever cache a GOOD, non-empty response.
+      const payload = JSON.stringify({ ts: now, data });
+      context.waitUntil(
+        cache.put(cacheKey, new Response(payload, { headers: { "cache-control": `public, max-age=${KEEP_S}` } })),
+      );
+      return new Response(JSON.stringify({ ok: true, data }), {
+        headers: jsonHeaders("public, max-age=60"),
+      });
+    }
+
+    // Upstream empty / rate-limited / errored → serve last-good, never a pinned empty.
+    if (stored) {
+      return new Response(JSON.stringify({ ok: true, data: stored.data }), { headers: jsonHeaders("no-store") });
+    }
+    return new Response(JSON.stringify({ ok: true, data: [] }), { headers: jsonHeaders("no-store") });
   } catch {
-    return new Response(JSON.stringify({ ok: false, error: "fetch_failed" }), { status: 502, headers });
+    if (stored) {
+      return new Response(JSON.stringify({ ok: true, data: stored.data }), { headers: jsonHeaders("no-store") });
+    }
+    return new Response(JSON.stringify({ ok: false, error: "fetch_failed" }), {
+      status: 502,
+      headers: jsonHeaders("no-store"),
+    });
   }
 };

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { Trophy, Star, Coins, ArrowRight, Telescope, Ticket, Activity, BarChart3, Swords, Check, Layers, Clock } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { TeamAvatar } from '@/components/TeamAvatar';
-import { getDailyBet, getGafferPicks, getValueFixtures, type Leg, type DailyBet } from '@/lib/gafferSelection';
+import { getDailyBet, getGafferPicks, getValueFixtures, getValueCandidates, type Leg, type DailyBet } from '@/lib/gafferSelection';
 import { useLiveDailyPicks } from './useLiveDailyPicks';
 import { useInPlay, type InPlayState } from './useInPlay';
 import { useLiveScores, matchLive, type LiveScore } from './useLiveScores';
@@ -125,6 +125,38 @@ const SNAP = (rawSnapshot as unknown as { fixtures: FormFixtureRow[] }).fixtures
 // ── snapshot enrichment: form %, league average, head-to-head hit rate ──────
 const norm = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
 const lineOf = (selection: string) => { const m = selection.match(/(\d+(?:\.\d+)?)/); return m ? Number(m[1]) : 0; };
+
+/** Choose the treble for MARKET VARIETY: best-edge leg per market first (so it
+ *  isn't three of the same market), then fill remaining slots by edge. Never
+ *  repeats a fixture and never reuses one of the double's games. */
+function pickDiverseTreble(
+  pool: Leg[],
+  excludeIds: Set<string>,
+  excludeMatchups: Set<string>,
+  matchupKey: (h: string, a: string) => string,
+  n = 3,
+): Leg[] {
+  const chosen: Leg[] = [];
+  const usedFixtures = new Set<string>();
+  const usedMarkets = new Set<string>();
+  const eligible = (l: Leg) =>
+    !excludeIds.has(l.fixtureId) &&
+    !excludeMatchups.has(matchupKey(l.home.name, l.away.name)) &&
+    !usedFixtures.has(l.fixtureId);
+  // Pass 1 — at most one leg per market, highest edge first.
+  for (const l of pool) {
+    if (chosen.length >= n) break;
+    if (!eligible(l) || usedMarkets.has(l.market)) continue;
+    chosen.push(l); usedFixtures.add(l.fixtureId); usedMarkets.add(l.market);
+  }
+  // Pass 2 — fill any remaining slots with the next best legs (unique fixtures).
+  for (const l of pool) {
+    if (chosen.length >= n) break;
+    if (!eligible(l)) continue;
+    chosen.push(l); usedFixtures.add(l.fixtureId);
+  }
+  return chosen;
+}
 
 function findFixture(leg: Leg): FormFixtureRow | undefined {
   const h = norm(leg.home.name), a = norm(leg.away.name);
@@ -571,27 +603,72 @@ export function GafferValueBoardSection() {
   const updatedAt = live?.updatedAt ?? null;
 
   const tips: Leg[] = bet.type === 'none' ? [] : (bet.legs as Leg[]);
-  const tipIds = new Set(tips.map((l) => l.fixtureId));
-  // The treble must NEVER repeat a game from the double. Exclude by fixture id
-  // AND by team matchup — the live double can carry a different id scheme, so
-  // id-only matching could let a duplicate slip through.
   const matchupKey = (h: string, a: string) => [norm(h), norm(a)].sort().join('|');
-  const tipMatchups = new Set(tips.map((l) => matchupKey(l.home.name, l.away.name)));
+
+  // Settlement state for the official legs — a leg the feed marks complete has
+  // already won/lost, so we must keep it (never swap a settled result out).
+  const { data: tipSettle } = useInPlay(tips.map((l) => l.fixtureId));
+  const settled = (l: Leg) => !!tipSettle?.[l.fixtureId]?.ended;
+
+  // Only ever feature games you can still back: upcoming value games (not yet
+  // kicked off), best edge first.
+  const upcomingPool = getValueCandidates().filter((l) => legPhase(l) === 'pre');
+
+  // Swap out ONLY games that are currently in play — you can't freshly back a
+  // game that's mid-match. Upcoming picks AND already-settled (won/lost) legs are
+  // left exactly as they are, so a winning leg keeps showing its result. Swaps
+  // pull the next best upcoming value game, never duplicating one on the slip.
+  const freshTips: Leg[] = (() => {
+    if (tips.length === 0) return [];
+    const usedId = new Set<string>();
+    const usedM = new Set<string>();
+    const keep = (l: Leg) => legPhase(l) !== 'live' || settled(l); // upcoming, or already won/lost
+    for (const l of tips) {
+      if (keep(l)) { usedId.add(l.fixtureId); usedM.add(matchupKey(l.home.name, l.away.name)); }
+    }
+    return tips.map((l) => {
+      if (keep(l)) return l; // keep upcoming and already-decided legs
+      const rep = upcomingPool.find((p) => !usedId.has(p.fixtureId) && !usedM.has(matchupKey(p.home.name, p.away.name)));
+      if (!rep) return l; // nothing upcoming to swap in — leave it as-is
+      usedId.add(rep.fixtureId); usedM.add(matchupKey(rep.home.name, rep.away.name));
+      return rep;
+    });
+  })();
+
+  const tipIds = new Set(freshTips.map((l) => l.fixtureId));
+  const tipMatchups = new Set(freshTips.map((l) => matchupKey(l.home.name, l.away.name)));
+
+  // If a leg was swapped, recompute the £10 slip's odds + returns so they stay honest.
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const swapped = freshTips.some((l, i) => l !== tips[i]);
+  const displayBet: DailyBet =
+    bet.type !== 'none' && swapped
+      ? ({
+          ...bet,
+          legs: freshTips,
+          combinedOdds: round2(freshTips.reduce((p, l) => p * l.odds, 1)),
+          returns: round2(bet.stake * freshTips.reduce((p, l) => p * l.odds, 1)),
+        } as DailyBet)
+      : bet;
+
   const valueWatch = getValueFixtures().filter(
     (p) => !tipIds.has(p.fixtureId) && !tipMatchups.has(matchupKey(p.home.name, p.away.name)),
   );
 
   // Featured card takes the full slip — all tip legs if we have tips, otherwise
   // the single best value pick as a "top value" callout.
-  const featuredLegs: Leg[] = tips.length > 0
-    ? tips.map((l) => withLogos(l))
+  const featuredLegs: Leg[] = freshTips.length > 0
+    ? freshTips.map((l) => withLogos(l))
     : (valueWatch[0] ? [withLogos(valueWatch[0])] : []);
-  const featuredIsTip = tips.length > 0;
+  const featuredIsTip = freshTips.length > 0;
 
-  // The Treble — the next 3 value games after the double, one £10 punt that gives
-  // the P&L a bigger swing. Only when we actually have an official double + 3 more.
-  // Treble = the next 3 best value games (already excludes the double's games).
-  const trebleLegs: Leg[] = featuredIsTip ? valueWatch.slice(0, 3).map((l) => withLogos(l)) : [];
+  // The Treble — three more UPCOMING value games after the double, one £10 punt
+  // that gives the P&L a bigger swing. Picked for MARKET VARIETY (not three of
+  // the same market): best-edge leg per market first, then fill by edge. Excludes
+  // the double's games and never repeats a fixture.
+  const trebleLegs: Leg[] = featuredIsTip
+    ? pickDiverseTreble(upcomingPool, tipIds, tipMatchups, matchupKey).map((l) => withLogos(l))
+    : [];
   const hasTreble = trebleLegs.length === 3;
 
   // Live in-play state for every selection on the board (double + treble).
@@ -652,7 +729,7 @@ export function GafferValueBoardSection() {
 
         {/* Featured — includes ALL tip legs (single, double, multi) */}
         {featuredLegs.length > 0 ? (
-          <div className="mt-6"><FeaturedCard legs={featuredLegs} isTip={featuredIsTip} bet={bet} inplay={inplay} liveList={liveList} /></div>
+          <div className="mt-6"><FeaturedCard legs={featuredLegs} isTip={featuredIsTip} bet={displayBet} inplay={inplay} liveList={liveList} /></div>
         ) : (
           <div className="mt-6 rounded-2xl border border-white/10 bg-[#0b0518]/80 p-6 text-center text-white/70">
             <h3 className="font-display text-2xl uppercase text-white">No bet today.</h3>
@@ -665,7 +742,7 @@ export function GafferValueBoardSection() {
 
         {/* Slip fallback only when there are no tips today */}
         {!featuredIsTip && (
-          <div className="mt-4"><SlipCard bet={bet} /></div>
+          <div className="mt-4"><SlipCard bet={displayBet} /></div>
         )}
 
 

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -31,6 +31,19 @@ function matchPhase(timeStr: string): 'pre' | 'live' | 'ended' {
   if (nowMin < koMin + 130) return 'live';
   return 'ended';
 }
+// Prefer the absolute kickoff (timezone-independent) so live/ended is correct for
+// a viewer anywhere in the world; fall back to the UK-clock string when we only
+// have a display time (e.g. the bundled value-watch slate).
+function legPhase(leg: { time: string; kickoffMs?: number | null }): 'pre' | 'live' | 'ended' {
+  const ms = leg.kickoffMs;
+  if (ms != null && Number.isFinite(ms)) {
+    const now = Date.now();
+    if (now < ms) return 'pre';
+    if (now < ms + 130 * 60_000) return 'live';
+    return 'ended';
+  }
+  return matchPhase(leg.time);
+}
 // A selection's live/finished status. FootyStats has no live scores on this
 // plan, so 'live' is time-based (badge only). Once a match is complete it
 // carries the FINAL numbers, so 'ft' shows the score + a settled Won/Lost.
@@ -65,7 +78,7 @@ function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | 
   }
   // No live data (e.g. corners-only markets, or match not on the live feed) —
   // fall back to the time-based badge so it still reads as in-play.
-  if (matchPhase(leg.time) === 'live') return { state: 'live', text: 'In Play' };
+  if (legPhase(leg) === 'live') return { state: 'live', text: 'In Play' };
   return null;
 }
 
@@ -586,7 +599,7 @@ export function GafferValueBoardSection() {
   const inplayIds = boardLegs.map((l) => l.fixtureId);
   const { data: inplay } = useInPlay(inplayIds);
   // Real live scores (API-Football) — only poll while a pick is in its window.
-  const anyLive = boardLegs.some((l) => matchPhase(l.time) === 'live');
+  const anyLive = boardLegs.some((l) => legPhase(l) === 'live');
   const { data: liveList } = useLiveScores(anyLive);
 
   const activeCount = featuredIsTip ? tips.length + trebleLegs.length : valueWatch.length;

--- a/src/components/homepage/content.ts
+++ b/src/components/homepage/content.ts
@@ -23,14 +23,17 @@ export const SOCIAL_LINKS = {
 } as const;
 
 /* ── Top navigation ───────────────────────────────────────────────────── */
+// Menu targets: on-page anchors that actually exist on the homepage, plus the
+// real tool pages for Form Tables / Fantasy / P&L. (The old #form-tables and
+// #gaffer-story anchors were dead — those sections were removed, so tapping
+// them did nothing.)
 export const NAV_LINKS = [
-  { label: 'Predictions', href: '#tip-of-the-day' },
+  { label: 'Predictions', href: '#daily-picks' },
+  { label: 'Form Tables', href: '/form-tables' },
+  { label: 'Fantasy League', href: '/fantasy-league' },
+  { label: 'P&L', href: '/pnl' },
   { label: 'Articles', href: '#latest-articles' },
-  { label: 'Tips', href: '#tip-of-the-day' },
-  { label: 'Form Tables', href: '#form-tables' },
-  { label: 'Fantasy League', href: '#fantasy-league' },
   { label: 'Community', href: '#community' },
-  { label: 'About The Gaffer', href: '#gaffer-story' },
 ] as const;
 
 /* ── Feature strip (editable cards under the hero) ────────────────────── */

--- a/src/components/homepage/useLiveDailyPicks.ts
+++ b/src/components/homepage/useLiveDailyPicks.ts
@@ -51,6 +51,7 @@ function rawLegToLeg(raw: RawPickLeg, i: number): Leg {
   const odds = toNumber(raw.best_price ?? raw.odds ?? raw.price, 1);
   const prob = normConf(raw.confidence ?? raw.probability ?? raw.formProb, 72);
   const edge = toNumber(raw.edge, Math.max(1, prob - Math.round(100 / Math.max(odds, 1))));
+  const koMs = raw.kickoff_time ? Date.parse(raw.kickoff_time) : NaN;
   return {
     fixtureId: raw.fixtureId ?? raw.fixture_id ?? `${home}-${away}-${i}`,
     home: { name: home, short: home.slice(0, 3).toUpperCase(), logo: raw.home_logo ?? raw.homeLogo ?? null },
@@ -58,6 +59,7 @@ function rawLegToLeg(raw: RawPickLeg, i: number): Leg {
     region: raw.region ?? 'Today',
     league: raw.league ?? 'Featured fixture',
     time: formatKO(raw.kickoff_time ?? raw.time),
+    kickoffMs: Number.isFinite(koMs) ? koMs : null,
     market: market.toLowerCase().includes('corner') ? 'Corners' : market.toLowerCase().includes('btts') ? 'BTTS' : 'Goals',
     selection, odds, prob, edge,
     flag: edge >= 8 ? 'strong' : 'value',

--- a/src/components/homepage/useLiveScores.ts
+++ b/src/components/homepage/useLiveScores.ts
@@ -19,16 +19,30 @@ export function useLiveScores(enabled: boolean) {
   });
 }
 
-const norm = (s: string) => s.normalize('NFKD').replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+// Diacritic-stripped, punctuation-free compact form ("ÍA" -> "ia", "Daegu FC" -> "daegufc").
+const compact = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+// Word tokens, diacritics stripped ("ÍA Akranes" -> ["ia","akranes"]).
+const words = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
 
-/** Match a fixture (by team names) to a live score. Names differ across feeds
- *  (e.g. "Daegu" vs "Daegu FC"), so we match on containment either way round. */
+/** Do two team names refer to the same club across feeds? Handles "Daegu" vs
+ *  "Daegu FC" (containment) AND short/abbreviated names like "ÍA" vs "ÍA
+ *  Akranes" — where one side's whole name is a standalone word of the other,
+ *  which the old ≥3-char containment guard wrongly rejected. */
+const sameTeam = (a: string, b: string): boolean => {
+  const ca = compact(a), cb = compact(b);
+  if (!ca || !cb) return false;
+  if (ca === cb) return true;
+  if (ca.length >= 4 && cb.length >= 4 && (ca.includes(cb) || cb.includes(ca))) return true;
+  // Short-name case: the full compact of one side appears as a whole word of the other.
+  return words(a).includes(cb) || words(b).includes(ca);
+};
+
+/** Match a fixture (by team names) to a live score, either way round. */
 export function matchLive(home: string, away: string, list: LiveScore[] | undefined): LiveScore | undefined {
   if (!list?.length) return undefined;
-  const h = norm(home), a = norm(away);
-  const hit = (x: string, y: string) => x.length >= 3 && y.length >= 3 && (x.includes(y) || y.includes(x));
-  return list.find((l) => {
-    const lh = norm(l.home), la = norm(l.away);
-    return (hit(lh, h) && hit(la, a)) || (hit(lh, a) && hit(la, h));
-  });
-}
+  return list.find(
+    (l) =>
+      (sameTeam(l.home, home) && sameTeam(l.away, away)) ||
+      (sameTeam(l.home, away) && sameTeam(l.away, home)),
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 /* Font loaded via index.html for non-render-blocking */
 
+/* Smooth in-page menu jumps, offset so targets clear the sticky header. */
+html { scroll-behavior: smooth; }
+:target { scroll-margin-top: 120px; }
+
 /* ── Copy Protection ── */
 body {
   -webkit-user-select: none;

--- a/src/lib/gafferSelection.ts
+++ b/src/lib/gafferSelection.ts
@@ -21,6 +21,9 @@ export interface Leg {
   home: { name: string; short: string; logo: string | null };
   away: { name: string; short: string; logo: string | null };
   region: string; league: string; time: string;
+  // Absolute kickoff (epoch ms) when known — lets us show the time in the
+  // viewer's own timezone and detect live/ended correctly anywhere in the world.
+  kickoffMs?: number | null;
   market: 'Goals' | 'Corners' | 'BTTS';
   selection: string;      // 'Over 9.5 Corners'
   odds: number;

--- a/src/lib/gafferSelection.ts
+++ b/src/lib/gafferSelection.ts
@@ -105,6 +105,32 @@ export function getValueFixtures(): Leg[] {
   return best.sort((a, b) => b.edge - a.edge);
 }
 
+/**
+ * Every qualifying value leg today across ALL markets (not deduped to one per
+ * fixture), best edge first. Used to assemble a market-diverse treble so it
+ * isn't three of the same market when other markets have value too.
+ */
+export function getValueCandidates(): Leg[] {
+  const makeLeg = (f: FormFixtureRow, market: Leg['market'], selection: string, cell: FormValueCell): Leg => ({
+    fixtureId: f.id, home: f.home, away: f.away, region: f.region, league: f.league, time: f.time,
+    market, selection, odds: cell.odds!, prob: cell.prob, edge: cell.edge, flag: cell.flag ?? 'value',
+    placeholderReason: gafferReason(
+      { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value' },
+      f.id,
+    ),
+  });
+  const today = todayUK();
+  const out: Leg[] = [];
+  const ok = (c: FormValueCell | null | undefined) => !!c?.odds && c.odds >= 1.4 && c.prob >= 60;
+  for (const f of DATA.fixtures) {
+    if (f.date !== today) continue;
+    for (const [mk, cell] of Object.entries(f.value.corners ?? {})) if (ok(cell)) out.push(makeLeg(f, 'Corners', `Over ${mk} Corners`, cell!));
+    for (const [mk, cell] of Object.entries(f.value.goals ?? {})) if (ok(cell)) out.push(makeLeg(f, 'Goals', `Over ${mk} Goals`, cell!));
+    if (ok(f.value.btts)) out.push(makeLeg(f, 'BTTS', 'BTTS – Yes', f.value.btts!));
+  }
+  return out.sort((a, b) => b.edge - a.edge);
+}
+
 /** The day's bet: £10 double if 2 qualify, else £10 single, else none. */
 export function getDailyBet(picks: Leg[] = getGafferPicks()): DailyBet {
   if (picks.length >= 2) {


### PR DESCRIPTION
Lands today's fixes and turns on hands-off deploys.

## Live scores
- `/api/live` no longer caches empty/rate-limited responses at the edge (that was pinning an empty feed for 15 min, so scores flickered in and out). It now keeps the last-good scores and only ever caches a non-empty result.
- Team-name matching now handles short/abbreviated clubs (e.g. `ÍA`, which normalised to `ia` and could never match `ÍA Akranes` under the old ≥3-char guard). Verified no false positives.

## Timezone
- Kickoff times render in each viewer's local timezone, and live/ended detection now uses the absolute kickoff time (`kickoffMs`) instead of a hardcoded UK clock — so "In Play" is correct for viewers anywhere.

## Homepage menu
- Menu items pointed at anchors on removed sections (`#form-tables`, `#gaffer-story`) did nothing. Rewired: Predictions/Articles/Community → real on-page anchors; Form Tables / Fantasy League / P&L → their actual pages. Dropped the dead "About The Gaffer" and duplicate "Tips" links, and added a scroll offset so anchor jumps clear the sticky header.

## CI / auto-deploy
- New GitHub Actions workflow builds, type-checks, and deploys to the `golden-bet-ai` Cloudflare Pages project (production/`main`) on every push to `main` — which is what `thefootyoracle.com` serves. Requires one repo secret: `CLOUDFLARE_API_TOKEN` (already added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic deployment for the site on pushes to the main branch, with manual deploy support.
  - Updated homepage navigation with new routes and links, including a new P&L page.

- **Bug Fixes**
  - Improved live-score and match detection so results stay accurate across time zones, accents, and abbreviated team names.
  - Made live data handling more reliable by keeping the last known good update when fresh data is unavailable.
  - Added smoother in-page navigation so section links land correctly beneath the sticky header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->