### PR TITLE
Board rule, timezone-correct kickoffs, Gaffer banter, error boundaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,9 +40,13 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
+        # Account ID is not a secret (it appears in dashboard URLs); the only repo
+        # secret needed is CLOUDFLARE_API_TOKEN. Passed via both the action input
+        # and env so wrangler always sees it.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: 964cd8ee33ecf4e58a581f4806cd0cb5
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          # Account ID is not a secret (it appears in dashboard URLs), so it's
-          # inline here — the only repo secret you need is CLOUDFLARE_API_TOKEN.
           accountId: 964cd8ee33ecf4e58a581f4806cd0cb5
           command: pages deploy dist --project-name=golden-bet-ai --branch=main

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -578,22 +578,22 @@ export function GafferValueBoardSection() {
     for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l); // sorted by edge desc
     return [...best.values()];
   })();
-  // Settlement for any game that has kicked off (live or finished) so we know
-  // which completed games WON.
+  // Settlement for games that have kicked off, so a finished LOSER doesn't sit on
+  // the board (and we can tell it from a winner).
   const checkIds = candidates.slice(0, 16).filter((l) => legPhase(l) !== 'pre').map((l) => l.fixtureId);
   const { data: settle } = useInPlay(checkIds);
 
-  // Board rule: keep every COMPLETED winner (proof), and fill the rest with games
-  // YET TO PLAY. A game that's in play is swapped out for one yet to play; games
-  // that finished and lost never show. Best value (edge) first within that.
-  const eligible = candidates.filter((l) => {
+  // Pure value ranking — top 2 = the £10 double, next 3 = the £10 treble — with two
+  // skips only: a game that's IN PLAY (today's in-play data is unreliable) and a
+  // game that FINISHED and LOST. Their slots go to the next value game. Winners and
+  // games yet to play stay exactly where the value ranks them.
+  const rankedPicks = candidates.filter((l) => {
     const ip = settle?.[l.fixtureId];
-    if (ip?.ended) return settleLeg(l, ip) === 'won'; // finished → keep only winners
-    return legPhase(l) === 'pre';                      // not finished → keep only upcoming (drop in-play)
+    if (ip?.ended) return settleLeg(l, ip) !== 'lost'; // finished → drop losers, keep winners
+    return legPhase(l) !== 'live';                      // not finished → drop in-play, keep upcoming
   });
-
-  const doubleLegs: Leg[] = eligible.slice(0, 2).map((l) => withLogos(l));
-  const trebleLegs: Leg[] = eligible.slice(2, 5).map((l) => withLogos(l));
+  const doubleLegs: Leg[] = rankedPicks.slice(0, 2).map((l) => withLogos(l));
+  const trebleLegs: Leg[] = rankedPicks.slice(2, 5).map((l) => withLogos(l));
   const featuredLegs = doubleLegs;
   const featuredIsTip = doubleLegs.length > 0;
   const hasTreble = trebleLegs.length === 3;

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -578,15 +578,27 @@ export function GafferValueBoardSection() {
     for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l); // sorted by edge desc
     return [...best.values()];
   })();
-  // Settlement only for finished games among the top contenders — enough to drop
-  // losers and keep winners, without polling every fixture on the card.
-  const endedIds = candidates.slice(0, 12).filter((l) => legPhase(l) === 'ended').map((l) => l.fixtureId);
+  // Settlement for finished games among the top contenders, so we know winners.
+  const endedIds = candidates.slice(0, 14).filter((l) => legPhase(l) === 'ended').map((l) => l.fixtureId);
   const { data: settle } = useInPlay(endedIds);
-  const lostAndDone = (l: Leg) => { const ip = settle?.[l.fixtureId]; return !!ip?.ended && settleLeg(l, ip) === 'lost'; };
-  const rankedPicks = candidates.filter((l) => !lostAndDone(l));
+  const wonNow = (l: Leg) => { const ip = settle?.[l.fixtureId]; return !!ip?.ended && settleLeg(l, ip) === 'won'; };
 
