### PR TITLE
Remove Join CTAs until membership is ready

### DIFF
--- a/src/components/homepage/FinalCallToActionBanner.tsx
+++ b/src/components/homepage/FinalCallToActionBanner.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Clock } from 'lucide-react';
 import { FINAL_CTA_FEATURES } from './content';
 import { Icon } from './icons';
 
@@ -34,8 +34,8 @@ export function FinalCallToActionBanner() {
         />
 
         <div className="relative z-[2] max-w-[62%] p-5 md:p-8">
-          <span className="inline-flex w-fit items-center rounded-full border border-[#f5c542]/45 bg-[#f5c542]/12 px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-[#f8e7a1]">
-            Join the Club
+          <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/12 px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-[#f8e7a1]">
+            <Clock className="h-3 w-3" /> Coming Soon
           </span>
           <h2 className="mt-3 font-display text-3xl uppercase leading-[0.9] tracking-tight text-white text-extrude md:text-5xl">
             Ready to bet{' '}
@@ -65,18 +65,15 @@ export function FinalCallToActionBanner() {
           ))}
         </div>
 
-        <div className="mt-6 flex flex-col gap-2.5 sm:flex-row">
+        <div className="mt-6 flex flex-col gap-2.5 sm:flex-row sm:items-center">
+          <span className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-[#f5c542]/45 bg-[#f5c542]/12 px-6 py-3.5 text-sm font-black uppercase tracking-wide text-[#f8e7a1]">
+            <Clock className="h-4 w-4" /> Membership Opening Soon
+          </span>
           <Link
-            to="/pricing"
-            className="group inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] shadow-[0_18px_44px_-16px_rgba(245,197,66,1)] transition-transform hover:-translate-y-0.5"
+            to="/form-tables"
+            className="group inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-6 py-3.5 text-sm font-black uppercase tracking-wide text-white/80 transition-colors hover:bg-white/[0.06]"
           >
-            Join the Footy Oracle Club <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-          </Link>
-          <Link
-            to="/pricing"
-            className="inline-flex items-center justify-center gap-2 rounded-full border border-[#f5c542]/45 px-6 py-3.5 text-sm font-black uppercase tracking-wide text-[#f8e7a1] transition-colors hover:bg-[#f5c542]/10"
-          >
-            See What's Inside <ArrowRight className="h-4 w-4" />
+            Explore Today's Tips <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
           </Link>
         </div>
       </div>

--- a/src/components/homepage/HeroBanner.tsx
+++ b/src/components/homepage/HeroBanner.tsx
@@ -101,16 +101,16 @@ export function HeroBanner() {
 
             <div className="mt-7 flex flex-col gap-3 sm:flex-row">
               <Link
-                to="/pricing"
+                to="/form-tables"
                 className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-7 py-3.5 text-sm font-black uppercase tracking-wide text-white shadow-[0_18px_44px_-18px_rgba(139,92,246,1)] transition-all hover:-translate-y-0.5 hover:from-violet-400 hover:to-fuchsia-400"
               >
-                Join the Club <ChevronRight className="h-4 w-4" />
+                Explore Today's Tips <ChevronRight className="h-4 w-4" />
               </Link>
               <Link
-                to="/form-tables"
+                to="/pnl"
                 className="inline-flex items-center justify-center gap-2 rounded-xl border border-[#f5c542]/55 bg-[#f5c542]/[0.06] px-7 py-3.5 text-sm font-black uppercase tracking-wide text-[#f8e7a1] backdrop-blur transition-all hover:-translate-y-0.5 hover:bg-[#f5c542]/15"
               >
-                Explore Today's Tips <ChevronRight className="h-4 w-4" />
+                The Gaffer's Record <ChevronRight className="h-4 w-4" />
               </Link>
             </div>
 

--- a/src/components/homepage/HomepageNav.tsx
+++ b/src/components/homepage/HomepageNav.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Menu, X, Facebook, Instagram, Youtube, Send, LockKeyhole, Trophy, Zap } from 'lucide-react';
+import { Menu, X, Facebook, Instagram, Youtube, Send, LockKeyhole, Zap } from 'lucide-react';
 import { OracleWordmark } from './primitives';
 import { NAV_LINKS } from './content';
 
@@ -67,14 +67,6 @@ export function HomepageNav() {
               Login
             </a>
 
-            <a
-              href="/pricing"
-              className="inline-flex h-11 items-center gap-2 rounded-full bg-[#f5c542] px-4 text-[12px] font-black uppercase tracking-wide text-[#16051f] shadow-[0_12px_32px_-14px_rgba(245,197,66,1)] transition-all hover:-translate-y-0.5 hover:bg-[#ffe487] md:px-5"
-            >
-              <Trophy className="h-4 w-4 fill-current" />
-              <span className="hidden min-[370px]:inline">Join</span>
-            </a>
-
             <button
               type="button"
               aria-label={open ? 'Close menu' : 'Open menu'}
@@ -102,20 +94,13 @@ export function HomepageNav() {
                 {l.label}
               </a>
             ))}
-            <div className="col-span-2 mt-1 grid grid-cols-2 gap-2 border-t border-white/10 pt-3">
+            <div className="col-span-2 mt-1 border-t border-white/10 pt-3">
               <a
                 href="/auth"
                 onClick={() => setOpen(false)}
-                className="inline-flex items-center justify-center gap-2 rounded-full border border-[#f5c542]/40 px-4 py-3 text-center text-[12px] font-black uppercase tracking-wide text-[#f8e7a1]"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-[#f5c542]/40 px-4 py-3 text-center text-[12px] font-black uppercase tracking-wide text-[#f8e7a1]"
               >
                 <LockKeyhole className="h-4 w-4" /> Login
-              </a>
-              <a
-                href="/pricing"
-                onClick={() => setOpen(false)}
-                className="inline-flex items-center justify-center gap-2 rounded-full bg-[#f5c542] px-4 py-3 text-center text-[12px] font-black uppercase tracking-wide text-[#16051f] shadow-[0_12px_32px_-14px_rgba(245,197,66,1)]"
-              >
-                <Trophy className="h-4 w-4 fill-current" /> Join
               </a>
             </div>
             <div className="col-span-2 mt-1 flex items-center justify-center gap-2 text-[#f8e7a1]">

--- a/src/pages/PreviewHome.tsx
+++ b/src/pages/PreviewHome.tsx
@@ -65,7 +65,7 @@ export default function PreviewHome() {
         </div>
       </HomepageScene>
 
-      <HomepageScene tone="finale" eyebrow="06 · Join the Club">
+      <HomepageScene tone="finale" eyebrow="06 · Coming Soon">
         <SectionErrorBoundary name="FinalCallToActionBanner">
           <FinalCallToActionBanner />
         </SectionErrorBoundary>


### PR DESCRIPTION
The site isn't open for signups yet, so the Join buttons are removed until it's fully operational.

- **Nav:** removed the Join button (desktop + mobile); Login stays.
- **Hero:** dropped "Join the Club"; now leads with "Explore Today's Tips" and adds "The Gaffer's Record".
- **Final banner:** the £20/month membership pitch is now a **Coming Soon** state — "Membership Opening Soon" + "Explore Today's Tips", section eyebrow "06 · Coming Soon".

Join CTAs on the fantasy inner pages and the `/pricing` page are left as-is for now (those pages haven't been reviewed yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_