### PR TITLE
Fantasy League waitlist — capture, pitch page, admin dashboard

### DIFF
--- a/functions/api/waitlist.ts
+++ b/functions/api/waitlist.ts
@@ -1,0 +1,109 @@
+// Cloudflare Pages Function — Fantasy League waitlist.
+//
+//   POST /api/waitlist        { email, name?, hp? }  -> capture a signup
+//   GET  /api/waitlist?key=…                          -> admin: count + list
+//   GET  /api/waitlist?key=…&format=csv               -> admin: CSV export
+//
+// Storage: the WAITLIST KV namespace. Each signup is a key `signup:<email>`
+// whose metadata carries { email, ts, country, source, name }, so the admin
+// view lists everyone from a single KV list (no per-row reads). Visitors never
+// see the total. On each NEW signup we ping Telegram (if configured).
+interface Env {
+  WAITLIST: KVNamespace;
+  ADMIN_KEY?: string;
+  TELEGRAM_BOT_TOKEN?: string;
+  TELEGRAM_CHAT_ID?: string;
+}
+
+type Meta = { email: string; ts: string; country?: string; source?: string; name?: string };
+
+const JSON_HEADERS = { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" };
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const clean = (s: unknown, max = 120) => (typeof s === "string" ? s.trim().slice(0, max) : "");
+
+// ── POST: capture a signup ──────────────────────────────────────────────────
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  let body: Record<string, unknown> = {};
+  try { body = await ctx.request.json(); } catch { /* ignore */ }
+
+  // Honeypot — bots fill hidden fields; humans don't.
+  if (clean(body.hp)) return json({ ok: true });
+
+  const email = clean(body.email).toLowerCase();
+  if (!EMAIL_RE.test(email) || email.length > 120) return json({ ok: false, error: "invalid_email" }, 400);
+  const name = clean(body.name, 80);
+
+  const key = `signup:${email}`;
+  const existing = await ctx.env.WAITLIST.get(key);
+  const country = (ctx.request.headers.get("cf-ipcountry") || "").toUpperCase() || undefined;
+  const source = clean(body.source, 40) || undefined;
+  const meta: Meta = { email, ts: new Date().toISOString(), country, source, name: name || undefined };
+
+  // Keep the first-seen timestamp on a repeat submit; always store latest name.
+  if (existing) {
+    const prev = (await listFind(ctx.env, email)) ?? meta;
+    await ctx.env.WAITLIST.put(key, "1", { metadata: { ...prev, name: name || prev.name } });
+    return json({ ok: true, already: true });
+  }
+
+  await ctx.env.WAITLIST.put(key, "1", { metadata: meta });
+
+  // Fire-and-forget Telegram ping on genuinely new signups.
+  ctx.waitUntil(notify(ctx.env, meta));
+  return json({ ok: true });
+};
+
+// ── GET: admin dashboard data (key-gated) ───────────────────────────────────
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const key = url.searchParams.get("key") || ctx.request.headers.get("x-admin-key") || "";
+  if (!ctx.env.ADMIN_KEY || key !== ctx.env.ADMIN_KEY) return json({ ok: false, error: "unauthorized" }, 401);
+
+  const rows: Meta[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await ctx.env.WAITLIST.list<Meta>({ prefix: "signup:", cursor, limit: 1000 });
+    for (const k of page.keys) if (k.metadata) rows.push(k.metadata as Meta);
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  rows.sort((a, b) => (a.ts < b.ts ? 1 : -1)); // newest first
+
+  if (url.searchParams.get("format") === "csv") {
+    const esc = (v: string) => `"${(v || "").replace(/"/g, '""')}"`;
+    const csv = ["email,signed_up,country,source,name",
+      ...rows.map((r) => [r.email, r.ts, r.country || "", r.source || "", r.name || ""].map(esc).join(","))].join("\n");
+    return new Response(csv, {
+      headers: { "content-type": "text/csv; charset=utf-8", "content-disposition": 'attachment; filename="waitlist.csv"', "cache-control": "no-store" },
+    });
+  }
+
+  return json({ ok: true, count: rows.length, signups: rows });
+};
+
+// Look up an existing row's metadata (for preserving first-seen ts on re-submit).
+async function listFind(env: Env, email: string): Promise<Meta | null> {
+  let cursor: string | undefined;
+  do {
+    const page = await env.WAITLIST.list<Meta>({ prefix: `signup:${email}`, cursor, limit: 10 });
+    for (const k of page.keys) if (k.name === `signup:${email}` && k.metadata) return k.metadata as Meta;
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return null;
+}
+
+// Telegram push — no-op unless both secrets are configured.
+async function notify(env: Env, m: Meta): Promise<void> {
+  if (!env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_CHAT_ID) return;
+  const text = `⚽️ New Fantasy waitlist signup!\n\n📧 ${m.email}${m.name ? `\n👤 ${m.name}` : ""}${m.country ? `\n🌍 ${m.country}` : ""}${m.source ? `\n🔗 ${m.source}` : ""}`;
+  try {
+    await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text, disable_web_page_preview: true }),
+    });
+  } catch { /* best-effort */ }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ const FantasyMyTeam = lazy(() => import("./pages/FantasyMyTeam"));
 const FantasyTransfers = lazy(() => import("./pages/FantasyTransfers"));
 const FantasyResults = lazy(() => import("./pages/FantasyResults"));
 const Pnl = lazy(() => import("./pages/Pnl"));
