### PR TITLE
Corners/cards selections: show the count with the score, live and at FT

### DIFF
--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -61,9 +61,13 @@ function settleLeg(leg: Leg, ip: InPlayState): 'won' | 'lost' | null {
   return metric > line ? 'won' : 'lost';
 }
 
+// Corners picks live and die on the corner count — append it to the score.
+const cornerNote = (leg: Leg, ip: InPlayState): string =>
+  leg.market === 'Corners' && ip.corners != null ? ` · ${ip.corners} crn` : '';
+
 function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | null {
   // Finished — FootyStats carries the final numbers → settle Won/Lost.
-  if (ip?.ended) return { state: 'ft', result: settleLeg(leg, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}` };
+  if (ip?.ended) return { state: 'ft', result: settleLeg(leg, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}${cornerNote(leg, ip)}` };
   // Live score from API-Football (real in-play, carries the minute).
   if (live) {
     const score = `${live.gh}–${live.ga}`;
@@ -79,7 +83,7 @@ function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | 
   // FootyStats carries the running goal count during the match, so show it.
   if (ip?.live) {
     const landed = settleLeg(leg, ip) === 'won';
-    return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}` };
+    return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}${cornerNote(leg, ip)}` };
   }
   // No score data anywhere yet — the time-based badge so it still reads live.
   if (legPhase(leg) === 'live') return { state: 'live', text: 'In Play' };

--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -289,9 +289,17 @@ function fixtureLive(time: string, date: string, today: string): boolean {
   return nowMin >= ko && nowMin < ko + 160;
 }
 
+// For corners/cards selections the market metric IS the story — append it to
+// the score so members can see the count (live and at FT).
+function metricNote(catKey: CatKey, ip: InPlayState): string {
+  if (catKey === 'corners' && ip.corners != null) return ` · ${ip.corners} crn`;
+  if (catKey === 'cards' && ip.cards != null) return ` · ${ip.cards} cards`;
+  return '';
+}
+
 function valueStatus(sel: ValueSel, ip: InPlayState | undefined, live: LiveScore | undefined, today: string): VStatus | null {
-  // Finished — settle Won/Lost from FootyStats final numbers.
-  if (ip?.ended) return { state: 'ft', result: settleMarket(sel.catKey, sel.line, sel.under, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}` };
+  // Finished — settle Won/Lost from FootyStats final numbers (+ corner/card count).
+  if (ip?.ended) return { state: 'ft', result: settleMarket(sel.catKey, sel.line, sel.under, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}${metricNote(sel.catKey, ip)}` };
   // Real live score from API-Football.
   if (live) {
     const score = `${live.gh}–${live.ga}`;
@@ -301,6 +309,12 @@ function valueStatus(sel: ValueSel, ip: InPlayState | undefined, live: LiveScore
       : !sel.under && sel.catKey === 'btts' ? live.gh > 0 && live.ga > 0
       : false;
     return { state: 'live', landed, text: `${clock} · ${score}` };
+  }
+  // FootyStats carries a running score + corner count mid-match for leagues
+  // API-Football doesn't stream — show it rather than a bare 'In Play'.
+  if (ip?.live) {
+    const landed = settleMarket(sel.catKey, sel.line, sel.under, ip) === 'won';
+    return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}${metricNote(sel.catKey, ip)}` };
   }
   if (fixtureLive(sel.f.time, sel.f.date, today)) return { state: 'live', text: 'In Play' };
   return null;


### PR DESCRIPTION
For corners (and cards) picks the market metric IS the story — the badge now reads **"FT 1–2 · 11 crn · LOST"** instead of a bare score, and shows **"LIVE · 1–1 · 7 crn"** mid-match via FootyStats' running numbers (for the leagues API-Football doesn't stream). Applied on the form-tables value board and the homepage board.

Verified live: Elfsborg v Hammarby (Under 9.5 Corners) now shows FT 1–2 · 11 crn · LOST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Score/status text now includes live and final corner/card counts where available, giving clearer at-a-glance context for corners and cards markets.
  * Live value-bet status display can now show updated in-match information more directly when live data is available.

* **Bug Fixes**
  * Improved consistency of “FT” and “LIVE” labels so market summaries better reflect the current match state across supported bet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->