### PR TITLE
Value-ranked board: best 2 = double, next 3 = treble (any market)

### DIFF
--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { Trophy, Star, Coins, ArrowRight, Telescope, Ticket, Activity, BarChart3, Swords, Check, Layers, Clock } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { TeamAvatar } from '@/components/TeamAvatar';
-import { getDailyBet, getGafferPicks, getValueFixtures, getValueCandidates, type Leg, type DailyBet } from '@/lib/gafferSelection';
+import { getValueCandidates, STAKE, type Leg, type DailyBet } from '@/lib/gafferSelection';
 import { useLiveDailyPicks } from './useLiveDailyPicks';
 import { useInPlay, type InPlayState } from './useInPlay';
 import { useLiveScores, matchLive, type LiveScore } from './useLiveScores';
@@ -125,38 +125,6 @@ const SNAP = (rawSnapshot as unknown as { fixtures: FormFixtureRow[] }).fixtures
 // ── snapshot enrichment: form %, league average, head-to-head hit rate ──────
 const norm = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
 const lineOf = (selection: string) => { const m = selection.match(/(\d+(?:\.\d+)?)/); return m ? Number(m[1]) : 0; };
-
-/** Choose the treble for MARKET VARIETY: best-edge leg per market first (so it
- *  isn't three of the same market), then fill remaining slots by edge. Never
- *  repeats a fixture and never reuses one of the double's games. */
-function pickDiverseTreble(
-  pool: Leg[],
-  excludeIds: Set<string>,
-  excludeMatchups: Set<string>,
-  matchupKey: (h: string, a: string) => string,
-  n = 3,
-): Leg[] {
-  const chosen: Leg[] = [];
-  const usedFixtures = new Set<string>();
-  const usedMarkets = new Set<string>();
-  const eligible = (l: Leg) =>
-    !excludeIds.has(l.fixtureId) &&
-    !excludeMatchups.has(matchupKey(l.home.name, l.away.name)) &&
-    !usedFixtures.has(l.fixtureId);
-  // Pass 1 — at most one leg per market, highest edge first.
-  for (const l of pool) {
-    if (chosen.length >= n) break;
-    if (!eligible(l) || usedMarkets.has(l.market)) continue;
-    chosen.push(l); usedFixtures.add(l.fixtureId); usedMarkets.add(l.market);
-  }
-  // Pass 2 — fill any remaining slots with the next best legs (unique fixtures).
-  for (const l of pool) {
-    if (chosen.length >= n) break;
-    if (!eligible(l)) continue;
-    chosen.push(l); usedFixtures.add(l.fixtureId);
-  }
-  return chosen;
-}
 
 function findFixture(leg: Leg): FormFixtureRow | undefined {
   const h = norm(leg.home.name), a = norm(leg.away.name);
@@ -597,79 +565,38 @@ export function GafferValueBoardSection() {
   const { data: live } = useLiveDailyPicks();
   const { data: monthProfit } = useMonthProfit();
 
-  // Official tips: live pick first, else the flagged snapshot bet.
-  const liveBet = live?.bet;
-  const bet: DailyBet = liveBet && liveBet.type !== 'none' ? liveBet : getDailyBet(getGafferPicks());
   const updatedAt = live?.updatedAt ?? null;
 
-  const tips: Leg[] = bet.type === 'none' ? [] : (bet.legs as Leg[]);
-  const matchupKey = (h: string, a: string) => [norm(h), norm(a)].sort().join('|');
-
-  // Settlement state for the official legs — a leg the feed marks complete has
-  // already won/lost, so we must keep it (never swap a settled result out).
-  const { data: tipSettle } = useInPlay(tips.map((l) => l.fixtureId));
-  const settled = (l: Leg) => !!tipSettle?.[l.fixtureId]?.ended;
-
-  // Only ever feature games you can still back: upcoming value games (not yet
-  // kicked off), best edge first.
-  const upcomingPool = getValueCandidates().filter((l) => legPhase(l) === 'pre');
-
-  // Swap out ONLY games that are currently in play — you can't freshly back a
-  // game that's mid-match. Upcoming picks AND already-settled (won/lost) legs are
-  // left exactly as they are, so a winning leg keeps showing its result. Swaps
-  // pull the next best upcoming value game, never duplicating one on the slip.
-  const freshTips: Leg[] = (() => {
-    if (tips.length === 0) return [];
-    const usedId = new Set<string>();
-    const usedM = new Set<string>();
-    const keep = (l: Leg) => legPhase(l) !== 'live' || settled(l); // upcoming, or already won/lost
-    for (const l of tips) {
-      if (keep(l)) { usedId.add(l.fixtureId); usedM.add(matchupKey(l.home.name, l.away.name)); }
+  // ── Value-ranked board ──────────────────────────────────────────────────
+  // The board is driven purely by the value tables: the best 2 value picks (any
+  // market — goals, corners or BTTS) form the £10 double, the next 3 the £10
+  // treble. One pick per fixture, ranked by value (edge). Games still to come or
+  // in play rank ahead of finished ones, so the board stays current and never
+  // shows a dead game while there's a live/upcoming one to show.
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const rankedPicks: Leg[] = (() => {
+    const bestPerFixture = new Map<string, Leg>();
+    for (const l of getValueCandidates()) { // already sorted by edge desc
+      if (!bestPerFixture.has(l.fixtureId)) bestPerFixture.set(l.fixtureId, l);
     }
-    return tips.map((l) => {
-      if (keep(l)) return l; // keep upcoming and already-decided legs
-      const rep = upcomingPool.find((p) => !usedId.has(p.fixtureId) && !usedM.has(matchupKey(p.home.name, p.away.name)));
-      if (!rep) return l; // nothing upcoming to swap in — leave it as-is
-      usedId.add(rep.fixtureId); usedM.add(matchupKey(rep.home.name, rep.away.name));
-      return rep;
-    });
+    const finishedLast = (l: Leg) => (legPhase(l) === 'ended' ? 1 : 0);
+    return [...bestPerFixture.values()].sort((a, b) => finishedLast(a) - finishedLast(b) || b.edge - a.edge);
   })();
 
-  const tipIds = new Set(freshTips.map((l) => l.fixtureId));
-  const tipMatchups = new Set(freshTips.map((l) => matchupKey(l.home.name, l.away.name)));
-
-  // If a leg was swapped, recompute the £10 slip's odds + returns so they stay honest.
-  const round2 = (n: number) => Math.round(n * 100) / 100;
-  const swapped = freshTips.some((l, i) => l !== tips[i]);
-  const displayBet: DailyBet =
-    bet.type !== 'none' && swapped
-      ? ({
-          ...bet,
-          legs: freshTips,
-          combinedOdds: round2(freshTips.reduce((p, l) => p * l.odds, 1)),
-          returns: round2(bet.stake * freshTips.reduce((p, l) => p * l.odds, 1)),
-        } as DailyBet)
-      : bet;
-
-  const valueWatch = getValueFixtures().filter(
-    (p) => !tipIds.has(p.fixtureId) && !tipMatchups.has(matchupKey(p.home.name, p.away.name)),
-  );
-
-  // Featured card takes the full slip — all tip legs if we have tips, otherwise
-  // the single best value pick as a "top value" callout.
-  const featuredLegs: Leg[] = freshTips.length > 0
-    ? freshTips.map((l) => withLogos(l))
-    : (valueWatch[0] ? [withLogos(valueWatch[0])] : []);
-  const featuredIsTip = freshTips.length > 0;
-
-  // The Treble — three more UPCOMING value games after the double, one £10 punt
-  // that gives the P&L a bigger swing. Picked for MARKET VARIETY (not three of
-  // the same market): best-edge leg per market first, then fill by edge. Excludes
-  // the double's games and never repeats a fixture.
-  const trebleLegs: Leg[] = featuredIsTip
-    ? pickDiverseTreble(upcomingPool, tipIds, tipMatchups, matchupKey).map((l) => withLogos(l))
-    : [];
+  const doubleLegs: Leg[] = rankedPicks.slice(0, 2).map((l) => withLogos(l));
+  const trebleLegs: Leg[] = rankedPicks.slice(2, 5).map((l) => withLogos(l));
+  const featuredLegs = doubleLegs;
+  const featuredIsTip = doubleLegs.length > 0;
   const hasTreble = trebleLegs.length === 3;
+
+  // £10 double built from the two best value picks.
+  const combined = round2(doubleLegs.reduce((p, l) => p * l.odds, 1));
+  const displayBet: DailyBet =
+    doubleLegs.length >= 2
+      ? { type: 'double', legs: [doubleLegs[0], doubleLegs[1]], combinedOdds: combined, stake: STAKE, returns: round2(STAKE * combined) }
+      : doubleLegs.length === 1
+        ? { type: 'single', legs: [doubleLegs[0]], combinedOdds: doubleLegs[0].odds, stake: STAKE, returns: round2(STAKE * doubleLegs[0].odds) }
+        : { type: 'none', legs: [] };
 
   // Live in-play state for every selection on the board (double + treble).
   const boardLegs = [...featuredLegs, ...trebleLegs];
@@ -679,7 +606,7 @@ export function GafferValueBoardSection() {
   const anyLive = boardLegs.some((l) => legPhase(l) === 'live');
   const { data: liveList } = useLiveScores(anyLive);
 
-  const activeCount = featuredIsTip ? tips.length + trebleLegs.length : valueWatch.length;
+  const activeCount = doubleLegs.length + trebleLegs.length;
 
   const profit = monthProfit ?? 48; // sample until first settlements
 


### PR DESCRIPTION
Drives the homepage picks board purely off the value tables:

- One pick per fixture, ranked by value (edge), across any market (goals / corners / BTTS).
- **Best 2 value picks → the £10 double. Next 3 → the £10 treble.**
- Games still to come or in play rank ahead of finished ones, so finished/dead games drop off and the board stays current and always full.
- Removes the earlier in-play swap logic (superseded by pure value ranking).
- Adds `getValueCandidates()` (all-market value legs) and exports `STAKE`.

Note: the dataset currently prices goals/corners/BTTS only — cards is not yet a computed value market.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_