### PR TITLE
Sharper, more elevated boxes (feature cards + frost-3d)

### DIFF
--- a/src/components/homepage/HeroBanner.tsx
+++ b/src/components/homepage/HeroBanner.tsx
@@ -153,7 +153,7 @@ export function HeroBanner() {
                 key={f.title}
                 to={f.to}
                 aria-label={f.title}
-                className="group relative overflow-hidden rounded-2xl border border-violet-400/20 shadow-[0_12px_30px_-16px_rgba(0,0,0,0.9)] transition-all hover:-translate-y-1 hover:border-violet-400/60 hover:shadow-[0_0_38px_-10px_rgba(139,92,246,0.75)]"
+                className="group relative overflow-hidden rounded-2xl border border-white/[0.16] shadow-[0_3px_5px_-1px_rgba(0,0,0,0.75),0_22px_38px_-16px_rgba(0,0,0,0.98),0_46px_64px_-34px_rgba(0,0,0,0.85)] transition-all duration-300 hover:-translate-y-1.5 hover:border-violet-400/70 hover:shadow-[0_3px_5px_-1px_rgba(0,0,0,0.75),0_0_46px_-8px_rgba(139,92,246,0.85),0_28px_46px_-16px_rgba(0,0,0,0.98)]"
               >
                 <img
                   src={f.img}
@@ -162,7 +162,8 @@ export function HeroBanner() {
                   draggable={false}
                   className="aspect-square w-full select-none object-cover transition-transform duration-300 group-hover:scale-[1.05]"
                 />
-                <span aria-hidden className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/5" />
+                {/* razor-sharp bevel: bright top edge + crisp inner frame */}
+                <span aria-hidden className="pointer-events-none absolute inset-0 rounded-2xl shadow-[inset_0_1.5px_0_rgba(255,255,255,0.4),inset_0_0_0_1px_rgba(255,255,255,0.08),inset_0_-2px_2px_rgba(0,0,0,0.5)]" />
               </Link>
             ))}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -478,22 +478,20 @@ input, textarea, [contenteditable] {
       inset 0 1px 0 rgba(255,255,255,0.07),
       0 1px 0 rgba(255,255,255,0.07);
   }
-  /* .frost-3d — a RAISED frosted-glass inner box: translucent light top, violet
-   * top-glow, a crisp bright top edge and a real drop shadow so it lifts off the
-   * card behind it. Higher contrast + clarity than .inset-3d, premium finish.
-   * Faked with layered gradients (backdrop-blur is off on mobile). */
+  /* .frost-3d — a RAISED box with razor-sharp bevelled edges and strong lift:
+   * a crisp bright top edge, a crisp dark bottom edge, a tight contact shadow
+   * for definition and a deep elevation shadow so it floats — no haze/glow. */
   .frost-3d {
     background:
-      linear-gradient(180deg, rgba(255,255,255,0.13) 0%, rgba(255,255,255,0.045) 44%, rgba(255,255,255,0.018) 100%),
-      radial-gradient(130% 92% at 50% -14%, rgba(139,92,246,0.18), transparent 60%),
-      rgba(15, 9, 32, 0.72);
-    border: 1px solid rgba(255,255,255,0.16);
-    border-top-color: rgba(255,255,255,0.34);
+      linear-gradient(180deg, rgba(255,255,255,0.10) 0%, rgba(255,255,255,0.03) 52%, rgba(255,255,255,0.012) 100%),
+      rgba(17, 11, 36, 0.86);
+    border: 1px solid rgba(255,255,255,0.20);
+    border-top-color: rgba(255,255,255,0.44);
     box-shadow:
-      inset 0 1.5px 0 rgba(255,255,255,0.34),
-      inset 0 -22px 36px -26px rgba(0,0,0,0.72),
-      0 22px 46px -22px rgba(0,0,0,0.95),
-      0 6px 14px -8px rgba(0,0,0,0.7);
+      inset 0 1px 0 rgba(255,255,255,0.42),
+      inset 0 -1px 0 rgba(0,0,0,0.55),
+      0 2px 4px -1px rgba(0,0,0,0.6),
+      0 16px 28px -14px rgba(0,0,0,0.95);
   }
   .text-emboss {
     text-shadow: 0 1px 0 rgba(0,0,0,0.55), 0 2px 4px rgba(0,0,0,0.5);


### PR DESCRIPTION
The frosted look read soft/hazy; the ask was razor-sharp and elevated.

- **`frost-3d`**: dropped the radial glow haze; now a crisp bright top edge + crisp dark bottom edge + a tight contact shadow and a deep elevation shadow.
- **Hero feature cards**: sharp defined frame, bright bevel top edge, and a strong three-layer drop shadow so they clearly float off the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_