### PR TITLE
Season date → Sat 22 Aug 2026; remove un-wired "Enter the League" CTA

### DIFF
--- a/src/components/fantasy/FantasyPageHero.tsx
+++ b/src/components/fantasy/FantasyPageHero.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Crown, Trophy, ChevronDown, TrendingUp, TrendingDown, Minus, CalendarClock } from 'lucide-react';
+import { Crown, ChevronDown, TrendingUp, TrendingDown, Minus, CalendarClock } from 'lucide-react';
 import { useFantasyPlayers, useFantasyStandings, useFantasyGameweek, FANTASY_RULES } from '@/hooks/useFantasyLeague';
 import type { FantasyStandingRow } from '@/types/footy';
 import { PlayerCard } from './PlayerCard';
@@ -65,12 +65,11 @@ export function FantasyPageHero() {
           </div>
 
           <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <Link to="/pricing" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-7 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5"><Trophy className="h-4 w-4 fill-current" /> Enter the League</Link>
             <a href="#pick-squad" className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-400/45 bg-violet-500/[0.08] px-7 py-3.5 text-sm font-black uppercase tracking-wide text-violet-100 transition-all hover:-translate-y-0.5 hover:bg-violet-500/15">Build Your Squad <ChevronDown className="h-4 w-4" /></a>
           </div>
 
           <div className="mt-5 inline-flex items-center gap-2 text-[12px] font-black uppercase tracking-[0.14em] text-white/55">
-            <Crown className="h-4 w-4 text-violet-300" /> Registration open · season starts Aug 2026
+            <Crown className="h-4 w-4 text-violet-300" /> Season starts Sat 22nd August 2026
           </div>
         </div>
 

--- a/src/components/fantasy/FantasyPrizes.tsx
+++ b/src/components/fantasy/FantasyPrizes.tsx
@@ -107,7 +107,7 @@ export function FantasyPrizes() {
               <div className="text-[12px] text-white/55">One league. Weekly rewards. Season-long glory.</div>
             </div>
           </div>
-          <Link to="/pricing" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Play Fantasy Now <ChevronRight className="h-4 w-4" /></Link>
+          <Link to="/fantasy-waitlist" className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Play Fantasy Now <ChevronRight className="h-4 w-4" /></Link>
         </div>
       </div>
     </section>

--- a/src/components/fantasy/LeagueStandings.tsx
+++ b/src/components/fantasy/LeagueStandings.tsx
@@ -126,7 +126,7 @@ export function LeagueStandings() {
                 </p>
               )}
             </div>
-            <Link to="/pricing" className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-5 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Join &amp; Climb <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" /></Link>
+            <Link to="/fantasy-waitlist" className="group inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-5 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] transition-transform hover:-translate-y-0.5">Join &amp; Climb <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" /></Link>
           </div>
         </div>
       </div>

--- a/src/components/fantasy/SquadBuilder.tsx
+++ b/src/components/fantasy/SquadBuilder.tsx
@@ -209,7 +209,7 @@ export function SquadBuilder() {
                 <span>Pick <span className="font-black text-white">{FANTASY_RULES.squadSize - selected.length}</span> more to complete your 15.</span>
               )}
             </div>
-            <Link to="/pricing" className={`inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-black uppercase tracking-wide transition-transform hover:-translate-y-0.5 ${ready ? 'bg-gradient-to-r from-amber-300 to-amber-500 text-[#16051f]' : 'bg-gradient-to-r from-amber-300/60 to-amber-500/60 text-[#16051f]/80'}`}>
+            <Link to="/fantasy-waitlist" className={`inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-sm font-black uppercase tracking-wide transition-transform hover:-translate-y-0.5 ${ready ? 'bg-gradient-to-r from-amber-300 to-amber-500 text-[#16051f]' : 'bg-gradient-to-r from-amber-300/60 to-amber-500/60 text-[#16051f]/80'}`}>
               <Lock className="h-4 w-4" /> Save Squad &amp; Join
             </Link>
           </div>

--- a/src/pages/FantasyWaitlist.tsx
+++ b/src/pages/FantasyWaitlist.tsx
@@ -9,7 +9,7 @@ import { FooterNavigation } from '@/components/homepage/FooterNavigation';
 
 // FPL-style vibrant band.
 const BAND = 'bg-[linear-gradient(120deg,#22d3ee_0%,#3b82f6_38%,#8b5cf6_72%,#d946ef_100%)]';
-const KICKOFF = '2026-08-01T18:00:00+01:00';
+const KICKOFF = '2026-08-22T15:00:00+01:00';
 
 /* ═══ tiny animation hooks (no deps) ═══════════════════════════════════════ */
 
@@ -323,7 +323,7 @@ function CountdownStrip() {
       <div className="mx-auto flex max-w-md items-center justify-between gap-2">
         <div className="shrink-0">
           <div className="text-[10px] font-black uppercase tracking-[0.18em] text-[#f8e7a1]">Season kicks off in</div>
-          <div className="mt-0.5 text-[11px] font-bold text-white/45">1st August · 6pm UK</div>
+          <div className="mt-0.5 text-[11px] font-bold text-white/45">Sat 22nd August 2026</div>
         </div>
         <div className="flex gap-1.5">
           {cells.map(([v, l]) => (
@@ -398,7 +398,7 @@ export default function FantasyWaitlist() {
           <div className="relative flex items-stretch">
             <div className="flex min-w-0 flex-1 flex-col justify-center px-5 py-9 md:px-8 md:py-14">
               <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-black/30 px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-white backdrop-blur-sm">
-                <Sparkles className="h-3 w-3" /> Kicks off 1st August
+                <Sparkles className="h-3 w-3" /> Season starts 22nd Aug
               </span>
               <h1 className="mt-3 font-display text-[42px] uppercase leading-[0.84] tracking-tight text-white drop-shadow-[0_3px_10px_rgba(0,0,0,0.35)] sm:text-6xl md:text-7xl">
                 Fantasy<br /><span className="text-[#f8e7a1]">Football</span>
@@ -427,8 +427,9 @@ export default function FantasyWaitlist() {
             </h2>
             <p className="mx-auto mt-3 max-w-xl text-[15px] leading-relaxed text-white/70 [text-wrap:balance]">
               Powered by the official Premier League game — real players, real points, real prizes. Your entry's part of the
-              all-in Footy Oracle membership: <b className="text-white">£8.99 a month, everything included</b>. The season kicks
-              off <b className="text-white">1st August</b> — join the waitlist and you're first through the door.
+              all-in Footy Oracle membership: <b className="text-white">£8.99 a month, everything included</b>, opening{' '}
+              <b className="text-white">1st August</b>. The Premier League season kicks off{' '}
+              <b className="text-white">Sat 22nd August</b> — join the waitlist and you're first through the door.
             </p>
             <div className="mt-6"><WaitlistForm source="fantasy-hero" /></div>
             <p className="mt-3 flex items-center justify-center gap-1.5 text-[11px] text-white/40">


### PR DESCRIPTION
- The Premier League season actually starts **Sat 22nd August 2026** (membership still opens 1st August). The countdown now targets 22 Aug; the hero chip and register copy state both dates correctly.
- `/fantasy-league`: removed the "Enter the League" button (it led to the un-wired pricing page) and repointed the page's other pricing CTAs at the live waitlist. Footer note now reads "Season starts Sat 22nd August 2026" instead of "Registration open".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_