-  const doubleLegs: Leg[] = rankedPicks.slice(0, 2).map((l) => withLogos(l));
-  const trebleLegs: Leg[] = rankedPicks.slice(2, 5).map((l) => withLogos(l));
+  const fresh = candidates.filter((l) => legPhase(l) !== 'ended');   // upcoming or in-play — still backable
+  const winners = candidates.filter(wonNow);                         // finished winners — proof
+
+  // Double = the two best games you can still back; fall back to winners only if
+  // there aren't enough fresh ones.
+  const doublePicks = [...fresh, ...winners].slice(0, 2);
+  const usedId = new Set(doublePicks.map((l) => l.fixtureId));
+  // Treble = lead with a recent winner (proof), then the next best fresh games.
+  const trebleSrc = [
+    ...winners.filter((l) => !usedId.has(l.fixtureId)).slice(0, 1),
+    ...fresh.filter((l) => !usedId.has(l.fixtureId)),
+    ...winners.filter((l) => !usedId.has(l.fixtureId)).slice(1),
+  ];
+
+  const doubleLegs: Leg[] = doublePicks.map((l) => withLogos(l));
+  const trebleLegs: Leg[] = trebleSrc.slice(0, 3).map((l) => withLogos(l));
   const featuredLegs = doubleLegs;
   const featuredIsTip = doubleLegs.length > 0;
   const hasTreble = trebleLegs.length === 3;

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -568,20 +568,22 @@ export function GafferValueBoardSection() {
   const updatedAt = live?.updatedAt ?? null;
 
   // ── Value-ranked board ──────────────────────────────────────────────────
-  // The board is driven purely by the value tables: the best 2 value picks (any
-  // market — goals, corners or BTTS) form the £10 double, the next 3 the £10
-  // treble. One pick per fixture, ranked by value (edge). Games still to come or
-  // in play rank ahead of finished ones, so the board stays current and never
-  // shows a dead game while there's a live/upcoming one to show.
+  // Best value picks (any market — goals, corners or BTTS), one per fixture,
+  // ranked by value (edge): best 2 = the £10 double, next 3 = the £10 treble.
+  // Games that finished and WON stay on (a winning pick is proof worth showing);
+  // only games that finished and LOST drop off. Upcoming and in-play stay too.
   const round2 = (n: number) => Math.round(n * 100) / 100;
-  const rankedPicks: Leg[] = (() => {
-    const bestPerFixture = new Map<string, Leg>();
-    for (const l of getValueCandidates()) { // already sorted by edge desc
-      if (!bestPerFixture.has(l.fixtureId)) bestPerFixture.set(l.fixtureId, l);
-    }
-    const finishedLast = (l: Leg) => (legPhase(l) === 'ended' ? 1 : 0);
-    return [...bestPerFixture.values()].sort((a, b) => finishedLast(a) - finishedLast(b) || b.edge - a.edge);
+  const candidates: Leg[] = (() => {
+    const best = new Map<string, Leg>();
+    for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l); // sorted by edge desc
+    return [...best.values()];
   })();
+  // Settlement only for finished games among the top contenders — enough to drop
+  // losers and keep winners, without polling every fixture on the card.
+  const endedIds = candidates.slice(0, 12).filter((l) => legPhase(l) === 'ended').map((l) => l.fixtureId);
+  const { data: settle } = useInPlay(endedIds);
+  const lostAndDone = (l: Leg) => { const ip = settle?.[l.fixtureId]; return !!ip?.ended && settleLeg(l, ip) === 'lost'; };
+  const rankedPicks = candidates.filter((l) => !lostAndDone(l));
 
   const doubleLegs: Leg[] = rankedPicks.slice(0, 2).map((l) => withLogos(l));
   const trebleLegs: Leg[] = rankedPicks.slice(2, 5).map((l) => withLogos(l));

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -578,27 +578,22 @@ export function GafferValueBoardSection() {
     for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l); // sorted by edge desc
     return [...best.values()];
   })();
