### PR TITLE
Lock team placing until 1st August

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,6 @@ const MembersDashboard = lazy(() => import("./pages/MembersDashboard"));
 const ComingSoon = lazy(() => import("./pages/ComingSoon"));
 const FormTables = lazy(() => import("./pages/FormTables"));
 const FantasyLeague = lazy(() => import("./pages/FantasyLeague"));
-const FantasyMyTeam = lazy(() => import("./pages/FantasyMyTeam"));
-const FantasyTransfers = lazy(() => import("./pages/FantasyTransfers"));
-const FantasyResults = lazy(() => import("./pages/FantasyResults"));
 const Pnl = lazy(() => import("./pages/Pnl"));
 const FantasyWaitlist = lazy(() => import("./pages/FantasyWaitlist"));
 const AdminWaitlist = lazy(() => import("./pages/AdminWaitlist"));
@@ -65,9 +62,10 @@ const App = () => {
 
                 {/* Placeholder shells — to be rebuilt from scratch */}
                 <Route path="/fantasy-league" element={<FantasyLeague />} />
-                <Route path="/fantasy-league/my-team" element={<FantasyMyTeam />} />
-                <Route path="/fantasy-league/transfers" element={<FantasyTransfers />} />
-                <Route path="/fantasy-league/results" element={<FantasyResults />} />
+                {/* Team management is locked until the membership opens (1 Aug). */}
+                <Route path="/fantasy-league/my-team" element={<ComingSoon title="My Team" eyebrow="Coming 1st August" description="Team building opens with the membership on 1st August — the Premier League season kicks off Sat 22nd. Join the fantasy waitlist to be first in." />} />
+                <Route path="/fantasy-league/transfers" element={<ComingSoon title="Transfers" eyebrow="Coming 1st August" description="The transfer market opens with the membership on 1st August. Join the fantasy waitlist to be first in." />} />
+                <Route path="/fantasy-league/results" element={<ComingSoon title="Gameweek Results" eyebrow="Coming 1st August" description="Gameweek results go live once the season kicks off on Sat 22nd August. Join the fantasy waitlist to be first in." />} />
                 <Route path="/form-tables" element={<FormTables />} />
                 <Route path="/fixtures" element={<ComingSoon title="Today's Fixtures" eyebrow="In Build" />} />
                 <Route path="/tips" element={<ComingSoon title="Daily Tips" eyebrow="In Build" />} />

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { CalendarClock, Lock, ArrowRight } from 'lucide-react';
 import { HomepageNav } from '@/components/homepage/HomepageNav';
 import { FooterNavigation } from '@/components/homepage/FooterNavigation';
 import { HomepageScene } from '@/components/homepage/HomepageScene';
 import { FantasySubNav } from '@/components/fantasy/FantasySubNav';
 import { FantasyPageHero } from '@/components/fantasy/FantasyPageHero';
-import { SquadBuilder } from '@/components/fantasy/SquadBuilder';
 import { LeagueStandings } from '@/components/fantasy/LeagueStandings';
 import { FantasyPrizes } from '@/components/fantasy/FantasyPrizes';
 
@@ -29,7 +30,26 @@ export default function FantasyLeague() {
 
       <HomepageScene tone="violet" eyebrow="01 · Pick Your Squad">
         <div className="mx-auto max-w-7xl px-3 sm:px-4 md:px-6">
-          <SquadBuilder />
+          {/* Squad building is locked until the membership opens — no team
+              placing before launch. */}
+          <div className="frost-3d mx-auto max-w-xl rounded-[1.4rem] p-8 text-center md:p-10">
+            <div className="mx-auto grid h-14 w-14 place-items-center rounded-full border border-[#f5c542]/40 bg-[#f5c542]/12 text-[#f5c542]">
+              <Lock className="h-6 w-6" />
+            </div>
+            <h3 className="mt-4 font-display text-3xl uppercase leading-none tracking-tight text-white md:text-4xl">
+              Squad building opens<br /><span className="text-[#f8e7a1]">1st August</span>
+            </h3>
+            <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-white/60">
+              Team picking is locked until the membership opens. The Premier League season kicks off Sat 22nd August —
+              get on the waitlist and you'll be first to build your squad.
+            </p>
+            <Link
+              to="/fantasy-waitlist"
+              className="mt-6 inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-7 py-3.5 text-sm font-black uppercase tracking-wide text-[#16051f] shadow-[0_16px_40px_-16px_rgba(245,197,66,1)] transition-transform hover:-translate-y-0.5"
+            >
+              <CalendarClock className="h-4 w-4" /> Coming 1st August — Join the Waitlist <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
         </div>
       </HomepageScene>
 


### PR DESCRIPTION
No squads can be built or teams placed before launch:

- **`/fantasy-league`** — the interactive SquadBuilder is replaced with a locked panel: "Squad building opens 1st August" + a **"Coming 1st August — Join the Waitlist"** button.
- **`/fantasy-league/my-team`, `/transfers`, `/results`** — now render Coming-1st-August gates (with launch-specific copy) instead of the interactive team-management pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_