+const FantasyWaitlist = lazy(() => import("./pages/FantasyWaitlist"));
+const AdminWaitlist = lazy(() => import("./pages/AdminWaitlist"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
@@ -70,6 +72,8 @@ const App = () => {
                 <Route path="/fixtures" element={<ComingSoon title="Today's Fixtures" eyebrow="In Build" />} />
                 <Route path="/tips" element={<ComingSoon title="Daily Tips" eyebrow="In Build" />} />
                 <Route path="/pnl" element={<Pnl />} />
+                <Route path="/fantasy-waitlist" element={<FantasyWaitlist />} />
+                <Route path="/admin" element={<AdminWaitlist />} />
                 <Route path="/the-gaffer" element={<ComingSoon title="The Gaffer" eyebrow="In Build" />} />
                 <Route path="/community" element={<ComingSoon title="Community" eyebrow="In Build" />} />
 

--- a/src/components/homepage/FantasyLeagueSellItSection.tsx
+++ b/src/components/homepage/FantasyLeagueSellItSection.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Bell, ArrowRight, Check } from 'lucide-react';
 import { Countdown } from '@/components/fantasy/Countdown';
-import { supabase } from '@/integrations/supabase/client';
 
 const POSTER = '/images/fantasy/fantasy-coming-soon.jpg';
 // Registration target for the coming-soon countdown (season opens Aug 2026).
@@ -30,8 +29,12 @@ export function FantasyLeagueSellItSection() {
     if (!clean) return;
     setDone(true); // optimistic — don't make them wait on the network
     try { localStorage.setItem('fantasy_waitlist_email', clean); } catch { /* ignore */ }
-    // Persist to the waitlist (fire-and-forget; localStorage is the fallback).
-    void supabase.functions.invoke('fantasy-waitlist', { body: { email: clean, source: 'homepage' } }).catch(() => {});
+    // Capture to the real waitlist (KV-backed). Fire-and-forget.
+    void fetch('/api/waitlist', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: clean, source: 'homepage' }),
+    }).catch(() => {});
   };
 
   return (

--- a/src/components/homepage/HeroBanner.tsx
+++ b/src/components/homepage/HeroBanner.tsx
@@ -47,13 +47,19 @@ export function HeroBanner() {
         <div aria-hidden className="absolute inset-x-0 bottom-0 hidden h-2/5 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/40 to-transparent md:block" />
 
         {/* Fantasy League — Coming Soon promo (DESKTOP: top-right, clear of the left-hand copy) */}
-        <img
-          src="/images/fantasy-coming-soon.png"
-          alt="Footy Oracle's Fantasy League — Coming Soon"
-          loading="lazy"
-          draggable={false}
-          className="pointer-events-none absolute right-6 top-6 z-[3] hidden w-[46%] max-w-[620px] select-none drop-shadow-[0_14px_34px_rgba(0,0,0,0.6)] md:block"
-        />
+        <Link
+          to="/fantasy-waitlist"
+          aria-label="Join the Fantasy League waitlist"
+          className="absolute right-6 top-6 z-[3] hidden w-[46%] max-w-[620px] transition-transform hover:-translate-y-0.5 md:block"
+        >
+          <img
+            src="/images/fantasy-coming-soon.png"
+            alt="Footy Oracle's Fantasy League — Coming Soon"
+            loading="lazy"
+            draggable={false}
+            className="w-full select-none drop-shadow-[0_14px_34px_rgba(0,0,0,0.6)]"
+          />
+        </Link>
 
         <div className="relative flex flex-col md:min-h-[660px] md:justify-between md:gap-8">
           {/* MOBILE scene banner — the Gaffer shown clearly up top, fading into the copy */}
@@ -64,13 +70,19 @@ export function HeroBanner() {
           >
             <div className="absolute inset-0 bg-gradient-to-t from-[#0a0414] via-[#0a0414]/25 to-transparent" />
             {/* MOBILE — Fantasy League Coming Soon promo, bottom-left and large */}
-            <img
-              src="/images/fantasy-coming-soon.png"
-              alt="Footy Oracle's Fantasy League — Coming Soon"
-              loading="lazy"
-              draggable={false}
-              className="pointer-events-none absolute bottom-2.5 left-2.5 z-[3] w-[86%] select-none drop-shadow-[0_10px_26px_rgba(0,0,0,0.65)]"
-            />
+            <Link
+              to="/fantasy-waitlist"
+              aria-label="Join the Fantasy League waitlist"
+              className="absolute bottom-2.5 left-2.5 z-[3] block w-[86%] active:scale-[0.99]"
+            >
+              <img
+                src="/images/fantasy-coming-soon.png"
+                alt="Footy Oracle's Fantasy League — Coming Soon"
+                loading="lazy"
+                draggable={false}
+                className="w-full select-none drop-shadow-[0_10px_26px_rgba(0,0,0,0.65)]"
+              />
+            </Link>
           </div>
 
           {/* copy */}

--- a/src/pages/AdminWaitlist.tsx
+++ b/src/pages/AdminWaitlist.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, RefreshCw, Download, Lock, Users } from 'lucide-react';
+
+type Signup = { email: string; ts: string; country?: string; source?: string; name?: string };
+
+const KEY_STORE = 'fo_admin_key';
+
+export default function AdminWaitlist() {
+  const [key, setKey] = useState(() => localStorage.getItem(KEY_STORE) || '');
+  const [input, setInput] = useState('');
+  const [rows, setRows] = useState<Signup[]>([]);
+  const [count, setCount] = useState(0);
+  const [state, setState] = useState<'idle' | 'loading' | 'ok' | 'unauth' | 'error'>('idle');
+
+  const load = useCallback(async (k: string) => {
+    if (!k) return;
+    setState('loading');
+    try {
+      const res = await fetch(`/api/waitlist?key=${encodeURIComponent(k)}`, { headers: { 'cache-control': 'no-cache' } });
+      if (res.status === 401) { setState('unauth'); return; }
+      const data = await res.json();
+      if (data.ok) { setRows(data.signups || []); setCount(data.count || 0); setState('ok'); }
+      else setState('error');
+    } catch { setState('error'); }
+  }, []);
+
+  useEffect(() => { if (key) load(key); }, [key, load]);
+
+  function unlock(e: React.FormEvent) {
+    e.preventDefault();
+    localStorage.setItem(KEY_STORE, input.trim());
+    setKey(input.trim());
+  }
+
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? iso : d.toLocaleString('en-GB', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' });
+  };
+
+  // ── gate ──
+  if (!key || state === 'unauth') {
+    return (
+      <div className="grid min-h-screen place-items-center bg-[#07000f] px-4 text-white">
+        <form onSubmit={unlock} className="w-full max-w-sm rounded-2xl border border-white/12 bg-[#130321] p-6 shadow-[0_22px_70px_-32px_rgba(245,197,66,0.6)]">
+          <div className="mb-3 grid h-11 w-11 place-items-center rounded-full bg-[#f5c542]/15 text-[#f5c542]"><Lock className="h-5 w-5" /></div>
+          <h1 className="font-display text-2xl uppercase tracking-tight">Waitlist admin</h1>
+          <p className="mt-1 text-sm text-white/50">Enter the admin key to view signups.</p>
+          <input
+            type="password" value={input} onChange={(e) => setInput(e.target.value)} autoFocus placeholder="Admin key"
+            className="mt-4 h-12 w-full rounded-xl border border-white/15 bg-[#07000f]/80 px-3 text-white outline-none focus:border-[#f5c542]/60"
+          />
+          {state === 'unauth' && <p className="mt-2 text-xs text-rose-300">Wrong key — try again.</p>}
+          <button className="mt-3 h-12 w-full rounded-xl bg-[#f5c542] font-black uppercase tracking-wide text-[#16051f]">Unlock</button>
+          <Link to="/" className="mt-3 block text-center text-xs text-white/40 hover:text-white/70">Back to site</Link>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#07000f] text-white">
+      <main className="mx-auto max-w-3xl px-3 py-6 md:px-6">
+        <div className="flex items-center justify-between">
+          <Link to="/" className="inline-flex items-center gap-1.5 text-sm text-white/55 transition hover:text-[#f5c542]"><ArrowLeft className="h-4 w-4" /> Site</Link>
+          <div className="flex items-center gap-2">
+            <button onClick={() => load(key)} className="inline-flex items-center gap-1.5 rounded-full border border-white/15 px-3 py-1.5 text-xs font-bold text-white/70 hover:text-white">
+              <RefreshCw className={`h-3.5 w-3.5 ${state === 'loading' ? 'animate-spin' : ''}`} /> Refresh
+            </button>
+            <a href={`/api/waitlist?key=${encodeURIComponent(key)}&format=csv`} className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/40 bg-[#f5c542]/10 px-3 py-1.5 text-xs font-bold text-[#f8e7a1] hover:bg-[#f5c542]/20">
+              <Download className="h-3.5 w-3.5" /> CSV
+            </a>
+          </div>
+        </div>
+
+        {/* count */}
+        <div className="mt-4 rounded-2xl border border-[#f5c542]/25 bg-[#130321] p-6">
+          <div className="flex items-center gap-1.5 text-[11px] font-black uppercase tracking-[0.16em] text-white/50"><Users className="h-4 w-4 text-[#f5c542]" /> Fantasy waitlist</div>
+          <div className="mt-1 font-display text-6xl leading-none text-[#f8e7a1] text-extrude">{count}</div>
+          <div className="mt-1 text-sm text-white/45">{count === 1 ? 'person wants in' : 'people want in'}</div>
+        </div>
+
+        {/* list */}
+        <div className="mt-4 overflow-hidden rounded-2xl border border-white/10">
+          <div className="grid grid-cols-[1fr_auto_auto] gap-2 border-b border-white/10 bg-white/[0.04] px-4 py-2.5 text-[10px] font-black uppercase tracking-wider text-white/40">
+            <span>Email</span><span className="text-right">When</span><span className="w-10 text-right">Geo</span>
+          </div>
+          {rows.length === 0 ? (
+            <div className="px-4 py-10 text-center text-sm text-white/40">{state === 'loading' ? 'Loading…' : 'No signups yet.'}</div>
+          ) : rows.map((r, i) => (
+            <div key={i} className="grid grid-cols-[1fr_auto_auto] items-center gap-2 border-b border-white/5 px-4 py-2.5 text-sm">
+              <div className="min-w-0">
+                <div className="truncate text-white/90">{r.email}</div>
+                {(r.name || r.source) && <div className="truncate text-[11px] text-white/35">{[r.name, r.source].filter(Boolean).join(' · ')}</div>}
+              </div>
+              <div className="whitespace-nowrap text-right text-[12px] text-white/45">{fmt(r.ts)}</div>
+              <div className="w-10 text-right text-[12px] text-white/45">{r.country || '—'}</div>
+            </div>
+          ))}
+        </div>
+        {state === 'error' && <p className="mt-3 text-center text-sm text-rose-300">Couldn't load. Check your connection and refresh.</p>}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/FantasyWaitlist.tsx
+++ b/src/pages/FantasyWaitlist.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, Trophy, Palmtree, MessagesSquare, Crown, Check, Mail, ShieldCheck, Sparkles, Users } from 'lucide-react';
+import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { FooterNavigation } from '@/components/homepage/FooterNavigation';
+
+const REASONS = [
+  { Icon: Trophy, title: 'Weekly cash-free prizes', body: 'Top the leaderboard each week and bank real rewards — every gameweek is a fresh shot at glory.' },
+  { Icon: Palmtree, title: 'A dream-holiday grand prize', body: "Win the season and you're not getting a mug — you're getting a getaway. The big one.", accent: true },
+  { Icon: MessagesSquare, title: 'Beat the Gaffer', body: "He picks a team too. Finish above him and you'll never let him hear the end of it. Loads of banter, rivalries, trash talk." },
+  { Icon: Crown, title: 'Founding-member status', body: "Everyone on this list is first through the door when it opens — you helped start it." },
+];
+
+const STEPS = [
+  'Pick your squad on a budget — brains over bank balance.',
+  'Rack up points every gameweek across the season.',
+  'Climb the league, win weekly prizes, chase the grand prize.',
+];
+
+function WaitlistForm({ source, compact = false }: { source: string; compact?: boolean }) {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [hp, setHp] = useState(''); // honeypot
+  const [state, setState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [msg, setMsg] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (state === 'loading') return;
+    setState('loading'); setMsg('');
+    try {
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, name, hp, source }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) { setState('done'); setMsg(data.already ? "You're already on the list — nice one." : "You're in. We'll shout when it kicks off."); }
+      else { setState('error'); setMsg(data.error === 'invalid_email' ? 'That email looks off — give it another go.' : 'Something went wrong. Try again in a sec.'); }
+    } catch { setState('error'); setMsg('Network hiccup — try again in a sec.'); }
+  }
+
+  if (state === 'done') {
+    return (
+      <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-5 text-center">
+        <div className="mx-auto mb-2 grid h-11 w-11 place-items-center rounded-full bg-emerald-500/20 text-emerald-300"><Check className="h-6 w-6" /></div>
+        <div className="font-display text-xl uppercase tracking-tight text-emerald-200">On the list!</div>
+        <p className="mt-1 text-sm text-white/70">{msg}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className={compact ? '' : 'rounded-2xl border border-[#f5c542]/25 bg-black/30 p-4 md:p-5'}>
+      {/* honeypot — hidden from humans */}
+      <input type="text" value={hp} onChange={(e) => setHp(e.target.value)} tabIndex={-1} autoComplete="off" aria-hidden className="absolute left-[-9999px] h-0 w-0 opacity-0" />
+      <div className="flex flex-col gap-2.5 sm:flex-row">
+        <div className="relative flex-1">
+          <Mail className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40" />
+          <input
+            type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@email.com"
+            className="h-12 w-full rounded-xl border border-white/15 bg-[#07000f]/80 pl-10 pr-3 text-[15px] text-white placeholder:text-white/35 outline-none transition-colors focus:border-[#f5c542]/60"
+          />
+        </div>
+        <button
+          type="submit" disabled={state === 'loading'}
+          className="inline-flex h-12 shrink-0 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 text-sm font-black uppercase tracking-wide text-[#16051f] shadow-[0_16px_40px_-16px_rgba(245,197,66,1)] transition-transform hover:-translate-y-0.5 disabled:opacity-70"
+        >
+          {state === 'loading' ? 'Adding…' : 'Join the Waitlist'}
+        </button>
+      </div>
+      {state === 'error' && <p className="mt-2 text-center text-xs text-rose-300 sm:text-left">{msg}</p>}
+      <p className="mt-2.5 flex items-center justify-center gap-1.5 text-[11px] text-white/45 sm:justify-start">
+        <ShieldCheck className="h-3.5 w-3.5" /> No payment, no spam. Just your spot saved for when it launches.
+      </p>
+    </form>
+  );
+}
+
+export default function FantasyWaitlist() {
+  return (
+    <div className="min-h-screen bg-[#07000f] text-white">
+      <HomepageNav />
+
+      <main className="mx-auto max-w-3xl px-3 pb-16 pt-4 md:px-6">
+        <Link to="/" className="inline-flex items-center gap-1.5 text-sm text-white/55 transition hover:text-[#f5c542]">
+          <ArrowLeft className="h-4 w-4" /> Back to the club
+        </Link>
+
+        {/* Hero */}
+        <section className="mt-4 overflow-hidden rounded-[1.4rem] border border-[#f5c542]/30 bg-[#130321] shadow-[0_22px_70px_-32px_rgba(245,197,66,0.6)] md:rounded-[1.9rem]">
+          <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+          <div className="p-5 md:p-8">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-fuchsia-400/40 bg-fuchsia-500/15 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-fuchsia-200">
+              <Sparkles className="h-3.5 w-3.5" /> Coming Soon
+            </span>
+            <h1 className="mt-3 font-display text-4xl uppercase leading-[0.92] tracking-tight text-white md:text-6xl">
+              The Footy Oracle<br /><span className="bg-gradient-to-r from-violet-400 via-fuchsia-500 to-[#f5c542] bg-clip-text text-transparent">Fantasy League</span>
+            </h1>
+            <p className="mt-3 max-w-xl text-[15px] leading-relaxed text-white/70 md:text-base">
+              A season-long fantasy league with real prizes, a dream-holiday grand prize, and the whole club scrapping it out —
+              plus the chance to beat The Gaffer at his own game. It's not live yet. Get on the waitlist and you're first in.
+            </p>
+
+            <div className="mt-6"><WaitlistForm source="waitlist-hero" /></div>
+
+            <p className="mt-3 flex items-center gap-1.5 text-[11px] text-white/40">
+              <Users className="h-3.5 w-3.5" /> Founding members get in before anyone else.
+            </p>
+          </div>
+        </section>
+
+        {/* Why join */}
+        <section className="mt-6">
+          <h2 className="mb-3 font-display text-xl uppercase tracking-tight text-white md:text-2xl">Why you'll want in</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {REASONS.map(({ Icon, title, body, accent }) => (
+              <div key={title} className={`card-3d rounded-2xl p-4 ${accent ? 'ring-1 ring-inset ring-[#f5c542]/30' : ''}`}>
+                <div className={`mb-2 grid h-10 w-10 place-items-center rounded-xl border ${accent ? 'border-[#f5c542]/45 bg-[#f5c542]/15 text-[#f5c542]' : 'border-violet-400/40 bg-violet-500/15 text-violet-200'}`}>
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="font-display text-lg uppercase tracking-tight text-white">{title}</div>
+                <p className="mt-1 text-[13px] leading-relaxed text-white/60">{body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section className="mt-6 rounded-2xl border border-white/10 bg-white/[0.03] p-5 md:p-6">
+          <h2 className="mb-3 font-display text-xl uppercase tracking-tight text-white md:text-2xl">How the season works</h2>
+          <ol className="space-y-2.5">
+            {STEPS.map((s, i) => (
+              <li key={i} className="flex items-start gap-3">
+                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#f5c542] text-[13px] font-black text-[#16051f]">{i + 1}</span>
+                <span className="pt-0.5 text-[14px] leading-relaxed text-white/80">{s}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        {/* Final capture */}
+        <section className="mt-6 overflow-hidden rounded-[1.4rem] border border-[#f5c542]/30 bg-gradient-to-br from-[#1a0730] to-[#0a0613] p-5 text-center md:p-8">
+          <h2 className="font-display text-3xl uppercase leading-none tracking-tight text-white md:text-4xl">Save your spot</h2>
+          <p className="mx-auto mt-2 max-w-md text-sm text-white/60">Drop your email and you're on the list. We'll only email you when it's ready to play.</p>
+          <div className="mx-auto mt-5 max-w-lg"><WaitlistForm source="waitlist-footer" compact /></div>
+        </section>
+
+        <div className="mt-10"><FooterNavigation /></div>
+      </main>
+    </div>
+  );
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,8 @@
 name = "golden-bet-ai"
 pages_build_output_dir = "./dist"
 compatibility_date = "2025-01-01"
+
+# Fantasy League waitlist store — read/written by functions/api/waitlist.ts.
+[[kv_namespaces]]
+binding = "WAITLIST"
+id = "7271f2775d904ee3934fa04f97f46c6d"


### PR DESCRIPTION
Collect pre-launch signups (no payment) to validate demand for the season-long fantasy league, with private owner visibility.

- **`functions/api/waitlist.ts`** — Cloudflare Pages Function on the `WAITLIST` KV store. `POST` captures a signup (email validation, honeypot, de-dupe, country/source metadata) and pings Telegram on new ones; `GET` is key-gated → count + list, or CSV export.
- **`wrangler.toml`** — binds the `WAITLIST` KV namespace.
- **`/fantasy-waitlist`** — a "why you'll want in" pitch page (weekly prizes, dream-holiday grand prize, beat-the-Gaffer, founding-member) with email capture. The hero banner links here.
- **`/admin`** — key-protected dashboard: live count, full list, CSV export.
- Homepage fantasy section rewired off the dead Supabase function onto `/api/waitlist`.

Visitors never see the total. The Telegram ping activates once the bot token + chat ID secrets are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_