-  // Settlement for finished games among the top contenders, so we know winners.
-  const endedIds = candidates.slice(0, 14).filter((l) => legPhase(l) === 'ended').map((l) => l.fixtureId);
-  const { data: settle } = useInPlay(endedIds);
-  const wonNow = (l: Leg) => { const ip = settle?.[l.fixtureId]; return !!ip?.ended && settleLeg(l, ip) === 'won'; };
+  // Settlement for any game that has kicked off (live or finished) so we know
+  // which completed games WON.
+  const checkIds = candidates.slice(0, 16).filter((l) => legPhase(l) !== 'pre').map((l) => l.fixtureId);
+  const { data: settle } = useInPlay(checkIds);
 
-  const fresh = candidates.filter((l) => legPhase(l) !== 'ended');   // upcoming or in-play — still backable
-  const winners = candidates.filter(wonNow);                         // finished winners — proof
+  // Board rule: keep every COMPLETED winner (proof), and fill the rest with games
+  // YET TO PLAY. A game that's in play is swapped out for one yet to play; games
+  // that finished and lost never show. Best value (edge) first within that.
+  const eligible = candidates.filter((l) => {
+    const ip = settle?.[l.fixtureId];
+    if (ip?.ended) return settleLeg(l, ip) === 'won'; // finished → keep only winners
+    return legPhase(l) === 'pre';                      // not finished → keep only upcoming (drop in-play)
+  });
 
-  // Double = the two best games you can still back; fall back to winners only if
-  // there aren't enough fresh ones.
-  const doublePicks = [...fresh, ...winners].slice(0, 2);
-  const usedId = new Set(doublePicks.map((l) => l.fixtureId));
-  // Treble = lead with a recent winner (proof), then the next best fresh games.
-  const trebleSrc = [
-    ...winners.filter((l) => !usedId.has(l.fixtureId)).slice(0, 1),
-    ...fresh.filter((l) => !usedId.has(l.fixtureId)),
-    ...winners.filter((l) => !usedId.has(l.fixtureId)).slice(1),
-  ];
-
-  const doubleLegs: Leg[] = doublePicks.map((l) => withLogos(l));
-  const trebleLegs: Leg[] = trebleSrc.slice(0, 3).map((l) => withLogos(l));
+  const doubleLegs: Leg[] = eligible.slice(0, 2).map((l) => withLogos(l));
+  const trebleLegs: Leg[] = eligible.slice(2, 5).map((l) => withLogos(l));
   const featuredLegs = doubleLegs;
   const featuredIsTip = doubleLegs.length > 0;
   const hasTreble = trebleLegs.length === 3;

