### PR TITLE
Value board: solid (un-misty) boxes + live FootyStats scores

### DIFF
--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -64,7 +64,7 @@ function settleLeg(leg: Leg, ip: InPlayState): 'won' | 'lost' | null {
 function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | null {
   // Finished — FootyStats carries the final numbers → settle Won/Lost.
   if (ip?.ended) return { state: 'ft', result: settleLeg(leg, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}` };
-  // Live score from API-Football (real in-play).
+  // Live score from API-Football (real in-play, carries the minute).
   if (live) {
     const score = `${live.gh}–${live.ga}`;
     const clock = live.status === 'HT' ? 'HT' : live.elapsed != null ? `${live.elapsed}'` : 'LIVE';
@@ -75,8 +75,13 @@ function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | 
       : false;
     return { state: 'live', landed, text: `${clock} · ${score}` };
   }
-  // No live data (e.g. corners-only markets, or match not on the live feed) —
-  // fall back to the time-based badge so it still reads as in-play.
+  // Fallback score for leagues API-Football doesn't stream (China, K-League…):
+  // FootyStats carries the running goal count during the match, so show it.
+  if (ip?.live) {
+    const landed = settleLeg(leg, ip) === 'won';
+    return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}` };
+  }
+  // No score data anywhere yet — the time-based badge so it still reads live.
   if (legPhase(leg) === 'live') return { state: 'live', text: 'In Play' };
   return null;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -478,20 +478,19 @@ input, textarea, [contenteditable] {
       inset 0 1px 0 rgba(255,255,255,0.07),
       0 1px 0 rgba(255,255,255,0.07);
   }
-  /* .frost-3d — a RAISED box with razor-sharp bevelled edges and strong lift:
-   * a crisp bright top edge, a crisp dark bottom edge, a tight contact shadow
-   * for definition and a deep elevation shadow so it floats — no haze/glow. */
+  /* .frost-3d — a RAISED, SOLID box (no translucency, so nothing bleeds through
+   * as haze): a clean opaque dark fill, a crisp bright top bevel, a crisp dark
+   * bottom edge, a tight contact shadow and a deep elevation shadow so it floats
+   * off the card — razor sharp, fully clear. */
   .frost-3d {
-    background:
-      linear-gradient(180deg, rgba(255,255,255,0.10) 0%, rgba(255,255,255,0.03) 52%, rgba(255,255,255,0.012) 100%),
-      rgba(17, 11, 36, 0.86);
-    border: 1px solid rgba(255,255,255,0.20);
-    border-top-color: rgba(255,255,255,0.44);
+    background: linear-gradient(180deg, #1d1440 0%, #150e30 100%);
+    border: 1px solid rgba(255,255,255,0.18);
+    border-top-color: rgba(255,255,255,0.42);
     box-shadow:
-      inset 0 1px 0 rgba(255,255,255,0.42),
-      inset 0 -1px 0 rgba(0,0,0,0.55),
-      0 2px 4px -1px rgba(0,0,0,0.6),
-      0 16px 28px -14px rgba(0,0,0,0.95);
+      inset 0 1px 0 rgba(255,255,255,0.34),
+      inset 0 -1px 0 rgba(0,0,0,0.6),
+      0 2px 4px -1px rgba(0,0,0,0.7),
+      0 18px 30px -14px rgba(0,0,0,0.96);
   }
   .text-emboss {
     text-shadow: 0 1px 0 rgba(0,0,0,0.55), 0 2px 4px rgba(0,0,0,0.5);


### PR DESCRIPTION
Two fixes:

- **Misty boxes** — `frost-3d` was semi-transparent, so the busy card behind bled through as haze. It's now a **solid opaque dark panel** (crisp, no mist) keeping the sharp bevel top edge + elevation shadow.
- **No live score** — the value picks are from leagues API-Football doesn't stream (China League One, K-League…), so the board only ever showed "In Play". FootyStats carries the running goal count mid-match, so it's now used as the live-score fallback (`LIVE · 1–3`) with the current won/lost lean. Once the match completes it settles to `FT x–y · Won/Lost` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live match badges now show more reliably when one live score source is unavailable, using a fallback to keep the status accurate.
  * Live indicators now better reflect whether a match has settled.

* **Style**
  * Updated the visual treatment of the raised box/card styling for a slightly refreshed look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->