### PR TITLE
Add first-party visitor counter (beacon + private stats endpoint)

### DIFF
--- a/functions/api/hit.ts
+++ b/functions/api/hit.ts
@@ -1,0 +1,34 @@
+interface Env {
+  WAITLIST: KVNamespace;
+}
+
+// Lightweight first-party page-view beacon. Stores only daily counters and a
+// 26h-TTL salted hash for unique-visitor dedupe — no IPs, no personal data.
+const DAY = 60 * 60 * 24;
+
+async function sha16(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 16);
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const ip = request.headers.get('cf-connecting-ip') ?? '';
+    const ua = request.headers.get('user-agent') ?? '';
+
+    const hits = Number((await env.WAITLIST.get(`hits:${today}`)) ?? '0') + 1;
+    await env.WAITLIST.put(`hits:${today}`, String(hits), { expirationTtl: DAY * 40 });
+
+    // Unique visitor: one count per ip+ua per day (hash expires after 26h).
+    const uvKey = `uv:${today}:${await sha16(ip + ua + today)}`;
+    if (!(await env.WAITLIST.get(uvKey))) {
+      await env.WAITLIST.put(uvKey, '1', { expirationTtl: 60 * 60 * 26 });
+      const uniq = Number((await env.WAITLIST.get(`uniq:${today}`)) ?? '0') + 1;
+      await env.WAITLIST.put(`uniq:${today}`, String(uniq), { expirationTtl: DAY * 40 });
+    }
+  } catch {
+    // Counting must never break the site — swallow everything.
+  }
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+};

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -1,0 +1,35 @@
+// Cloudflare Pages Function — private traffic stats.
+//
+//   GET /api/stats?key=…   -> { days: [{date, views, uniques}], waitlist }
+//
+// Reads the daily counters written by /api/hit plus the waitlist count.
+interface Env {
+  WAITLIST: KVNamespace;
+  ADMIN_KEY?: string;
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  });
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const url = new URL(request.url);
+  const key = url.searchParams.get('key') ?? request.headers.get('x-admin-key') ?? '';
+  if (!env.ADMIN_KEY || key !== env.ADMIN_KEY) return json({ ok: false, error: 'unauthorized' }, 401);
+
+  const days: { date: string; views: number; uniques: number }[] = [];
+  const now = Date.now();
+  for (let i = 13; i >= 0; i--) {
+    const date = new Date(now - i * 86_400_000).toISOString().slice(0, 10);
+    const [views, uniques] = await Promise.all([
+      env.WAITLIST.get(`hits:${date}`),
+      env.WAITLIST.get(`uniq:${date}`),
+    ]);
+    days.push({ date, views: Number(views ?? 0), uniques: Number(uniques ?? 0) });
+  }
+
+  const signups = await env.WAITLIST.list({ prefix: 'signup:', limit: 1000 });
+  return json({ ok: true, days, waitlist: signups.keys.length });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,12 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+// First-party visit beacon — once per browser session, production host only.
+try {
+  if (!/^(localhost|127\.|192\.168\.)/.test(location.hostname) && !sessionStorage.getItem("fo_hit")) {
+    sessionStorage.setItem("fo_hit", "1");
+    if (!navigator.sendBeacon?.("/api/hit")) void fetch("/api/hit", { method: "POST", keepalive: true }).catch(() => {});
+  }
+} catch { /* counting must never break the site */ }
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
- `POST /api/hit` — increments daily `hits:<date>` and `uniq:<date>` counters in the existing WAITLIST KV namespace. Unique-visitor dedupe uses a SHA-256 hash of ip+ua+date with a 26-hour TTL — no IPs or personal data are ever stored. Counters expire after 40 days. All failures are swallowed so counting can never break the site.
- `GET /api/stats?key=…` — admin-key gated (same ADMIN_KEY as the waitlist), returns the last 14 days of `{date, views, uniques}` plus the current waitlist count.
- `src/main.tsx` — a once-per-browser-session `sendBeacon('/api/hit')` (fetch keepalive fallback), skipped on localhost/LAN hosts.

Verified end-to-end in production: beacon POST recorded, stats endpoint returns today's counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_