--- a/src/components/homepage/SectionErrorBoundary.tsx
+++ b/src/components/homepage/SectionErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+/**
+ * Wraps a homepage section so a runtime error inside it renders a small fallback
+ * instead of crashing the whole page to a black screen. The error message is
+ * shown (compact) so issues are visible rather than silent.
+ */
+interface Props {
+  name: string;
+  children: ReactNode;
+}
+interface State {
+  error: Error | null;
+}
+
+export class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface it in the console for diagnosis.
+    // eslint-disable-next-line no-console
+    console.error(`[${this.props.name}] crashed:`, error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="mx-auto max-w-2xl rounded-2xl border border-rose-400/25 bg-rose-500/[0.06] p-5 text-center text-sm text-white/70">
+          <div className="font-black uppercase tracking-wide text-rose-200">This section hit a snag</div>
+          <p className="mt-1 text-white/55">We're on it — the rest of the page still works.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/data/gaffer/phraseLibrary.ts
+++ b/src/data/gaffer/phraseLibrary.ts
@@ -129,6 +129,10 @@ export const MARKET_FLAVOUR: Record<string, string[]> = {
     'Both sides force it wide and chuck bodies forward — corners pile up.',
     'They don’t do narrow. It’s wing play and whipped balls — corners coming.',
     'This pair turn every attack into a corner. Proper flag-fest.',
+    'These two attack down the flanks like the middle of the pitch owes ’em money — corners galore.',
+    'Cross, block, corner. Cross, block, corner. It’s basically their whole gameplan.',
+    'The corner flag’s about to get more touches than either striker.',
+    'Both defences clear it straight back out for a corner like it’s a party trick.',
   ],
   Goals: [
     'Both these lot think defending’s beneath them — goals guaranteed entertainment.',
@@ -143,6 +147,10 @@ export const MARKET_FLAVOUR: Record<string, string[]> = {
     'Defences made of paper, strikers in form — fill yer boots.',
     'These two go gung-ho. The scoreboard’s going to tick over.',
     'All-out attack from both ends — keepers picking it out the net.',
+    'These two defend like the goal’s got a “please score” sign on it.',
+    'Both keepers might as well bring a deckchair — then a shovel to dig it out.',
+    'A clean sheet in this one would be front-page news. Goals it is.',
+    'They swap goals like kids swap stickers. Got, got, need, GOAL.',
   ],
   Cards: [
     'A proper needle match, this — ref’ll be reaching for his pocket early.',
@@ -165,6 +173,10 @@ export const MARKET_FLAVOUR: Record<string, string[]> = {
     'Open defences, dangerous forwards — the net bulges at both ends.',
     'Clean sheets are a foreign language to this pair. Both score.',
     'Goals guaranteed at both ends — they can’t help themselves.',
+    'Both these lot leak like a chocolate teapot and bite at the other end. Both score.',
+    'A clean sheet for this pair would be a genuine collector’s item. Both to net.',
+    'They attack brilliantly and defend like it’s optional — nets bulging at both ends.',
+    'Two front lines that fancy it, two back lines that don’t. Both score, no drama.',
   ],
 };
 
@@ -328,6 +340,25 @@ export const ASIDES = [
   'Even me old man, rest him, would’ve had this.',
   'Bookies hate this one trick: reading the form.',
   'Call it a hunch backed by a spreadsheet.',
+  'I trust this more than I trust a VAR check.',
+  'Safer than a back-pass to a keeper with hands. Well — almost.',
+  'The stats don’t drink, don’t lie, and don’t support a team. Beautiful.',
+  'This one’s so tasty I nearly kept it to meself.',
+  'I’d walk to the bookies in the rain for this. And I hate rain.',
+  'Numbers this pretty should come with a warning label.',
+  'Cold, hard maths — served with a cheeky grin.',
+  'If confidence were a currency, I’d be buying a yacht off this one.',
+  'I’ve triple-checked it, then checked it again out of pure greed.',
+  'The bookie who priced this is having a Monday. On a Saturday.',
+  'This is less a gamble, more a stern word with probability.',
+  'My spreadsheet did a little dance when it saw this.',
+  'Reads like a gimme, priced like a mystery. Ours.',
+  'I’d put the works Christmas fund on it. Don’t tell the lads.',
+  'Value this loud should be wearing high-vis.',
+  'The bookies left the safe open and wandered off for a brew.',
+  'Form’s screaming, the price is snoozing — rude not to.',
+  'I’ve seen tighter defending in a game of headers-and-volleys.',
+  'This isn’t luck, it’s homework with a sense of humour.',
 ];
 
 /* ── Donkey of the Week roasts ───────────────────────────────────────────── */

--- a/src/lib/gafferSelection.ts
+++ b/src/lib/gafferSelection.ts
@@ -16,6 +16,25 @@ export const STAKE = 10;
 /** Today's UK date (YYYY-MM-DD) — the Gaffer only picks from today's card. */
 const todayUK = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
 
+/** The bundled fixtures store kick-off as a UK (Europe/London) wall-clock time.
+ *  Turn a date + "HH:MM" into an absolute epoch (ms) so it can be shown in the
+ *  viewer's own timezone and compared to "now" correctly anywhere. */
+const ukWallToMs = (dateStr: string, timeStr: string): number | null => {
+  const dm = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr || '');
+  const tm = /^(\d{1,2}):(\d{2})/.exec(timeStr || '');
+  if (!dm || !tm) return null;
+  const y = +dm[1], mo = +dm[2] - 1, d = +dm[3], h = +tm[1], mi = +tm[2];
+  const utcGuess = Date.UTC(y, mo, d, h, mi);
+  // Offset of Europe/London at that instant (handles BST/GMT automatically).
+  const asUK = new Date(new Date(utcGuess).toLocaleString('en-US', { timeZone: 'Europe/London' })).getTime();
+  const asUTC = new Date(new Date(utcGuess).toLocaleString('en-US', { timeZone: 'UTC' })).getTime();
+  return utcGuess - (asUK - asUTC);
+};
+
+/** Kick-off shown in the viewer's own timezone, e.g. "19:00". */
+const localKO = (ms: number | null, fallback: string): string =>
+  ms == null ? fallback : new Date(ms).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+
 export interface Leg {
   fixtureId: string;
   home: { name: string; short: string; logo: string | null };
@@ -111,14 +130,18 @@ export function getValueFixtures(): Leg[] {
  * isn't three of the same market when other markets have value too.
  */
 export function getValueCandidates(): Leg[] {
-  const makeLeg = (f: FormFixtureRow, market: Leg['market'], selection: string, cell: FormValueCell): Leg => ({
-    fixtureId: f.id, home: f.home, away: f.away, region: f.region, league: f.league, time: f.time,
-    market, selection, odds: cell.odds!, prob: cell.prob, edge: cell.edge, flag: cell.flag ?? 'value',
-    placeholderReason: gafferReason(
-      { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value' },
-      f.id,
-    ),
-  });
+  const makeLeg = (f: FormFixtureRow, market: Leg['market'], selection: string, cell: FormValueCell): Leg => {
+    const koMs = ukWallToMs(f.date, f.time);
+    return {
+      fixtureId: f.id, home: f.home, away: f.away, region: f.region, league: f.league,
+      time: localKO(koMs, f.time), kickoffMs: koMs,
+      market, selection, odds: cell.odds!, prob: cell.prob, edge: cell.edge, flag: cell.flag ?? 'value',
+      placeholderReason: gafferReason(
+        { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value' },
+        f.id,
+      ),
+    };
+  };
   const today = todayUK();
   const out: Leg[] = [];
   const ok = (c: FormValueCell | null | undefined) => !!c?.odds && c.odds >= 1.4 && c.prob >= 60;

--- a/src/lib/gafferVoice.ts
+++ b/src/lib/gafferVoice.ts
@@ -106,11 +106,16 @@ export function gafferPickLine(s: PickSignals, seed = '', flavourful = true): st
 export function gafferReason(s: PickSignals, seed = ''): string {
   const rng = mulberry32(seedOf(`${s.team}|${s.opp}|${s.market}|reason|${seed}`));
   const vars = varsFor(s, rng);
+  // Read → value → PUNCHLINE. He lands on a bit of wit or a confident verdict —
+  // never a limp "bet responsibly" hedge (that belongs on the small print, not
+  // in his mouth). Keeps every pick fun, funny and sharp.
+  const closer = rng() > 0.38
+    ? pick(ASIDES, 'aside', rng)
+    : pick(verdictBankFor(s), `verdict:${s.tier}`, rng);
   const parts = [
     pick(MARKET_FLAVOUR[s.market] ?? MARKET_FLAVOUR.Goals, `flavour:${s.market}`, rng),
     pick(edgeBankFor(s), 'edge', rng),
-    pick(verdictBankFor(s), `verdict:${s.tier}`, rng),
-    pick(HEDGES, 'hedge', rng),
+    closer,
   ];
   return parts.map((p) => fill(p, vars)).join(' ');
 }

--- a/src/pages/PreviewHome.tsx
+++ b/src/pages/PreviewHome.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { SectionErrorBoundary } from '@/components/homepage/SectionErrorBoundary';
 import { HeroBanner } from '@/components/homepage/HeroBanner';
 
 import { FantasyLeagueSellItSection } from '@/components/homepage/FantasyLeagueSellItSection';
@@ -25,33 +26,49 @@ export default function PreviewHome() {
       <HomepageNav />
 
       <HomepageScene tone="hero" flushTop flushBottom boxed={false}>
-        <HeroBanner />
+        <SectionErrorBoundary name="HeroBanner">
+          <HeroBanner />
+        </SectionErrorBoundary>
       </HomepageScene>
 
       <HomepageScene tone="finale" eyebrow="01 · The Gaffer's Picks">
-        <GafferValueBoardSection />
+        <SectionErrorBoundary name="GafferValueBoardSection">
+          <GafferValueBoardSection />
+        </SectionErrorBoundary>
         <div className="mt-3 md:mt-4">
-          <GafferPnLTrustSection />
+          <SectionErrorBoundary name="GafferPnLTrustSection">
+            <GafferPnLTrustSection />
+          </SectionErrorBoundary>
         </div>
       </HomepageScene>
 
       <HomepageScene tone="emerald" eyebrow="02 · Fantasy">
-        <FantasyLeagueSellItSection />
+        <SectionErrorBoundary name="FantasyLeagueSellItSection">
+          <FantasyLeagueSellItSection />
+        </SectionErrorBoundary>
       </HomepageScene>
 
       <HomepageScene tone="editorial" eyebrow="03 · The Newsroom">
-        <LatestArticlesSection />
+        <SectionErrorBoundary name="LatestArticlesSection">
+          <LatestArticlesSection />
+        </SectionErrorBoundary>
       </HomepageScene>
 
       <HomepageScene tone="crowd" eyebrow="05 · The Community">
         <div className="grid gap-3 lg:grid-cols-[1.1fr_0.9fr] md:gap-4">
-          <CommunityFeatureCard />
-          <TipOfTheDayCard />
+          <SectionErrorBoundary name="CommunityFeatureCard">
+            <CommunityFeatureCard />
+          </SectionErrorBoundary>
+          <SectionErrorBoundary name="TipOfTheDayCard">
+            <TipOfTheDayCard />
+          </SectionErrorBoundary>
         </div>
       </HomepageScene>
 
       <HomepageScene tone="finale" eyebrow="06 · Join the Club">
-        <FinalCallToActionBanner />
+        <SectionErrorBoundary name="FinalCallToActionBanner">
+          <FinalCallToActionBanner />
+        </SectionErrorBoundary>
       </HomepageScene>
 
 


### PR DESCRIPTION
Lands today's remaining work so `main` matches production and auto-deploy is the single source of truth.

- **Board selection:** pure value ranking — top 2 = the £10 double, next 3 = the £10 treble. Two skips only: games in play (today's in-play data is unreliable) and games that finished and lost; those slots go to the next value game. Winners and games yet to play stay as ranked.
- **Timezones:** value-board picks now carry an absolute kickoff and render in the viewer's local timezone (a 17:00 UK kickoff reads 19:00 in Sofia), with live/upcoming state correct anywhere.
- **Gaffer write-ups:** each pick ends on a witty aside or a confident verdict instead of a limp hedge, plus a batch of sharper, funnier lines.
- **Robustness:** each homepage section is wrapped in an error boundary so one runtime fault renders a small fallback instead of blacking out the whole page.
- **CI:** pass `CLOUDFLARE_API_TOKEN` via env for reliable auth in the deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added section-level error handling so a single broken homepage section no longer takes down the whole page.
  * Improved kickoff times to display in the viewer’s local timezone.

* **Bug Fixes**
  * Refined the value-ranked board to better filter out settled losers and in-play items, keeping the board more accurate.
  * Improved homepage stability by isolating failures to the affected section.

* **Content Updates**
  * Refreshed in-app phrasing and commentary for a broader variety of matchup and aside text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->