### PR TITLE
Form tables: rolling week ahead, past days pruned

### DIFF
--- a/scripts/generate-board.py
+++ b/scripts/generate-board.py
@@ -23,7 +23,7 @@ if not KEY:
     raise SystemExit("FOOTYSTATS_KEY is not set — refusing to run without a key.")
 BASE = "https://api.football-data-api.com"
 OUT = "src/data/formTablesData.json"
-KEEP_PAST_DAYS = 8   # keep this many past days in the file for settlement / history
+KEEP_PAST_DAYS = 2   # yesterday (for settlement) + one spare; the UI never shows past days
 
 def get(path, tries=4):
     for i in range(tries):
@@ -122,7 +122,7 @@ for lg in ll:
         if s.get("id") is not None and nm: smap[int(s["id"])]={"name":nm,"country":co}
 
 today=datetime.datetime.utcnow().date()
-window=[(today+datetime.timedelta(days=n)).isoformat() for n in range(3)]
+window=[(today+datetime.timedelta(days=n)).isoformat() for n in range(7)]  # a week ahead — quiet midweeks still show the coming games
 active=set()
 for d in window:
     for m in get(f"/todays-matches?key={KEY}&date={d}").get("data",[]):

--- a/src/data/formTablesData.json
+++ b/src/data/formTablesData.json
@@ -1,38 +1,6 @@
 {
   "leagues": [
     {
-      "name": "First Division",
-      "region": "Norway"
-    },
-    {
-      "name": "Esiliiga",
-      "region": "Estonia"
-    },
-    {
-      "name": "Meistriliiga",
-      "region": "Estonia"
-    },
-    {
-      "name": "Úrvalsdeild",
-      "region": "Iceland"
-    },
-    {
-      "name": "Chinese Super League",
-      "region": "China"
-    },
-    {
-      "name": "Ykkösliiga",
-      "region": "Finland"
-    },
-    {
-      "name": "Allsvenskan",
-      "region": "Sweden"
-    },
-    {
-      "name": "Premier Division",
-      "region": "Republic of Ireland"
-    },
-    {
       "name": "China League One",
       "region": "China"
     },
@@ -45,6604 +13,47 @@
       "region": "South Korea"
     },
     {
+      "name": "Chinese Super League",
+      "region": "China"
+    },
+    {
+      "name": "First Division",
+      "region": "Norway"
+    },
+    {
       "name": "Veikkausliiga",
       "region": "Finland"
+    },
+    {
+      "name": "Esiliiga",
+      "region": "Estonia"
+    },
+    {
+      "name": "Allsvenskan",
+      "region": "Sweden"
+    },
+    {
+      "name": "Ykkösliiga",
+      "region": "Finland"
+    },
+    {
+      "name": "Úrvalsdeild",
+      "region": "Iceland"
+    },
+    {
+      "name": "Meistriliiga",
+      "region": "Estonia"
+    },
+    {
+      "name": "Premier Division",
+      "region": "Republic of Ireland"
+    },
+    {
+      "name": "Eliteserien",
+      "region": "Norway"
     }
   ],
   "fixtures": [
-    {
-      "id": "8412462",
-      "league": "First Division",
-      "region": "Norway",
-      "date": "2026-07-02",
-      "time": "17:00",
-      "home": {
-        "name": "Lyn",
-        "short": "LYN",
-        "logo": "https://cdn.footystats.org/img/teams/norway-fc-lyn-oslo.png"
-      },
-      "away": {
-        "name": "Åsane",
-        "short": "ÅSA",
-        "logo": "https://cdn.footystats.org/img/teams/norway-asane-fotball.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.1,
-      "corners_avg": 10.7,
-      "cards_avg": 3.3,
-      "btts_pct": 34.5,
-      "goals_over": {
-        "0.5": 96,
-        "1.5": 81,
-        "2.5": 65.5,
-        "3.5": 31,
-        "4.5": 19
-      },
-      "corners_over": {
-        "8.5": 77,
-        "9.5": 69,
-        "10.5": 42.5,
-        "11.5": 31
-      },
-      "cards_over": {
-        "2.5": 65.5,
-        "3.5": 50,
-        "4.5": 38.5,
-        "5.5": 19.5
-      },
-      "goals_odds": {
-        "2.5": 1.51,
-        "3.5": 2.24,
-        "4.5": 3.9
-      },
-      "corners_odds": {
-        "8.5": 1.23,
-        "9.5": 1.58,
-        "10.5": 1.77,
-        "11.5": 2
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.47,
-      "goals_under_odds": {
-        "0.5": 15,
-        "1.5": 5.25,
-        "2.5": 2.55,
-        "3.5": 1.58
-      },
-      "corners_under_odds": {
-        "8.5": 3.42,
-        "9.5": 2.47,
-        "10.5": 1.93,
-        "11.5": 1.7
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.4,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 65.5,
-            "odds": 1.51,
-            "implied": 66.2,
-            "edge": -0.7,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 31,
-            "odds": 2.24,
-            "implied": 44.6,
-            "edge": -13.6,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 19,
-            "odds": 3.9,
-            "implied": 25.6,
-            "edge": -6.6,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 77,
-            "odds": 1.23,
-            "implied": 81.3,
-            "edge": -4.3,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 69,
-            "odds": 1.58,
-            "implied": 63.3,
-            "edge": 5.7,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 42.5,
-            "odds": 1.77,
-            "implied": 56.5,
-            "edge": -14,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 31,
-            "odds": 2,
-            "implied": 50,
-            "edge": -19,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 34.5,
-          "odds": 1.47,
-          "implied": 68,
-          "edge": -33.5,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Hødd",
-          "ha": "H",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Ranheim",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 10,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Bryne",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 14,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-30",
-          "opp": "Odd",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Strømmen",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 6,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Egersund",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 10,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Kongsvinger",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Raufoss",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 1,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Ranheim",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 15,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Bryne",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 11,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Odd",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Kongsvinger",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 11,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Raufoss",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Sandnes Ulf",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 8,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Haugesund",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 12,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Strømsgodset",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8464277",
-      "league": "Esiliiga",
-      "region": "Estonia",
-      "date": "2026-07-02",
-      "time": "17:00",
-      "home": {
-        "name": "Tartu JK Welco",
-        "short": "TAR",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-tartu-jk-welco.png"
-      },
-      "away": {
-        "name": "Viimsi",
-        "short": "VII",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-viimsi-jk.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.3,
-      "corners_avg": 9,
-      "cards_avg": 3.4,
-      "btts_pct": 48.5,
-      "goals_over": {
-        "0.5": 97,
-        "1.5": 84.5,
-        "2.5": 54.5,
-        "3.5": 42,
-        "4.5": 26.5
-      },
-      "corners_over": {
-        "8.5": 45,
-        "9.5": 33,
-        "10.5": 23.5,
-        "11.5": 20.5
-      },
-      "cards_over": {
-        "2.5": 69.5,
-        "3.5": 41.5,
-        "4.5": 24,
-        "5.5": 17
-      },
-      "goals_odds": {
-        "2.5": 1.48,
-        "3.5": 2.23,
-        "4.5": 3.68
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.44,
-      "goals_under_odds": {
-        "0.5": 15,
-        "1.5": 6,
-        "2.5": 2.33,
-        "3.5": 1.54
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.5,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 54.5,
-            "odds": 1.48,
-            "implied": 67.6,
-            "edge": -13.1,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 42,
-            "odds": 2.23,
-            "implied": 44.8,
-            "edge": -2.8,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 26.5,
-            "odds": 3.68,
-            "implied": 27.2,
-            "edge": -0.7,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
-        },
-        "btts": {
-          "prob": 48.5,
-          "odds": 1.44,
-          "implied": 69.4,
-          "edge": -20.9,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-21",
-          "opp": "Nõmme United II",
-          "ha": "H",
-          "gf": 5,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-18",
-          "opp": "Tallinna FC Levadia U21",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-13",
-          "opp": "FC Tallinn",
-          "ha": "H",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-06-01",
-          "opp": "Elva",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-28",
-          "opp": "Nõmme Kalju FC U21",
-          "ha": "H",
-          "gf": 4,
-          "ga": 2,
-          "res": "W",
-          "corners": 16,
-          "cards": 0,
-          "btts": true
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Maardu Linnameeskond",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Tallinna FC Flora U21",
-          "ha": "H",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Tallinna Kalev",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 5,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-22",
-          "opp": "Maardu Linnameeskond",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 8,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-06-18",
-          "opp": "Elva",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 17,
-          "cards": 8,
-          "btts": false
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Tallinna FC Levadia U21",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 8,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-27",
-          "opp": "Tallinna Kalev",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "FC Tallinn",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 5,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Nõmme Kalju FC U21",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Tallinna FC Flora U21",
-          "ha": "A",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 5,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-01",
-          "opp": "Tallinna FC Levadia U21",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 6,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-23",
-          "home": "Viimsi",
-          "away": "Tartu JK Welco",
-          "hg": 2,
-          "ag": 0,
-          "corners": 10,
-          "cards": 8
-        }
-      ]
-    },
-    {
-      "id": "8465697",
-      "league": "Meistriliiga",
-      "region": "Estonia",
-      "date": "2026-07-02",
-      "time": "17:00",
-      "home": {
-        "name": "Kuressaare",
-        "short": "KUR",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-kuressaare.png"
-      },
-      "away": {
-        "name": "Tallinna FC Flora",
-        "short": "TAL",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-flora.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.9,
-      "corners_avg": 11.5,
-      "cards_avg": 3.8,
-      "btts_pct": 47,
-      "goals_over": {
-        "0.5": 97,
-        "1.5": 79.5,
-        "2.5": 64.5,
-        "3.5": 29.5,
-        "4.5": 15
-      },
-      "corners_over": {
-        "8.5": 88,
-        "9.5": 76.5,
-        "10.5": 67.5,
-        "11.5": 59
-      },
-      "cards_over": {
-        "2.5": 70.5,
-        "3.5": 49.5,
-        "4.5": 34.5,
-        "5.5": 23
-      },
-      "goals_odds": {
-        "2.5": 1.44,
-        "3.5": 1.89,
-        "4.5": 3.58
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": 1.23,
-        "10.5": 1.4,
-        "11.5": 1.63
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.76,
-      "goals_under_odds": {
-        "0.5": 17,
-        "1.5": 3.5,
-        "2.5": 2.55,
-        "3.5": 1.49
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": 3.5,
-        "10.5": 2.65,
-        "11.5": 2.1
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.75,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 64.5,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": -4.9,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 29.5,
-            "odds": 1.89,
-            "implied": 52.9,
-            "edge": -23.4,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 15,
-            "odds": 3.58,
-            "implied": 27.9,
-            "edge": -12.9,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": {
-            "prob": 76.5,
-            "odds": 1.23,
-            "implied": 81.3,
-            "edge": -4.8,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 67.5,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": -3.9,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 59,
-            "odds": 1.63,
-            "implied": 61.3,
-            "edge": -2.3,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 47,
-          "odds": 1.76,
-          "implied": 56.8,
-          "edge": -9.8,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Vaprus",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 16,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Trans",
-          "ha": "H",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 12,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-06-13",
-          "opp": "Harju Jalgpallikool",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 16,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Paide",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Nõmme United",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Nõmme Kalju",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Tammeka",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 10,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Tallinna FC Levadia",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 10,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "Tallinna FC Levadia",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Paide",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Vaprus",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-13",
-          "opp": "Tallinna FC Levadia",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Nõmme United",
-          "ha": "A",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Trans",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Nõmme Kalju",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 18,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-04-30",
-          "opp": "Harju Jalgpallikool",
-          "ha": "H",
-          "gf": 5,
-          "ga": 0,
-          "res": "W",
-          "corners": 5,
-          "cards": 1,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-07",
-          "home": "Tallinna FC Flora",
-          "away": "Kuressaare",
-          "hg": 2,
-          "ag": 1,
-          "corners": 11,
-          "cards": 2
-        }
-      ]
-    },
-    {
-      "id": "8447231",
-      "league": "Úrvalsdeild",
-      "region": "Iceland",
-      "date": "2026-07-02",
-      "time": "18:00",
-      "home": {
-        "name": "Thór",
-        "short": "THÓ",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-thor-akureyri.png"
-      },
-      "away": {
-        "name": "KR",
-        "short": "KR",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-kr-reykjavik.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 4.7,
-      "corners_avg": 13.3,
-      "cards_avg": 4.4,
-      "btts_pct": 75,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 87.5,
-        "2.5": 79.5,
-        "3.5": 71,
-        "4.5": 55
-      },
-      "corners_over": {
-        "8.5": 80,
-        "9.5": 80,
-        "10.5": 80,
-        "11.5": 80
-      },
-      "cards_over": {
-        "2.5": 91.5,
-        "3.5": 71,
-        "4.5": 31.5,
-        "5.5": 24
-      },
-      "goals_odds": {
-        "2.5": 1.14,
-        "3.5": 1.4,
-        "4.5": 2.04
-      },
-      "corners_odds": {
-        "8.5": 1.07,
-        "9.5": 1.2,
-        "10.5": 1.34,
-        "11.5": 1.59
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.22,
-      "goals_under_odds": {
-        "0.5": 27,
-        "1.5": 11,
-        "2.5": 4.5,
-        "3.5": 2.7
-      },
-      "corners_under_odds": {
-        "8.5": 5.75,
-        "9.5": 4.01,
-        "10.5": 2.83,
-        "11.5": 2.18
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.14,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 79.5,
-            "odds": 1.14,
-            "implied": 87.7,
-            "edge": -8.2,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 71,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": -0.4,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 55,
-            "odds": 2.04,
-            "implied": 49,
-            "edge": 6,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 80,
-            "odds": 1.07,
-            "implied": 93.5,
-            "edge": -13.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 80,
-            "odds": 1.2,
-            "implied": 83.3,
-            "edge": -3.3,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 80,
-            "odds": 1.34,
-            "implied": 74.6,
-            "edge": 5.4,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 80,
-            "odds": 1.59,
-            "implied": 62.9,
-            "edge": 17.1,
-            "flag": "value"
-          }
-        },
-        "btts": {
-          "prob": 75,
-          "odds": 1.22,
-          "implied": 82,
-          "edge": -7,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "Valur",
-          "ha": "H",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 6,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "FH",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "ÍBV",
-          "ha": "H",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Stjarnan",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 14,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Keflavík",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 16,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "ÍA",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 20,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Víkingur Reykjavík",
-          "ha": "A",
-          "gf": 0,
-          "ga": 6,
-          "res": "L",
-          "corners": 8,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 12,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "Keflavík",
-          "ha": "A",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "ÍA",
-          "ha": "H",
-          "gf": 5,
-          "ga": 3,
-          "res": "W",
-          "corners": 17,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Víkingur Reykjavík",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 13,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 5,
-          "ga": 3,
-          "res": "W",
-          "corners": 19,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-26",
-          "opp": "Valur",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 17,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Breidablik",
-          "ha": "A",
-          "gf": 3,
-          "ga": 6,
-          "res": "L",
-          "corners": 14,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 15,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Stjarnan",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 14,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-17",
-          "home": "KR",
-          "away": "Thór",
-          "hg": 5,
-          "ag": 2,
-          "corners": 12,
-          "cards": 4
-        }
-      ]
-    },
-    {
-      "id": "8447228",
-      "league": "Úrvalsdeild",
-      "region": "Iceland",
-      "date": "2026-07-02",
-      "time": "20:15",
-      "home": {
-        "name": "Víkingur Reykjavík",
-        "short": "VÍK",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-vikingur-reykjavik.png"
-      },
-      "away": {
-        "name": "KA",
-        "short": "KA",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-ka-akureyri.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.8,
-      "corners_avg": 11.8,
-      "cards_avg": 4.4,
-      "btts_pct": 56.5,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 91.5,
-        "2.5": 63.5,
-        "3.5": 55.5,
-        "4.5": 35.5
-      },
-      "corners_over": {
-        "8.5": 88.5,
-        "9.5": 76,
-        "10.5": 68.5,
-        "11.5": 44
-      },
-      "cards_over": {
-        "2.5": 80.5,
-        "3.5": 64.5,
-        "4.5": 28,
-        "5.5": 24
-      },
-      "goals_odds": {
-        "2.5": 1.25,
-        "3.5": 1.58,
-        "4.5": 1.99
-      },
-      "corners_odds": {
-        "8.5": 1.09,
-        "9.5": 1.24,
-        "10.5": 1.44,
-        "11.5": 1.75
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.53,
-      "goals_under_odds": {
-        "0.5": 23,
-        "1.5": 9,
-        "2.5": 3.75,
-        "3.5": 1.91
-      },
-      "corners_under_odds": {
-        "8.5": 4.99,
-        "9.5": 3.34,
-        "10.5": 2.47,
-        "11.5": 1.94
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.83,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 63.5,
-            "odds": 1.25,
-            "implied": 80,
-            "edge": -16.5,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 55.5,
-            "odds": 1.58,
-            "implied": 63.3,
-            "edge": -7.8,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 35.5,
-            "odds": 1.99,
-            "implied": 50.3,
-            "edge": -14.8,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 88.5,
-            "odds": 1.09,
-            "implied": 91.7,
-            "edge": -3.2,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 76,
-            "odds": 1.24,
-            "implied": 80.6,
-            "edge": -4.6,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 68.5,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": -0.9,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 44,
-            "odds": 1.75,
-            "implied": 57.1,
-            "edge": -13.1,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 56.5,
-          "odds": 1.53,
-          "implied": 65.4,
-          "edge": -8.9,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-25",
-          "opp": "Breidablik",
-          "ha": "A",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 7,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Fram",
-          "ha": "A",
-          "gf": 5,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "KR",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Valur",
-          "ha": "A",
-          "gf": 5,
-          "ga": 1,
-          "res": "W",
-          "corners": 15,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-26",
-          "opp": "Stjarnan",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 13,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "FH",
-          "ha": "H",
-          "gf": 5,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "ÍBV",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Thór",
-          "ha": "H",
-          "gf": 6,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "Stjarnan",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 20,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Breidablik",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 15,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-15",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "KR",
-          "ha": "A",
-          "gf": 3,
-          "ga": 5,
-          "res": "L",
-          "corners": 19,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Valur",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 14,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "FH",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "ÍBV",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Thór",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-17",
-          "home": "KA",
-          "away": "Víkingur Reykjavík",
-          "hg": 0,
-          "ag": 2,
-          "corners": 11,
-          "cards": 4
-        }
-      ]
-    },
-    {
-      "id": "8471306",
-      "league": "Chinese Super League",
-      "region": "China",
-      "date": "2026-07-03",
-      "time": "13:00",
-      "home": {
-        "name": "Yunnan Yukun",
-        "short": "YUN",
-        "logo": "https://cdn.footystats.org/img/teams/china-yunnan-yukun-fc.png"
-      },
-      "away": {
-        "name": "Henan Jianye",
-        "short": "HEN",
-        "logo": "https://cdn.footystats.org/img/teams/china-henan-jianye-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.9,
-      "corners_avg": 9.8,
-      "cards_avg": 4.1,
-      "btts_pct": 62.5,
-      "goals_over": {
-        "0.5": 94,
-        "1.5": 81.5,
-        "2.5": 68.5,
-        "3.5": 25,
-        "4.5": 12.5
-      },
-      "corners_over": {
-        "8.5": 50,
-        "9.5": 44,
-        "10.5": 31.5,
-        "11.5": 31.5
-      },
-      "cards_over": {
-        "2.5": 72,
-        "3.5": 53,
-        "4.5": 34.5,
-        "5.5": 25.5
-      },
-      "goals_odds": {
-        "2.5": 1.5,
-        "3.5": 2.28,
-        "4.5": 3.81
-      },
-      "corners_odds": {
-        "8.5": 1.36,
-        "9.5": 1.66,
-        "10.5": 2.06,
-        "11.5": 2.56
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.42,
-      "goals_under_odds": {
-        "0.5": 17,
-        "1.5": 7.28,
-        "2.5": 2.5,
-        "3.5": 1.64
-      },
-      "corners_under_odds": {
-        "8.5": 2.76,
-        "9.5": 2.25,
-        "10.5": 1.68,
-        "11.5": 1.39
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.66,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 68.5,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": 1.8,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 25,
-            "odds": 2.28,
-            "implied": 43.9,
-            "edge": -18.9,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 12.5,
-            "odds": 3.81,
-            "implied": 26.2,
-            "edge": -13.7,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 50,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": -23.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 44,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -16.2,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 31.5,
-            "odds": 2.06,
-            "implied": 48.5,
-            "edge": -17,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 31.5,
-            "odds": 2.56,
-            "implied": 39.1,
-            "edge": -7.6,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 62.5,
-          "odds": 1.42,
-          "implied": 70.4,
-          "edge": -7.9,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Qingdao Jonoon",
-          "ha": "A",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Wuhan Three Towns",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 9,
-          "btts": true
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Qingdao Youth Island",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Chongqing Tongliang Long",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 9,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Shanghai Shenhua",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Shenyang Urban",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-06",
-          "opp": "Zhejiang FC",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Beijing Guoan",
-          "ha": "H",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 13,
-          "cards": 0,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Shanghai SIPG",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 5,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-30",
-          "opp": "Zhejiang FC",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 8,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Beijing Guoan",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-19",
-          "opp": "Tianjin Teda",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 5,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Sichuan Jiuniu",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Chengdu Better City FC",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-05",
-          "opp": "Chongqing Tongliang Long",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-01",
-          "opp": "Shenyang Urban",
-          "ha": "H",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-03-15",
-          "home": "Henan Jianye",
-          "away": "Yunnan Yukun",
-          "hg": 2,
-          "ag": 1,
-          "corners": 10,
-          "cards": 3
-        }
-      ]
-    },
-    {
-      "id": "8431901",
-      "league": "Ykkösliiga",
-      "region": "Finland",
-      "date": "2026-07-03",
-      "time": "16:30",
-      "home": {
-        "name": "JäPS",
-        "short": "JÄP",
-        "logo": "https://cdn.footystats.org/img/teams/finland-jarvenpaan-palloseura.png"
-      },
-      "away": {
-        "name": "SJK Akatemia",
-        "short": "SJK",
-        "logo": "https://cdn.footystats.org/img/teams/finland-kerho-07-sjk-ii.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.1,
-      "corners_avg": 9.9,
-      "cards_avg": 3.5,
-      "btts_pct": 21,
-      "goals_over": {
-        "0.5": 92,
-        "1.5": 58.5,
-        "2.5": 33.5,
-        "3.5": 16.5,
-        "4.5": 8.5
-      },
-      "corners_over": {
-        "8.5": 62.5,
-        "9.5": 54.5,
-        "10.5": 37.5,
-        "11.5": 25
-      },
-      "cards_over": {
-        "2.5": 54.5,
-        "3.5": 54.5,
-        "4.5": 29,
-        "5.5": 12.5
-      },
-      "goals_odds": {
-        "2.5": 1.59,
-        "3.5": 2.41,
-        "4.5": 4.25
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.52,
-      "goals_under_odds": {
-        "0.5": 11.9,
-        "1.5": 4.1,
-        "2.5": 2.15,
-        "3.5": 1.45
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.32,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 33.5,
-            "odds": 1.59,
-            "implied": 62.9,
-            "edge": -29.4,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 16.5,
-            "odds": 2.41,
-            "implied": 41.5,
-            "edge": -25,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 8.5,
-            "odds": 4.25,
-            "implied": 23.5,
-            "edge": -15,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
-        },
-        "btts": {
-          "prob": 21,
-          "odds": 1.52,
-          "implied": 65.8,
-          "edge": -44.8,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "KäPa",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "PK-35",
-          "ha": "H",
-          "gf": 0,
-          "ga": 5,
-          "res": "L",
-          "corners": 8,
-          "cards": 0,
-          "btts": false
-        },
-        {
-          "date": "2026-06-05",
-          "opp": "Haka",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "KäPa",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "MP",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 12,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "KTP",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "SJK Akatemia",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "PK-35",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Klubi-04",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 16,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-06-15",
-          "opp": "Haka",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 10,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-06-09",
-          "opp": "JIPPO",
-          "ha": "H",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "KTP",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 13,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Haka",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "EIF",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 8,
-          "cards": 0,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "JäPS",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 8,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Klubi-04",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 5,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-09",
-          "home": "SJK Akatemia",
-          "away": "JäPS",
-          "hg": 0,
-          "ag": 2,
-          "corners": 8,
-          "cards": 2
-        }
-      ]
-    },
-    {
-      "id": "8431908",
-      "league": "Ykkösliiga",
-      "region": "Finland",
-      "date": "2026-07-03",
-      "time": "16:30",
-      "home": {
-        "name": "KTP",
-        "short": "KTP",
-        "logo": "https://cdn.footystats.org/img/teams/finland-kotkan-tyovaen-palloilijat.png"
-      },
-      "away": {
-        "name": "JIPPO",
-        "short": "JIP",
-        "logo": "https://cdn.footystats.org/img/teams/finland-jippo-joensuu.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2,
-      "corners_avg": 9.6,
-      "cards_avg": 3.9,
-      "btts_pct": 37.5,
-      "goals_over": {
-        "0.5": 83.5,
-        "1.5": 54,
-        "2.5": 33,
-        "3.5": 12.5,
-        "4.5": 8.5
-      },
-      "corners_over": {
-        "8.5": 46,
-        "9.5": 42,
-        "10.5": 37.5,
-        "11.5": 29
-      },
-      "cards_over": {
-        "2.5": 83,
-        "3.5": 53.5,
-        "4.5": 25,
-        "5.5": 12.5
-      },
-      "goals_odds": {
-        "2.5": 2,
-        "3.5": 3.42,
-        "4.5": 6.75
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.79,
-      "goals_under_odds": {
-        "0.5": 8.4,
-        "1.5": 3.04,
-        "2.5": 1.72,
-        "3.5": 1.23
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.9,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 33,
-            "odds": 2,
-            "implied": 50,
-            "edge": -17,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 12.5,
-            "odds": 3.42,
-            "implied": 29.2,
-            "edge": -16.7,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 8.5,
-            "odds": 6.75,
-            "implied": 14.8,
-            "edge": -6.3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
-        },
-        "btts": {
-          "prob": 37.5,
-          "odds": 1.79,
-          "implied": 55.9,
-          "edge": -18.4,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Haka",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "EIF",
-          "ha": "H",
-          "gf": 5,
-          "ga": 1,
-          "res": "W",
-          "corners": 16,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-08",
-          "opp": "Haka",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 7,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-06-05",
-          "opp": "KäPa",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 17,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "SJK Akatemia",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "Klubi-04",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 4,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "JäPS",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "KäPa",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 6,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "EIF",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 12,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-13",
-          "opp": "KäPa",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-06-09",
-          "opp": "SJK Akatemia",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Haka",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-23",
-          "opp": "PK-35",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "MP",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 13,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Klubi-04",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 4,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "KäPa",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 17,
-          "cards": 6,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-18",
-          "home": "JIPPO",
-          "away": "KTP",
-          "hg": 0,
-          "ag": 0,
-          "corners": 8,
-          "cards": 3
-        }
-      ]
-    },
-    {
-      "id": "8412546",
-      "league": "First Division",
-      "region": "Norway",
-      "date": "2026-07-03",
-      "time": "17:00",
-      "home": {
-        "name": "Raufoss",
-        "short": "RAU",
-        "logo": "https://cdn.footystats.org/img/teams/norway-raufoss-il.png"
-      },
-      "away": {
-        "name": "Strømmen",
-        "short": "STR",
-        "logo": "https://cdn.footystats.org/img/teams/norway-strommen-if.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.8,
-      "corners_avg": 9.7,
-      "cards_avg": 2.4,
-      "btts_pct": 58,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 85,
-        "2.5": 77,
-        "3.5": 46,
-        "4.5": 30.5
-      },
-      "corners_over": {
-        "8.5": 61.5,
-        "9.5": 46,
-        "10.5": 42,
-        "11.5": 27
-      },
-      "cards_over": {
-        "2.5": 54,
-        "3.5": 31,
-        "4.5": 11.5,
-        "5.5": 4
-      },
-      "goals_odds": {
-        "2.5": 1.44,
-        "3.5": 2.25,
-        "4.5": 3.5
-      },
-      "corners_odds": {
-        "8.5": 1.38,
-        "9.5": 1.73,
-        "10.5": 1.93,
-        "11.5": 2.45
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.41,
-      "goals_under_odds": {
-        "0.5": 15,
-        "1.5": 6,
-        "2.5": 2.43,
-        "3.5": 1.63
-      },
-      "corners_under_odds": {
-        "8.5": 2.75,
-        "9.5": 2.22,
-        "10.5": 1.77,
-        "11.5": 1.46
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.7,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 77,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": 7.6,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 46,
-            "odds": 2.25,
-            "implied": 44.4,
-            "edge": 1.6,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 30.5,
-            "odds": 3.5,
-            "implied": 28.6,
-            "edge": 1.9,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 61.5,
-            "odds": 1.38,
-            "implied": 72.5,
-            "edge": -11,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 46,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": -11.8,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 42,
-            "odds": 1.93,
-            "implied": 51.8,
-            "edge": -9.8,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 27,
-            "odds": 2.45,
-            "implied": 40.8,
-            "edge": -13.8,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 58,
-          "odds": 1.41,
-          "implied": 70.9,
-          "edge": -12.9,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Sandnes Ulf",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 8,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Sogndal",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Strømsgodset",
-          "ha": "A",
-          "gf": 1,
-          "ga": 6,
-          "res": "L",
-          "corners": 13,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Haugesund",
-          "ha": "H",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 11,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Åsane",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 10,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Bryne",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 11,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Stabæk",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Lyn",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 1,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Moss",
-          "ha": "H",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 8,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Stabæk",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Sandnes Ulf",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 9,
-          "cards": 0,
-          "btts": false
-        },
-        {
-          "date": "2026-06-07",
-          "opp": "Ranheim",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Sogndal",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Lyn",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 6,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Haugesund",
-          "ha": "H",
-          "gf": 0,
-          "ga": 7,
-          "res": "L",
-          "corners": 7,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Bryne",
-          "ha": "A",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 9,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8412581",
-      "league": "First Division",
-      "region": "Norway",
-      "date": "2026-07-03",
-      "time": "17:00",
-      "home": {
-        "name": "Kongsvinger",
-        "short": "KON",
-        "logo": "https://cdn.footystats.org/img/teams/norway-kongsvinger-il.png"
-      },
-      "away": {
-        "name": "Sogndal",
-        "short": "SOG",
-        "logo": "https://cdn.footystats.org/img/teams/norway-sogndal-fotball.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 4.1,
-      "corners_avg": 11.8,
-      "cards_avg": 3.2,
-      "btts_pct": 69.5,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 100,
-        "2.5": 85,
-        "3.5": 57.5,
-        "4.5": 30.5
-      },
-      "corners_over": {
-        "8.5": 81,
-        "9.5": 73,
-        "10.5": 58,
-        "11.5": 46
-      },
-      "cards_over": {
-        "2.5": 61.5,
-        "3.5": 30.5,
-        "4.5": 15.5,
-        "5.5": 0
-      },
-      "goals_odds": {
-        "2.5": 1.27,
-        "3.5": 1.78,
-        "4.5": 2.65
-      },
-      "corners_odds": {
-        "8.5": 1.24,
-        "9.5": 1.4,
-        "10.5": 1.8,
-        "11.5": 2.24
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.34,
-      "goals_under_odds": {
-        "0.5": 18.5,
-        "1.5": 7.1,
-        "2.5": 3.4,
-        "3.5": 1.98
-      },
-      "corners_under_odds": {
-        "8.5": 3.34,
-        "9.5": 2.7,
-        "10.5": 1.9,
-        "11.5": 1.56
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.93,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 85,
-            "odds": 1.27,
-            "implied": 78.7,
-            "edge": 6.3,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 57.5,
-            "odds": 1.78,
-            "implied": 56.2,
-            "edge": 1.3,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 30.5,
-            "odds": 2.65,
-            "implied": 37.7,
-            "edge": -7.2,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 81,
-            "odds": 1.24,
-            "implied": 80.6,
-            "edge": 0.4,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 73,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": 1.6,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 58,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 2.4,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 46,
-            "odds": 2.24,
-            "implied": 44.6,
-            "edge": 1.4,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 69.5,
-          "odds": 1.34,
-          "implied": 74.6,
-          "edge": -5.1,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Haugesund",
-          "ha": "A",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 16,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Strømsgodset",
-          "ha": "H",
-          "gf": 4,
-          "ga": 4,
-          "res": "D",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Hødd",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 15,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Åsane",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Stabæk",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 13,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Odd",
-          "ha": "H",
-          "gf": 4,
-          "ga": 2,
-          "res": "W",
-          "corners": 10,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Lyn",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 7,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Ranheim",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Egersund",
-          "ha": "H",
-          "gf": 4,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Raufoss",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Moss",
-          "ha": "H",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Strømmen",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 7,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Sandnes Ulf",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 17,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Stabæk",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 25,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Hødd",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 16,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Haugesund",
-          "ha": "H",
-          "gf": 5,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 2,
-          "btts": true
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8465695",
-      "league": "Meistriliiga",
-      "region": "Estonia",
-      "date": "2026-07-03",
-      "time": "17:00",
-      "home": {
-        "name": "Nõmme United",
-        "short": "NÕM",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-nomme-united.png"
-      },
-      "away": {
-        "name": "Nõmme Kalju",
-        "short": "NÕM",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-nomme-kalju-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.4,
-      "corners_avg": 10.6,
-      "cards_avg": 4.5,
-      "btts_pct": 69,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 86,
-        "2.5": 66.5,
-        "3.5": 38,
-        "4.5": 20.5
-      },
-      "corners_over": {
-        "8.5": 74.5,
-        "9.5": 57.5,
-        "10.5": 51.5,
-        "11.5": 34.5
-      },
-      "cards_over": {
-        "2.5": 82.5,
-        "3.5": 65.5,
-        "4.5": 45.5,
-        "5.5": 28.5
-      },
-      "goals_odds": {
-        "2.5": 1.5,
-        "3.5": 2.12,
-        "4.5": 3.4
-      },
-      "corners_odds": {
-        "8.5": 1.22,
-        "9.5": 1.38,
-        "10.5": 1.64,
-        "11.5": 1.98
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.5,
-      "goals_under_odds": {
-        "0.5": 16,
-        "1.5": 5.4,
-        "2.5": 2.5,
-        "3.5": 1.68
-      },
-      "corners_under_odds": {
-        "8.5": 3.6,
-        "9.5": 2.7,
-        "10.5": 2.08,
-        "11.5": 1.71
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.38,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 66.5,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": -0.2,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 38,
-            "odds": 2.12,
-            "implied": 47.2,
-            "edge": -9.2,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 20.5,
-            "odds": 3.4,
-            "implied": 29.4,
-            "edge": -8.9,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 74.5,
-            "odds": 1.22,
-            "implied": 82,
-            "edge": -7.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 57.5,
-            "odds": 1.38,
-            "implied": 72.5,
-            "edge": -15,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 51.5,
-            "odds": 1.64,
-            "implied": 61,
-            "edge": -9.5,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 34.5,
-            "odds": 1.98,
-            "implied": 50.5,
-            "edge": -16,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 69,
-          "odds": 1.5,
-          "implied": 66.7,
-          "edge": 2.3,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-20",
-          "opp": "Harju Jalgpallikool",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-17",
-          "opp": "Tallinna FC Levadia",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 16,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-13",
-          "opp": "Trans",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Tallinna FC Flora",
-          "ha": "H",
-          "gf": 0,
-          "ga": 4,
-          "res": "L",
-          "corners": 12,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Kuressaare",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Tammeka",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Paide",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Vaprus",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 2,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "Paide",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-20",
-          "opp": "Tallinna FC Levadia",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-17",
-          "opp": "Tammeka",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 10,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Paide",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 8,
-          "cards": 9,
-          "btts": true
-        },
-        {
-          "date": "2026-05-30",
-          "opp": "Vaprus",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Harju Jalgpallikool",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 11,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Kuressaare",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 6,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Tallinna FC Flora",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 18,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-22",
-          "home": "Nõmme Kalju",
-          "away": "Nõmme United",
-          "hg": 7,
-          "ag": 1,
-          "corners": 9,
-          "cards": 2
-        }
-      ]
-    },
-    {
-      "id": "8412421",
-      "league": "First Division",
-      "region": "Norway",
-      "date": "2026-07-03",
-      "time": "18:00",
-      "home": {
-        "name": "Ranheim",
-        "short": "RAN",
-        "logo": "https://cdn.footystats.org/img/teams/norway-ranheim-fotball.png"
-      },
-      "away": {
-        "name": "Stabæk",
-        "short": "STA",
-        "logo": "https://cdn.footystats.org/img/teams/norway-stabaek-fotball.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.9,
-      "corners_avg": 12,
-      "cards_avg": 2.9,
-      "btts_pct": 65.5,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 92.5,
-        "2.5": 80.5,
-        "3.5": 65.5,
-        "4.5": 31
-      },
-      "corners_over": {
-        "8.5": 85,
-        "9.5": 73.5,
-        "10.5": 54,
-        "11.5": 42
-      },
-      "cards_over": {
-        "2.5": 61.5,
-        "3.5": 38.5,
-        "4.5": 26.5,
-        "5.5": 11.5
-      },
-      "goals_odds": {
-        "2.5": 1.36,
-        "3.5": 1.89,
-        "4.5": 2.81
-      },
-      "corners_odds": {
-        "8.5": 1.19,
-        "9.5": 1.37,
-        "10.5": 1.75,
-        "11.5": 1.92
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.3,
-      "goals_under_odds": {
-        "0.5": 19,
-        "1.5": 6.8,
-        "2.5": 3.1,
-        "3.5": 1.93
-      },
-      "corners_under_odds": {
-        "8.5": 3.76,
-        "9.5": 2.8,
-        "10.5": 2.16,
-        "11.5": 1.61
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.2,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 80.5,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": 7,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 65.5,
-            "odds": 1.89,
-            "implied": 52.9,
-            "edge": 12.6,
-            "flag": "value"
-          },
-          "4.5": {
-            "prob": 31,
-            "odds": 2.81,
-            "implied": 35.6,
-            "edge": -4.6,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 85,
-            "odds": 1.19,
-            "implied": 84,
-            "edge": 1,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 73.5,
-            "odds": 1.37,
-            "implied": 73,
-            "edge": 0.5,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 54,
-            "odds": 1.75,
-            "implied": 57.1,
-            "edge": -3.1,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 42,
-            "odds": 1.92,
-            "implied": 52.1,
-            "edge": -10.1,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 65.5,
-          "odds": 1.3,
-          "implied": 76.9,
-          "edge": -11.4,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Åsane",
-          "ha": "A",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 15,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Lyn",
-          "ha": "H",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 10,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Haugesund",
-          "ha": "A",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-07",
-          "opp": "Strømmen",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Sandnes Ulf",
-          "ha": "H",
-          "gf": 5,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Odd",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Hødd",
-          "ha": "H",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Strømsgodset",
-          "ha": "A",
-          "gf": 4,
-          "ga": 5,
-          "res": "L",
-          "corners": 9,
-          "cards": 5,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Bryne",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Strømmen",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Egersund",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-30",
-          "opp": "Moss",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Kongsvinger",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-20",
-          "opp": "Sogndal",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 25,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Raufoss",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-10",
-          "opp": "Sandnes Ulf",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 5,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8420464",
-      "league": "Allsvenskan",
-      "region": "Sweden",
-      "date": "2026-07-03",
-      "time": "18:00",
-      "home": {
-        "name": "Sirius",
-        "short": "SIR",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-ik-sirius-fotboll.png"
-      },
-      "away": {
-        "name": "Mjällby",
-        "short": "MJÄ",
-        "logo": "https://cdn.footystats.org/img/teams/sweden-mjallby-aif.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.1,
-      "corners_avg": 9.4,
-      "cards_avg": 3.7,
-      "btts_pct": 50,
-      "goals_over": {
-        "0.5": 95,
-        "1.5": 90,
-        "2.5": 60,
-        "3.5": 35,
-        "4.5": 30
-      },
-      "corners_over": {
-        "8.5": 60,
-        "9.5": 50,
-        "10.5": 40,
-        "11.5": 35
-      },
-      "cards_over": {
-        "2.5": 60,
-        "3.5": 55,
-        "4.5": 30,
-        "5.5": 20
-      },
-      "goals_odds": {
-        "2.5": 1.66,
-        "3.5": 2.48,
-        "4.5": 5
-      },
-      "corners_odds": {
-        "8.5": 1.29,
-        "9.5": 1.7,
-        "10.5": 1.9,
-        "11.5": 2.44
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.63,
-      "goals_under_odds": {
-        "0.5": 11.5,
-        "1.5": 4.33,
-        "2.5": 2.15,
-        "3.5": 1.43
-      },
-      "corners_under_odds": {
-        "8.5": 3.04,
-        "9.5": 2.43,
-        "10.5": 1.78,
-        "11.5": 1.45
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.14,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 60,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -0.2,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 35,
-            "odds": 2.48,
-            "implied": 40.3,
-            "edge": -5.3,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 30,
-            "odds": 5,
-            "implied": 20,
-            "edge": 10,
-            "flag": "value"
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 60,
-            "odds": 1.29,
-            "implied": 77.5,
-            "edge": -17.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 50,
-            "odds": 1.7,
-            "implied": 58.8,
-            "edge": -8.8,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 40,
-            "odds": 1.9,
-            "implied": 52.6,
-            "edge": -12.6,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 35,
-            "odds": 2.44,
-            "implied": 41,
-            "edge": -6,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 50,
-          "odds": 1.63,
-          "implied": 61.3,
-          "edge": -11.3,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-05-30",
-          "opp": "AIK",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "GAIS",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-18",
-          "opp": "Djurgården",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 10,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-11",
-          "opp": "Örgryte",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-05-02",
-          "opp": "Kalmar",
-          "ha": "H",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Häcken",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 14,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "Malmö FF",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Västerås SK",
-          "ha": "H",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 1,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-05-25",
-          "opp": "IFK Göteborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 5,
-          "cards": 9,
-          "btts": true
-        },
-        {
-          "date": "2026-05-21",
-          "opp": "Elfsborg",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Häcken",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 12,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Degerfors",
-          "ha": "A",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Malmö FF",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 7,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-04-27",
-          "opp": "Halmstad",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 13,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-04-23",
-          "opp": "GAIS",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 9,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-04-18",
-          "opp": "Brommapojkarna",
-          "ha": "H",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 6,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "h2h": []
-    },
-    {
-      "id": "8464484",
-      "league": "Esiliiga",
-      "region": "Estonia",
-      "date": "2026-07-03",
-      "time": "18:30",
-      "home": {
-        "name": "Tallinna Kalev",
-        "short": "TAL",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-tallinna-kalev.png"
-      },
-      "away": {
-        "name": "Maardu Linnameeskond",
-        "short": "MAA",
-        "logo": "https://cdn.footystats.org/img/teams/estonia-maardu-linnameeskond.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3.6,
-      "corners_avg": 10.8,
-      "cards_avg": 2.9,
-      "btts_pct": 70,
-      "goals_over": {
-        "0.5": 97,
-        "1.5": 90.5,
-        "2.5": 69.5,
-        "3.5": 42.5,
-        "4.5": 33.5
-      },
-      "corners_over": {
-        "8.5": 64,
-        "9.5": 54.5,
-        "10.5": 51.5,
-        "11.5": 45.5
-      },
-      "cards_over": {
-        "2.5": 54,
-        "3.5": 47,
-        "4.5": 22.5,
-        "5.5": 10
-      },
-      "goals_odds": {
-        "2.5": 1.28,
-        "3.5": 1.75,
-        "4.5": 2.08
-      },
-      "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.32,
-      "goals_under_odds": {
-        "0.5": 34,
-        "1.5": 8.5,
-        "2.5": 3.3,
-        "3.5": 1.96
-      },
-      "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.15,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 69.5,
-            "odds": 1.28,
-            "implied": 78.1,
-            "edge": -8.6,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 42.5,
-            "odds": 1.75,
-            "implied": 57.1,
-            "edge": -14.6,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 33.5,
-            "odds": 2.08,
-            "implied": 48.1,
-            "edge": -14.6,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
-        },
-        "btts": {
-          "prob": 70,
-          "odds": 1.32,
-          "implied": 75.8,
-          "edge": -5.8,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-21",
-          "opp": "Nõmme Kalju FC U21",
-          "ha": "H",
-          "gf": 5,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-18",
-          "opp": "Nõmme United II",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Tallinna FC Flora U21",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Tallinna FC Levadia U21",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 0,
-          "btts": true
-        },
-        {
-          "date": "2026-05-27",
-          "opp": "Viimsi",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 8,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Elva",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 8,
-          "cards": 0,
-          "btts": true
-        },
-        {
-          "date": "2026-05-14",
-          "opp": "FC Tallinn",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Tartu JK Welco",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 6,
-          "cards": 5,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-22",
-          "opp": "Viimsi",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 8,
-          "cards": 1,
-          "btts": false
-        },
-        {
-          "date": "2026-06-18",
-          "opp": "Nõmme Kalju FC U21",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 16,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-11",
-          "opp": "Elva",
-          "ha": "A",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 7,
-          "cards": 0,
-          "btts": true
-        },
-        {
-          "date": "2026-05-28",
-          "opp": "FC Tallinn",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 15,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-24",
-          "opp": "Tartu JK Welco",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 8,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Tallinna FC Levadia U21",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Nõmme United II",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-01",
-          "opp": "Tallinna FC Flora U21",
-          "ha": "A",
-          "gf": 0,
-          "ga": 5,
-          "res": "L",
-          "corners": 7,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-03",
-          "home": "Maardu Linnameeskond",
-          "away": "Tallinna Kalev",
-          "hg": 1,
-          "ag": 1,
-          "corners": 12,
-          "cards": 1
-        }
-      ]
-    },
-    {
-      "id": "8408055",
-      "league": "Premier Division",
-      "region": "Republic of Ireland",
-      "date": "2026-07-03",
-      "time": "19:45",
-      "home": {
-        "name": "Sligo Rovers",
-        "short": "SLI",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-sligo-rovers-fc.png"
-      },
-      "away": {
-        "name": "Shamrock Rovers",
-        "short": "SHA",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-shamrock-rovers-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.4,
-      "corners_avg": 10.1,
-      "cards_avg": 3.8,
-      "btts_pct": 47.5,
-      "goals_over": {
-        "0.5": 91,
-        "1.5": 69.5,
-        "2.5": 43.5,
-        "3.5": 26,
-        "4.5": 11
-      },
-      "corners_over": {
-        "8.5": 59,
-        "9.5": 40,
-        "10.5": 31.5,
-        "11.5": 29
-      },
-      "cards_over": {
-        "2.5": 78,
-        "3.5": 56,
-        "4.5": 45,
-        "5.5": 25.5
-      },
-      "goals_odds": {
-        "2.5": 1.79,
-        "3.5": 2.89,
-        "4.5": 6
-      },
-      "corners_odds": {
-        "8.5": 1.44,
-        "9.5": 1.98,
-        "10.5": 2.07,
-        "11.5": 2.65
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.87,
-      "goals_under_odds": {
-        "0.5": 10.9,
-        "1.5": 3.62,
-        "2.5": 2,
-        "3.5": 1.32
-      },
-      "corners_under_odds": {
-        "8.5": 2.52,
-        "9.5": 1.94,
-        "10.5": 1.64,
-        "11.5": 1.4
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.9,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 43.5,
-            "odds": 1.79,
-            "implied": 55.9,
-            "edge": -12.4,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 26,
-            "odds": 2.89,
-            "implied": 34.6,
-            "edge": -8.6,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 11,
-            "odds": 6,
-            "implied": 16.7,
-            "edge": -5.7,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 59,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": -10.4,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 40,
-            "odds": 1.98,
-            "implied": 50.5,
-            "edge": -10.5,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 31.5,
-            "odds": 2.07,
-            "implied": 48.3,
-            "edge": -16.8,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 29,
-            "odds": 2.65,
-            "implied": 37.7,
-            "edge": -8.7,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 47.5,
-          "odds": 1.87,
-          "implied": 53.5,
-          "edge": -6,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Shelbourne",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 17,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "St Patrick's Athl.",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 21,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Waterford",
-          "ha": "A",
-          "gf": 0,
-          "ga": 4,
-          "res": "L",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Bohemians",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Shamrock Rovers",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 7,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Galway United",
-          "ha": "H",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 15,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Shelbourne",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 18,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "St Patrick's Athl.",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Galway United",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 7,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "Derry City",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 8,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Waterford",
-          "ha": "A",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Shelbourne",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "St Patrick's Athl.",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Bohemians",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 6,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Sligo Rovers",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 7,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Dundalk",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 4,
-          "btts": false
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-22",
-          "home": "Shamrock Rovers",
-          "away": "Sligo Rovers",
-          "hg": 1,
-          "ag": 2,
-          "corners": 7,
-          "cards": 3
-        },
-        {
-          "date": "2026-03-13",
-          "home": "Sligo Rovers",
-          "away": "Shamrock Rovers",
-          "hg": 0,
-          "ag": 2,
-          "corners": 8,
-          "cards": 8
-        }
-      ]
-    },
-    {
-      "id": "8408060",
-      "league": "Premier Division",
-      "region": "Republic of Ireland",
-      "date": "2026-07-03",
-      "time": "19:45",
-      "home": {
-        "name": "Derry City",
-        "short": "DER",
-        "logo": "https://cdn.footystats.org/img/teams/northern-ireland-derry-city-fc.png"
-      },
-      "away": {
-        "name": "Waterford",
-        "short": "WAT",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-waterford-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.8,
-      "corners_avg": 10.6,
-      "cards_avg": 5.1,
-      "btts_pct": 61,
-      "goals_over": {
-        "0.5": 89,
-        "1.5": 76.5,
-        "2.5": 50,
-        "3.5": 33,
-        "4.5": 20
-      },
-      "corners_over": {
-        "8.5": 74,
-        "9.5": 52,
-        "10.5": 41.5,
-        "11.5": 37
-      },
-      "cards_over": {
-        "2.5": 87,
-        "3.5": 67.5,
-        "4.5": 47.5,
-        "5.5": 28
-      },
-      "goals_odds": {
-        "2.5": 1.66,
-        "3.5": 2.48,
-        "4.5": 4.3
-      },
-      "corners_odds": {
-        "8.5": 1.34,
-        "9.5": 1.8,
-        "10.5": 2.02,
-        "11.5": 2.59
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.8,
-      "goals_under_odds": {
-        "0.5": 12,
-        "1.5": 4.41,
-        "2.5": 2.18,
-        "3.5": 1.43
-      },
-      "corners_under_odds": {
-        "8.5": 2.82,
-        "9.5": 2.12,
-        "10.5": 1.71,
-        "11.5": 1.41
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.85,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 50,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -10.2,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 33,
-            "odds": 2.48,
-            "implied": 40.3,
-            "edge": -7.3,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 20,
-            "odds": 4.3,
-            "implied": 23.3,
-            "edge": -3.3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 74,
-            "odds": 1.34,
-            "implied": 74.6,
-            "edge": -0.6,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 52,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": -3.6,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 41.5,
-            "odds": 2.02,
-            "implied": 49.5,
-            "edge": -8,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 37,
-            "odds": 2.59,
-            "implied": 38.6,
-            "edge": -1.6,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 61,
-          "odds": 1.8,
-          "implied": 55.6,
-          "edge": 5.4,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Drogheda United",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 12,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "Shamrock Rovers",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 8,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Galway United",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 5,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Bohemians",
-          "ha": "H",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 12,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Dundalk",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Shelbourne",
-          "ha": "H",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 8,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "St Patrick's Athl.",
-          "ha": "H",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 12,
-          "cards": 10,
-          "btts": false
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Waterford",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Dundalk",
-          "ha": "A",
-          "gf": 3,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Shamrock Rovers",
-          "ha": "H",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Sligo Rovers",
-          "ha": "H",
-          "gf": 4,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Drogheda United",
-          "ha": "A",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 7,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Shelbourne",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 5,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-18",
-          "opp": "Drogheda United",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 8,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Derry City",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "St Patrick's Athl.",
-          "ha": "A",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 11,
-          "cards": 1,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-15",
-          "home": "Waterford",
-          "away": "Derry City",
-          "hg": 2,
-          "ag": 2,
-          "corners": 7,
-          "cards": 4
-        },
-        {
-          "date": "2026-02-27",
-          "home": "Derry City",
-          "away": "Waterford",
-          "hg": 4,
-          "ag": 2,
-          "corners": 9,
-          "cards": 3
-        }
-      ]
-    },
-    {
-      "id": "8408065",
-      "league": "Premier Division",
-      "region": "Republic of Ireland",
-      "date": "2026-07-03",
-      "time": "19:45",
-      "home": {
-        "name": "St Patrick's Athl.",
-        "short": "ST ",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-st-patricks-athletic-fc.png"
-      },
-      "away": {
-        "name": "Galway United",
-        "short": "GAL",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-galway-united-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.7,
-      "corners_avg": 10.6,
-      "cards_avg": 4.1,
-      "btts_pct": 53.5,
-      "goals_over": {
-        "0.5": 93,
-        "1.5": 72,
-        "2.5": 44,
-        "3.5": 37,
-        "4.5": 18.5
-      },
-      "corners_over": {
-        "8.5": 74.5,
-        "9.5": 62,
-        "10.5": 51.5,
-        "11.5": 39.5
-      },
-      "cards_over": {
-        "2.5": 81.5,
-        "3.5": 58,
-        "4.5": 32,
-        "5.5": 14
-      },
-      "goals_odds": {
-        "2.5": 1.63,
-        "3.5": 2.62,
-        "4.5": 4.8
-      },
-      "corners_odds": {
-        "8.5": 1.3,
-        "9.5": 1.73,
-        "10.5": 1.94,
-        "11.5": 2.45
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.83,
-      "goals_under_odds": {
-        "0.5": 15,
-        "1.5": 4.3,
-        "2.5": 2.35,
-        "3.5": 1.44
-      },
-      "corners_under_odds": {
-        "8.5": 2.99,
-        "9.5": 2.22,
-        "10.5": 1.79,
-        "11.5": 1.46
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 1.9,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 44,
-            "odds": 1.63,
-            "implied": 61.3,
-            "edge": -17.3,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 37,
-            "odds": 2.62,
-            "implied": 38.2,
-            "edge": -1.2,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 18.5,
-            "odds": 4.8,
-            "implied": 20.8,
-            "edge": -2.3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 74.5,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -2.4,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 62,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": 4.2,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 51.5,
-            "odds": 1.94,
-            "implied": 51.5,
-            "edge": 0,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 39.5,
-            "odds": 2.45,
-            "implied": 40.8,
-            "edge": -1.3,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 53.5,
-          "odds": 1.83,
-          "implied": 54.6,
-          "edge": -1.1,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Bohemians",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Sligo Rovers",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 21,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Drogheda United",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 17,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Shamrock Rovers",
-          "ha": "A",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 10,
-          "cards": 6,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Derry City",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 12,
-          "cards": 10,
-          "btts": false
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Shelbourne",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 9,
-          "cards": 10,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Waterford",
-          "ha": "H",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Sligo Rovers",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Shamrock Rovers",
-          "ha": "A",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 7,
-          "cards": 1,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Derry City",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 5,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Dundalk",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 15,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Shelbourne",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Bohemians",
-          "ha": "H",
-          "gf": 2,
-          "ga": 4,
-          "res": "L",
-          "corners": 9,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-16",
-          "opp": "Sligo Rovers",
-          "ha": "A",
-          "gf": 4,
-          "ga": 1,
-          "res": "W",
-          "corners": 15,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Shamrock Rovers",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 9,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Derry City",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-01",
-          "home": "Galway United",
-          "away": "St Patrick's Athl.",
-          "hg": 2,
-          "ag": 2,
-          "corners": 7,
-          "cards": 4
-        },
-        {
-          "date": "2026-03-02",
-          "home": "St Patrick's Athl.",
-          "away": "Galway United",
-          "hg": 1,
-          "ag": 0,
-          "corners": 12,
-          "cards": 5
-        }
-      ]
-    },
-    {
-      "id": "8408066",
-      "league": "Premier Division",
-      "region": "Republic of Ireland",
-      "date": "2026-07-03",
-      "time": "19:45",
-      "home": {
-        "name": "Shelbourne",
-        "short": "SHE",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-shelbourne-fc.png"
-      },
-      "away": {
-        "name": "Dundalk",
-        "short": "DUN",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-dundalk-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 3,
-      "corners_avg": 10.2,
-      "cards_avg": 5.1,
-      "btts_pct": 71,
-      "goals_over": {
-        "0.5": 93.5,
-        "1.5": 82,
-        "2.5": 62,
-        "3.5": 38,
-        "4.5": 17.5
-      },
-      "corners_over": {
-        "8.5": 73.5,
-        "9.5": 60.5,
-        "10.5": 43,
-        "11.5": 29
-      },
-      "cards_over": {
-        "2.5": 84.5,
-        "3.5": 71,
-        "4.5": 57.5,
-        "5.5": 44.5
-      },
-      "goals_odds": {
-        "2.5": 1.6,
-        "3.5": 2.51,
-        "4.5": 4.87
-      },
-      "corners_odds": {
-        "8.5": 1.45,
-        "9.5": 1.67,
-        "10.5": 2.24,
-        "11.5": 2.97
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.5,
-      "goals_under_odds": {
-        "0.5": 13.2,
-        "1.5": 4.2,
-        "2.5": 2.2,
-        "3.5": 1.42
-      },
-      "corners_under_odds": {
-        "8.5": 2.48,
-        "9.5": 2.02,
-        "10.5": 1.56,
-        "11.5": 1.31
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2.38,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 62,
-            "odds": 1.6,
-            "implied": 62.5,
-            "edge": -0.5,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 38,
-            "odds": 2.51,
-            "implied": 39.8,
-            "edge": -1.8,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 17.5,
-            "odds": 4.87,
-            "implied": 20.5,
-            "edge": -3,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 73.5,
-            "odds": 1.45,
-            "implied": 69,
-            "edge": 4.5,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 60.5,
-            "odds": 1.67,
-            "implied": 59.9,
-            "edge": 0.6,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 43,
-            "odds": 2.24,
-            "implied": 44.6,
-            "edge": -1.6,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 29,
-            "odds": 2.97,
-            "implied": 33.7,
-            "edge": -4.7,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 71,
-          "odds": 1.5,
-          "implied": 66.7,
-          "edge": 4.3,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-27",
-          "opp": "Sligo Rovers",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 17,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "Bohemians",
-          "ha": "H",
-          "gf": 0,
-          "ga": 3,
-          "res": "L",
-          "corners": 9,
-          "cards": 8,
-          "btts": false
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Drogheda United",
-          "ha": "A",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 3,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Shamrock Rovers",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 6,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Galway United",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Derry City",
-          "ha": "A",
-          "gf": 0,
-          "ga": 0,
-          "res": "D",
-          "corners": 8,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Waterford",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 5,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "St Patrick's Athl.",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 10,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Waterford",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 9,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Bohemians",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Galway United",
-          "ha": "A",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 15,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Derry City",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Drogheda United",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Shamrock Rovers",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Bohemians",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 3,
-          "cards": 8,
-          "btts": true
-        },
-        {
-          "date": "2026-05-04",
-          "opp": "Waterford",
-          "ha": "A",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 21,
-          "cards": 5,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-01",
-          "home": "Dundalk",
-          "away": "Shelbourne",
-          "hg": 1,
-          "ag": 2,
-          "corners": 10,
-          "cards": 9
-        },
-        {
-          "date": "2026-04-03",
-          "home": "Shelbourne",
-          "away": "Dundalk",
-          "hg": 2,
-          "ag": 3,
-          "corners": 11,
-          "cards": 6
-        }
-      ]
-    },
-    {
-      "id": "8408145",
-      "league": "Premier Division",
-      "region": "Republic of Ireland",
-      "date": "2026-07-03",
-      "time": "19:45",
-      "home": {
-        "name": "Drogheda United",
-        "short": "DRO",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-drogheda-united-fc.png"
-      },
-      "away": {
-        "name": "Bohemians",
-        "short": "BOH",
-        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-bohemian-fc.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 2.8,
-      "corners_avg": 10,
-      "cards_avg": 4.6,
-      "btts_pct": 63.5,
-      "goals_over": {
-        "0.5": 89.5,
-        "1.5": 76,
-        "2.5": 56.5,
-        "3.5": 34.5,
-        "4.5": 18
-      },
-      "corners_over": {
-        "8.5": 65.5,
-        "9.5": 56,
-        "10.5": 39,
-        "11.5": 30.5
-      },
-      "cards_over": {
-        "2.5": 80.5,
-        "3.5": 65.5,
-        "4.5": 46,
-        "5.5": 24
-      },
-      "goals_odds": {
-        "2.5": 1.78,
-        "3.5": 2.88,
-        "4.5": 5.52
-      },
-      "corners_odds": {
-        "8.5": 1.4,
-        "9.5": 1.72,
-        "10.5": 2.15,
-        "11.5": 2.83
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.7,
-      "goals_under_odds": {
-        "0.5": 10.5,
-        "1.5": 3.62,
-        "2.5": 2.05,
-        "3.5": 1.39
-      },
-      "corners_under_odds": {
-        "8.5": 2.6,
-        "9.5": 1.98,
-        "10.5": 1.58,
-        "11.5": 1.33
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 2,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 56.5,
-            "odds": 1.78,
-            "implied": 56.2,
-            "edge": 0.3,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 34.5,
-            "odds": 2.88,
-            "implied": 34.7,
-            "edge": -0.2,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 18,
-            "odds": 5.52,
-            "implied": 18.1,
-            "edge": -0.1,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 65.5,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": -5.9,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 56,
-            "odds": 1.72,
-            "implied": 58.1,
-            "edge": -2.1,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 39,
-            "odds": 2.15,
-            "implied": 46.5,
-            "edge": -7.5,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 30.5,
-            "odds": 2.83,
-            "implied": 35.3,
-            "edge": -4.8,
-            "flag": null
-          }
-        },
-        "btts": {
-          "prob": 63.5,
-          "odds": 1.7,
-          "implied": 58.8,
-          "edge": 4.7,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "Derry City",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 12,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Shelbourne",
-          "ha": "H",
-          "gf": 2,
-          "ga": 2,
-          "res": "D",
-          "corners": 3,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "St Patrick's Athl.",
-          "ha": "A",
-          "gf": 0,
-          "ga": 2,
-          "res": "L",
-          "corners": 17,
-          "cards": 3,
-          "btts": false
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Waterford",
-          "ha": "H",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 7,
-          "cards": 7,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Dundalk",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-18",
-          "opp": "Waterford",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 8,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Bohemians",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 16,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Derry City",
-          "ha": "H",
-          "gf": 1,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 3,
-          "btts": false
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-26",
-          "opp": "St Patrick's Athl.",
-          "ha": "H",
-          "gf": 2,
-          "ga": 0,
-          "res": "W",
-          "corners": 10,
-          "cards": 4,
-          "btts": false
-        },
-        {
-          "date": "2026-06-22",
-          "opp": "Shelbourne",
-          "ha": "A",
-          "gf": 3,
-          "ga": 0,
-          "res": "W",
-          "corners": 9,
-          "cards": 8,
-          "btts": false
-        },
-        {
-          "date": "2026-06-19",
-          "opp": "Dundalk",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-12",
-          "opp": "Derry City",
-          "ha": "A",
-          "gf": 1,
-          "ga": 4,
-          "res": "L",
-          "corners": 12,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "Sligo Rovers",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 3,
-          "btts": true
-        },
-        {
-          "date": "2026-05-25",
-          "opp": "Shamrock Rovers",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Galway United",
-          "ha": "A",
-          "gf": 4,
-          "ga": 2,
-          "res": "W",
-          "corners": 9,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-05-15",
-          "opp": "Drogheda United",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 16,
-          "cards": 5,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-05-15",
-          "home": "Bohemians",
-          "away": "Drogheda United",
-          "hg": 2,
-          "ag": 1,
-          "corners": 16,
-          "cards": 5
-        },
-        {
-          "date": "2026-04-03",
-          "home": "Drogheda United",
-          "away": "Bohemians",
-          "hg": 0,
-          "ag": 0,
-          "corners": 10,
-          "cards": 4
-        }
-      ]
-    },
-    {
-      "id": "8447230",
-      "league": "Úrvalsdeild",
-      "region": "Iceland",
-      "date": "2026-07-03",
-      "time": "20:15",
-      "home": {
-        "name": "FH",
-        "short": "FH",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-fh-hafnarfjordur.png"
-      },
-      "away": {
-        "name": "Stjarnan",
-        "short": "STJ",
-        "logo": "https://cdn.footystats.org/img/teams/iceland-umf-stjarnan.png"
-      },
-      "result": {
-        "hg": 0,
-        "ag": 0,
-        "corners": 0,
-        "cards": 0,
-        "btts": false
-      },
-      "goals_avg": 4,
-      "corners_avg": 12.6,
-      "cards_avg": 4.7,
-      "btts_pct": 83.5,
-      "goals_over": {
-        "0.5": 100,
-        "1.5": 92,
-        "2.5": 76,
-        "3.5": 55.5,
-        "4.5": 44
-      },
-      "corners_over": {
-        "8.5": 84,
-        "9.5": 84,
-        "10.5": 76,
-        "11.5": 68
-      },
-      "cards_over": {
-        "2.5": 80,
-        "3.5": 76,
-        "4.5": 51.5,
-        "5.5": 39.5
-      },
-      "goals_odds": {
-        "2.5": 1.3,
-        "3.5": 1.78,
-        "4.5": 2.64
-      },
-      "corners_odds": {
-        "8.5": 1.1,
-        "9.5": 1.25,
-        "10.5": 1.48,
-        "11.5": 1.8
-      },
-      "cards_odds": {
-        "3.5": null,
-        "4.5": null,
-        "5.5": null
-      },
-      "btts_odds": 1.2,
-      "goals_under_odds": {
-        "0.5": 19.5,
-        "1.5": 6.7,
-        "2.5": 3.4,
-        "3.5": 1.98
-      },
-      "corners_under_odds": {
-        "8.5": 4.83,
-        "9.5": 3.24,
-        "10.5": 2.4,
-        "11.5": 1.88
-      },
-      "cards_under_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
-      },
-      "btts_no_odds": 3.34,
-      "value": {
-        "goals": {
-          "2.5": {
-            "prob": 76,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -0.9,
-            "flag": null
-          },
-          "3.5": {
-            "prob": 55.5,
-            "odds": 1.78,
-            "implied": 56.2,
-            "edge": -0.7,
-            "flag": null
-          },
-          "4.5": {
-            "prob": 44,
-            "odds": 2.64,
-            "implied": 37.9,
-            "edge": 6.1,
-            "flag": null
-          }
-        },
-        "corners": {
-          "8.5": {
-            "prob": 84,
-            "odds": 1.1,
-            "implied": 90.9,
-            "edge": -6.9,
-            "flag": null
-          },
-          "9.5": {
-            "prob": 84,
-            "odds": 1.25,
-            "implied": 80,
-            "edge": 4,
-            "flag": null
-          },
-          "10.5": {
-            "prob": 76,
-            "odds": 1.48,
-            "implied": 67.6,
-            "edge": 8.4,
-            "flag": null
-          },
-          "11.5": {
-            "prob": 68,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 12.4,
-            "flag": "value"
-          }
-        },
-        "btts": {
-          "prob": 83.5,
-          "odds": 1.2,
-          "implied": 83.3,
-          "edge": 0.2,
-          "flag": null
-        }
-      },
-      "home_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "ÍBV",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 15,
-          "cards": 2,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "Thór",
-          "ha": "H",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 7,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-06-14",
-          "opp": "Keflavík",
-          "ha": "A",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 11,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-29",
-          "opp": "ÍA",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 14,
-          "cards": 5,
-          "btts": false
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Víkingur Reykjavík",
-          "ha": "A",
-          "gf": 0,
-          "ga": 5,
-          "res": "L",
-          "corners": 12,
-          "cards": 2,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 11,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "Breidablik",
-          "ha": "A",
-          "gf": 3,
-          "ga": 3,
-          "res": "D",
-          "corners": 21,
-          "cards": 5,
-          "btts": true
-        },
-        {
-          "date": "2026-05-03",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 3,
-          "ga": 4,
-          "res": "L",
-          "corners": 12,
-          "cards": 3,
-          "btts": true
-        }
-      ],
-      "away_form": [
-        {
-          "date": "2026-06-28",
-          "opp": "KA",
-          "ha": "H",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 20,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-21",
-          "opp": "ÍBV",
-          "ha": "A",
-          "gf": 1,
-          "ga": 2,
-          "res": "L",
-          "corners": 6,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-06-16",
-          "opp": "Breidablik",
-          "ha": "H",
-          "gf": 4,
-          "ga": 4,
-          "res": "D",
-          "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-31",
-          "opp": "Thór",
-          "ha": "A",
-          "gf": 3,
-          "ga": 1,
-          "res": "W",
-          "corners": 14,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-26",
-          "opp": "Víkingur Reykjavík",
-          "ha": "H",
-          "gf": 1,
-          "ga": 3,
-          "res": "L",
-          "corners": 13,
-          "cards": 6,
-          "btts": true
-        },
-        {
-          "date": "2026-05-22",
-          "opp": "Fram",
-          "ha": "H",
-          "gf": 0,
-          "ga": 1,
-          "res": "L",
-          "corners": 6,
-          "cards": 7,
-          "btts": false
-        },
-        {
-          "date": "2026-05-17",
-          "opp": "Keflavík",
-          "ha": "A",
-          "gf": 1,
-          "ga": 1,
-          "res": "D",
-          "corners": 10,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-08",
-          "opp": "KR",
-          "ha": "H",
-          "gf": 2,
-          "ga": 3,
-          "res": "L",
-          "corners": 14,
-          "cards": 4,
-          "btts": true
-        }
-      ],
-      "h2h": [
-        {
-          "date": "2026-04-17",
-          "home": "Stjarnan",
-          "away": "FH",
-          "hg": 3,
-          "ag": 2,
-          "corners": 13,
-          "cards": 6
-        }
-      ]
-    },
     {
       "id": "8483493",
       "league": "China League One",
@@ -24387,6 +17798,19847 @@
           "ag": 1,
           "corners": 13,
           "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8464534",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-09",
+      "time": "17:00",
+      "home": {
+        "name": "Maardu Linnameeskond",
+        "short": "MAA",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-maardu-linnameeskond.png"
+      },
+      "away": {
+        "name": "Tallinna FC Flora U21",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-flora-u21.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4,
+      "corners_avg": 10.4,
+      "cards_avg": 3.2,
+      "btts_pct": 70,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 91,
+        "2.5": 82.5,
+        "3.5": 64.5,
+        "4.5": 42.5
+      },
+      "corners_over": {
+        "8.5": 57.5,
+        "9.5": 45.5,
+        "10.5": 45.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 55,
+        "3.5": 37,
+        "4.5": 20.5,
+        "5.5": 17
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-11",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 15,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-30",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 2,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-01",
+          "home": "Tallinna FC Flora U21",
+          "away": "Maardu Linnameeskond",
+          "hg": 5,
+          "ag": 0,
+          "corners": 7,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8471630",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-10",
+      "time": "11:30",
+      "home": {
+        "name": "Cheonan City",
+        "short": "CHE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-cheonan-city-government-fc.png"
+      },
+      "away": {
+        "name": "Gimhae City",
+        "short": "GIM",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gimhae-city-government-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 8.5,
+      "cards_avg": 4.2,
+      "btts_pct": 66.5,
+      "goals_over": {
+        "0.5": 93.5,
+        "1.5": 73.5,
+        "2.5": 56.5,
+        "3.5": 36.5,
+        "4.5": 13.5
+      },
+      "corners_over": {
+        "8.5": 43.5,
+        "9.5": 40,
+        "10.5": 33,
+        "11.5": 30
+      },
+      "cards_over": {
+        "2.5": 80,
+        "3.5": 60,
+        "4.5": 43.5,
+        "5.5": 23.5
+      },
+      "goals_odds": {
+        "2.5": 2.05,
+        "3.5": 3.7,
+        "4.5": 7.5
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.8,
+      "goals_under_odds": {
+        "0.5": 8.5,
+        "1.5": 3.0,
+        "2.5": 1.7,
+        "3.5": 1.25
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.91,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 56.5,
+            "odds": 2.05,
+            "implied": 48.8,
+            "edge": 7.7,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 36.5,
+            "odds": 3.7,
+            "implied": 27,
+            "edge": 9.5,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 13.5,
+            "odds": 7.5,
+            "implied": 13.3,
+            "edge": 0.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": {
+          "prob": 66.5,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": 10.9,
+          "flag": "value"
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 16,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Suwon Bluewings",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Paju Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Jeonnam Dragons",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Busan I'Park",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471632",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-10",
+      "time": "11:30",
+      "home": {
+        "name": "Suwon",
+        "short": "SUW",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-suwon-fc.png"
+      },
+      "away": {
+        "name": "Jeonnam Dragons",
+        "short": "JEO",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-jeonnam-dragons-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 9.5,
+      "cards_avg": 3.3,
+      "btts_pct": 70,
+      "goals_over": {
+        "0.5": 93,
+        "1.5": 80,
+        "2.5": 66.5,
+        "3.5": 50,
+        "4.5": 16.5
+      },
+      "corners_over": {
+        "8.5": 56.5,
+        "9.5": 50,
+        "10.5": 40,
+        "11.5": 30
+      },
+      "cards_over": {
+        "2.5": 76.5,
+        "3.5": 60,
+        "4.5": 43.5,
+        "5.5": 27
+      },
+      "goals_odds": {
+        "2.5": 1.79,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.89,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 66.5,
+            "odds": 1.79,
+            "implied": 55.9,
+            "edge": 10.6,
+            "flag": "value"
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 16,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Asan Mugunghwa",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Suwon Bluewings",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Busan I'Park",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Gimpo Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 5,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 14,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Cheongju",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 4,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Asan Mugunghwa",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471160",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-10",
+      "time": "12:35",
+      "home": {
+        "name": "Shandong Luneng",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shandong-luneng-taishan-fc.png"
+      },
+      "away": {
+        "name": "Yunnan Yukun",
+        "short": "YUN",
+        "logo": "https://cdn.footystats.org/img/teams/china-yunnan-yukun-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.5,
+      "corners_avg": 9.4,
+      "cards_avg": 4.2,
+      "btts_pct": 73.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 88,
+        "2.5": 76.5,
+        "3.5": 41,
+        "4.5": 26.5
+      },
+      "corners_over": {
+        "8.5": 59,
+        "9.5": 41,
+        "10.5": 29.5,
+        "11.5": 26
+      },
+      "cards_over": {
+        "2.5": 76.5,
+        "3.5": 67.5,
+        "4.5": 47,
+        "5.5": 31.5
+      },
+      "goals_odds": {
+        "2.5": 1.33,
+        "3.5": 1.8,
+        "4.5": 2.88
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.4,
+      "goals_under_odds": {
+        "0.5": 26.0,
+        "1.5": 11.3,
+        "2.5": 3.1,
+        "3.5": 1.9
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.8,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 76.5,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": 1.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 41,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": -14.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 26.5,
+            "odds": 2.88,
+            "implied": 34.7,
+            "edge": -8.2,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": {
+          "prob": 73.5,
+          "odds": 1.4,
+          "implied": 71.4,
+          "edge": 2.1,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 5,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Wuhan Three Towns",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Qingdao Youth Island",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Yunnan Yukun",
+          "away": "Shandong Luneng",
+          "hg": 4,
+          "ag": 0,
+          "corners": 15,
+          "cards": 7
+        }
+      ]
+    },
+    {
+      "id": "8431911",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-10",
+      "time": "16:30",
+      "home": {
+        "name": "KTP",
+        "short": "KTP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-kotkan-tyovaen-palloilijat.png"
+      },
+      "away": {
+        "name": "JäPS",
+        "short": "JÄP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-jarvenpaan-palloseura.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9.8,
+      "cards_avg": 3.6,
+      "btts_pct": 30.5,
+      "goals_over": {
+        "0.5": 92,
+        "1.5": 58,
+        "2.5": 42,
+        "3.5": 23,
+        "4.5": 19
+      },
+      "corners_over": {
+        "8.5": 57.5,
+        "9.5": 50,
+        "10.5": 34.5,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 73.5,
+        "3.5": 58,
+        "4.5": 23,
+        "5.5": 8
+      },
+      "goals_odds": {
+        "2.5": 1.54,
+        "3.5": 2.4,
+        "4.5": 4.4
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.62,
+      "goals_under_odds": {
+        "0.5": 12.7,
+        "1.5": 4.7,
+        "2.5": 2.32,
+        "3.5": 1.48
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.08,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 42,
+            "odds": 1.54,
+            "implied": 64.9,
+            "edge": -22.9,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 23,
+            "odds": 2.4,
+            "implied": 41.7,
+            "edge": -18.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 19,
+            "odds": 4.4,
+            "implied": 22.7,
+            "edge": -3.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": {
+          "prob": 30.5,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": -31.2,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "EIF",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-08",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 17,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-16",
+          "home": "JäPS",
+          "away": "KTP",
+          "hg": 0,
+          "ag": 1,
+          "corners": 10,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8419862",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-10",
+      "time": "17:00",
+      "home": {
+        "name": "VPS",
+        "short": "VPS",
+        "logo": "https://cdn.footystats.org/img/teams/finland-vaasan-palloseura.png"
+      },
+      "away": {
+        "name": "SJK",
+        "short": "SJK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-seinajoen-jalkapallokerho.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 9.4,
+      "cards_avg": 3.9,
+      "btts_pct": 60.5,
+      "goals_over": {
+        "0.5": 89.5,
+        "1.5": 75,
+        "2.5": 46.5,
+        "3.5": 28.5,
+        "4.5": 14
+      },
+      "corners_over": {
+        "8.5": 63.5,
+        "9.5": 53,
+        "10.5": 43,
+        "11.5": 36
+      },
+      "cards_over": {
+        "2.5": 60,
+        "3.5": 43,
+        "4.5": 24.5,
+        "5.5": 21
+      },
+      "goals_odds": {
+        "2.5": 1.7,
+        "3.5": 2.76,
+        "4.5": 4.99
+      },
+      "corners_odds": {
+        "8.5": 1.3,
+        "9.5": 1.52,
+        "10.5": 1.82,
+        "11.5": 2.25
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.58,
+      "goals_under_odds": {
+        "0.5": 10.5,
+        "1.5": 3.84,
+        "2.5": 2.1,
+        "3.5": 1.38
+      },
+      "corners_under_odds": {
+        "8.5": 3.1,
+        "9.5": 2.33,
+        "10.5": 1.86,
+        "11.5": 1.55
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.18,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 46.5,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -12.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 28.5,
+            "odds": 2.76,
+            "implied": 36.2,
+            "edge": -7.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 14,
+            "odds": 4.99,
+            "implied": 20,
+            "edge": -6,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 63.5,
+            "odds": 1.3,
+            "implied": 76.9,
+            "edge": -13.4,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 53,
+            "odds": 1.52,
+            "implied": 65.8,
+            "edge": -12.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 43,
+            "odds": 1.82,
+            "implied": 54.9,
+            "edge": -11.9,
+            "flag": null
+          },
+          "11.5": {
+            "prob": 36,
+            "odds": 2.25,
+            "implied": 44.4,
+            "edge": -8.4,
+            "flag": null
+          }
+        },
+        "btts": {
+          "prob": 60.5,
+          "odds": 1.58,
+          "implied": 63.3,
+          "edge": -2.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Mariehamn",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Oulu",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "SJK",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "TPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "TPS",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Inter Turku",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 3,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Oulu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-17",
+          "home": "SJK",
+          "away": "VPS",
+          "hg": 1,
+          "ag": 2,
+          "corners": 6,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8431961",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-10",
+      "time": "17:00",
+      "home": {
+        "name": "PK-35",
+        "short": "PK-",
+        "logo": "https://cdn.footystats.org/img/teams/finland-pallokerho-35-ry.png"
+      },
+      "away": {
+        "name": "KäPa",
+        "short": "KÄP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-kapylan-pallo.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 10,
+      "cards_avg": 3.8,
+      "btts_pct": 44.5,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 60.5,
+        "2.5": 52.5,
+        "3.5": 24,
+        "4.5": 7.5
+      },
+      "corners_over": {
+        "8.5": 63,
+        "9.5": 52,
+        "10.5": 39.5,
+        "11.5": 28
+      },
+      "cards_over": {
+        "2.5": 84,
+        "3.5": 60.5,
+        "4.5": 32.5,
+        "5.5": 16.5
+      },
+      "goals_odds": {
+        "2.5": 1.76,
+        "3.5": 2.83,
+        "4.5": 5.25
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.77,
+      "goals_under_odds": {
+        "0.5": 9.9,
+        "1.5": 3.58,
+        "2.5": 1.95,
+        "3.5": 1.33
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 1.92,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 52.5,
+            "odds": 1.76,
+            "implied": 56.8,
+            "edge": -4.3,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 24,
+            "odds": 2.83,
+            "implied": 35.3,
+            "edge": -11.3,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 7.5,
+            "odds": 5.25,
+            "implied": 19,
+            "edge": -11.5,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": {
+          "prob": 44.5,
+          "odds": 1.77,
+          "implied": 56.5,
+          "edge": -12,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "EIF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "KäPa",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-07",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-28",
+          "opp": "JäPS",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "JäPS",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "EIF",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-17",
+          "home": "KäPa",
+          "away": "PK-35",
+          "hg": 0,
+          "ag": 0,
+          "corners": 11,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8465907",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-10",
+      "time": "17:00",
+      "home": {
+        "name": "Harju Jalgpallikool",
+        "short": "HAR",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-harju-jalgpallikool.png"
+      },
+      "away": {
+        "name": "Trans",
+        "short": "TRA",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-narva-trans.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 10.7,
+      "cards_avg": 4.2,
+      "btts_pct": 44.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 80.5,
+        "2.5": 69.5,
+        "3.5": 27.5,
+        "4.5": 17
+      },
+      "corners_over": {
+        "8.5": 75,
+        "9.5": 61,
+        "10.5": 55.5,
+        "11.5": 41.5
+      },
+      "cards_over": {
+        "2.5": 86,
+        "3.5": 67,
+        "4.5": 53,
+        "5.5": 36
+      },
+      "goals_odds": {
+        "2.5": 1.62,
+        "3.5": 2.49,
+        "4.5": 4.6
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.51,
+      "goals_under_odds": {
+        "0.5": 12.5,
+        "1.5": 4.3,
+        "2.5": 2.16,
+        "3.5": 1.42
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 2.36,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 69.5,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": 7.8,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 27.5,
+            "odds": 2.49,
+            "implied": 40.2,
+            "edge": -12.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 17,
+            "odds": 4.6,
+            "implied": 21.7,
+            "edge": -4.7,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": {
+          "prob": 44.5,
+          "odds": 1.51,
+          "implied": 66.2,
+          "edge": -21.7,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-20",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Kuressaare",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 16,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Nõmme Kalju",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Vaprus",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tallinna FC Levadia",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 4,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Kuressaare",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-30",
+          "home": "Harju Jalgpallikool",
+          "away": "Trans",
+          "hg": 3,
+          "ag": 0,
+          "corners": 6,
+          "cards": 4
+        },
+        {
+          "date": "2026-03-07",
+          "home": "Trans",
+          "away": "Harju Jalgpallikool",
+          "hg": 1,
+          "ag": 2,
+          "corners": 13,
+          "cards": 8
+        }
+      ]
+    },
+    {
+      "id": "8408052",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-10",
+      "time": "19:45",
+      "home": {
+        "name": "Dundalk",
+        "short": "DUN",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-dundalk-fc.png"
+      },
+      "away": {
+        "name": "Drogheda United",
+        "short": "DRO",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-drogheda-united-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 10.4,
+      "cards_avg": 5,
+      "btts_pct": 65.5,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 82.5,
+        "2.5": 56.5,
+        "3.5": 37,
+        "4.5": 19.5
+      },
+      "corners_over": {
+        "8.5": 71.5,
+        "9.5": 63,
+        "10.5": 45.5,
+        "11.5": 32.5
+      },
+      "cards_over": {
+        "2.5": 87,
+        "3.5": 67.5,
+        "4.5": 50,
+        "5.5": 34.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Galway United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Drogheda United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 8,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Dundalk",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-22",
+          "home": "Drogheda United",
+          "away": "Dundalk",
+          "hg": 1,
+          "ag": 1,
+          "corners": 6,
+          "cards": 6
+        },
+        {
+          "date": "2026-02-20",
+          "home": "Dundalk",
+          "away": "Drogheda United",
+          "hg": 1,
+          "ag": 1,
+          "corners": 11,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8408059",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-10",
+      "time": "20:00",
+      "home": {
+        "name": "Waterford",
+        "short": "WAT",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-waterford-fc.png"
+      },
+      "away": {
+        "name": "St Patrick's Athl.",
+        "short": "ST ",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-st-patricks-athletic-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 11,
+      "cards_avg": 4.9,
+      "btts_pct": 48,
+      "goals_over": {
+        "0.5": 91.5,
+        "1.5": 78.5,
+        "2.5": 45.5,
+        "3.5": 39,
+        "4.5": 26
+      },
+      "corners_over": {
+        "8.5": 76,
+        "9.5": 61,
+        "10.5": 52,
+        "11.5": 41
+      },
+      "cards_over": {
+        "2.5": 83,
+        "3.5": 61,
+        "4.5": 39,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Dundalk",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Sligo Rovers",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Drogheda United",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Galway United",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Bohemians",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Sligo Rovers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 21,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Drogheda United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Derry City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 10,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 10,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Waterford",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-08",
+          "home": "St Patrick's Athl.",
+          "away": "Waterford",
+          "hg": 4,
+          "ag": 1,
+          "corners": 11,
+          "cards": 1
+        },
+        {
+          "date": "2026-03-20",
+          "home": "Waterford",
+          "away": "St Patrick's Athl.",
+          "hg": 0,
+          "ag": 2,
+          "corners": 13,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8483584",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "11:00",
+      "home": {
+        "name": "Yanbian Longding",
+        "short": "YAN",
+        "logo": "https://cdn.footystats.org/img/teams/china-yanbian-longding-fc.png"
+      },
+      "away": {
+        "name": "Suzhou Dongwu",
+        "short": "SUZ",
+        "logo": "https://cdn.footystats.org/img/teams/china-suzhou-dongwu-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.2,
+      "corners_avg": 8.3,
+      "cards_avg": 4.7,
+      "btts_pct": 46,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 65.5,
+        "2.5": 42,
+        "3.5": 15,
+        "4.5": 4
+      },
+      "corners_over": {
+        "8.5": 34.5,
+        "9.5": 26.5,
+        "10.5": 23,
+        "11.5": 15.5
+      },
+      "cards_over": {
+        "2.5": 84.5,
+        "3.5": 65.5,
+        "4.5": 42.5,
+        "5.5": 19
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 7,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Guangzhou E-Power",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 5,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8436123",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Gwangju",
+        "short": "GWA",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gwangju-fc.png"
+      },
+      "away": {
+        "name": "Pohang Steelers",
+        "short": "POH",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-pohang-steelers-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.3,
+      "corners_avg": 7.8,
+      "cards_avg": 3.8,
+      "btts_pct": 31,
+      "goals_over": {
+        "0.5": 87.5,
+        "1.5": 56.5,
+        "2.5": 31.5,
+        "3.5": 28.5,
+        "4.5": 22
+      },
+      "corners_over": {
+        "8.5": 37.5,
+        "9.5": 34.5,
+        "10.5": 25,
+        "11.5": 12.5
+      },
+      "cards_over": {
+        "2.5": 91,
+        "3.5": 72,
+        "4.5": 50.5,
+        "5.5": 22
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gangwon",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Daejeon Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 2,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Anyang",
+          "ha": "H",
+          "gf": 2,
+          "ga": 5,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Pohang Steelers",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 3,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Gwangju",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-22",
+          "home": "Pohang Steelers",
+          "away": "Gwangju",
+          "hg": 1,
+          "ag": 0,
+          "corners": 7,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8436174",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Sangju Sangmu",
+        "short": "SAN",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-sangju-sangmu-phoenix-fc.png"
+      },
+      "away": {
+        "name": "Bucheon 1995",
+        "short": "BUC",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-bucheon-fc-1995.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 7.8,
+      "cards_avg": 4.9,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 87.5,
+        "1.5": 69,
+        "2.5": 34.5,
+        "3.5": 16,
+        "4.5": 6
+      },
+      "corners_over": {
+        "8.5": 31.5,
+        "9.5": 28.5,
+        "10.5": 22,
+        "11.5": 9.5
+      },
+      "cards_over": {
+        "2.5": 88,
+        "3.5": 59.5,
+        "4.5": 44,
+        "5.5": 25
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Gangwon",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-25",
+          "home": "Bucheon 1995",
+          "away": "Sangju Sangmu",
+          "hg": 0,
+          "ag": 2,
+          "corners": 8,
+          "cards": 7
+        }
+      ]
+    },
+    {
+      "id": "8436175",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Ulsan",
+        "short": "ULS",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-ulsan-hyundai-horang-i.png"
+      },
+      "away": {
+        "name": "Jeonbuk Motors",
+        "short": "JEO",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-jeonbuk-hyundai-motors-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 8.3,
+      "cards_avg": 3.1,
+      "btts_pct": 56.5,
+      "goals_over": {
+        "0.5": 91,
+        "1.5": 75,
+        "2.5": 44,
+        "3.5": 22,
+        "4.5": 16
+      },
+      "corners_over": {
+        "8.5": 43.5,
+        "9.5": 34.5,
+        "10.5": 22,
+        "11.5": 18.5
+      },
+      "cards_over": {
+        "2.5": 69,
+        "3.5": 56,
+        "4.5": 40.5,
+        "5.5": 16
+      },
+      "goals_odds": {
+        "2.5": 1.88,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.84,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 44,
+            "odds": 1.88,
+            "implied": 53.2,
+            "edge": -9.2,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Bucheon 1995",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Sangju Sangmu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Daejeon Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Gangwon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Anyang",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Gwangju",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Jeju United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-04",
+          "home": "Jeonbuk Motors",
+          "away": "Ulsan",
+          "hg": 2,
+          "ag": 0,
+          "corners": 8,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8471620",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Yongin City",
+        "short": "YON",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-yongin-city-government-fc.png"
+      },
+      "away": {
+        "name": "Cheongju",
+        "short": "CHE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-cheongju-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 8.3,
+      "cards_avg": 4,
+      "btts_pct": 73.5,
+      "goals_over": {
+        "0.5": 83.5,
+        "1.5": 76.5,
+        "2.5": 60,
+        "3.5": 47,
+        "4.5": 13.5
+      },
+      "corners_over": {
+        "8.5": 50,
+        "9.5": 33.5,
+        "10.5": 17,
+        "11.5": 10
+      },
+      "cards_over": {
+        "2.5": 76.5,
+        "3.5": 60,
+        "4.5": 33.5,
+        "5.5": 17
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Paju Citizen",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Hwaseong",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Jeonnam Dragons",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Paju Citizen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471627",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Ansan Greeners",
+        "short": "ANS",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-ansan-greeners-fc.png"
+      },
+      "away": {
+        "name": "Suwon Bluewings",
+        "short": "SUW",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-suwon-samsung-bluewings-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 8.1,
+      "cards_avg": 3.6,
+      "btts_pct": 53.5,
+      "goals_over": {
+        "0.5": 93.5,
+        "1.5": 70,
+        "2.5": 53.5,
+        "3.5": 26.5,
+        "4.5": 10
+      },
+      "corners_over": {
+        "8.5": 40,
+        "9.5": 26.5,
+        "10.5": 16.5,
+        "11.5": 10
+      },
+      "cards_over": {
+        "2.5": 80,
+        "3.5": 53.5,
+        "4.5": 30,
+        "5.5": 17
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Daegu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Yongin City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Jeonnam Dragons",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 3,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Seongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Asan Mugunghwa",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Daegu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Busan I'Park",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Gyeongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471629",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Hwaseong",
+        "short": "HWA",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-hwaseong-fc.png"
+      },
+      "away": {
+        "name": "Paju Citizen",
+        "short": "PAJ",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-paju-citizen-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 8.5,
+      "cards_avg": 4.1,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 90,
+        "1.5": 63,
+        "2.5": 47,
+        "3.5": 33,
+        "4.5": 16.5
+      },
+      "corners_over": {
+        "8.5": 43.5,
+        "9.5": 33,
+        "10.5": 20,
+        "11.5": 13.5
+      },
+      "cards_over": {
+        "2.5": 70,
+        "3.5": 67,
+        "4.5": 50,
+        "5.5": 23.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-06",
+          "opp": "Suwon Bluewings",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Cheongju",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Busan I'Park",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Ansan Greeners",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Yongin City",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Daegu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Gimpo Citizen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Cheongju",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471631",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-11",
+      "time": "11:30",
+      "home": {
+        "name": "Daegu",
+        "short": "DAE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-daegu-fc.png"
+      },
+      "away": {
+        "name": "Seongnam",
+        "short": "SEO",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-seongnam-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 8.9,
+      "cards_avg": 4.2,
+      "btts_pct": 63.5,
+      "goals_over": {
+        "0.5": 86.5,
+        "1.5": 70,
+        "2.5": 50,
+        "3.5": 36.5,
+        "4.5": 16.5
+      },
+      "corners_over": {
+        "8.5": 57,
+        "9.5": 46.5,
+        "10.5": 23.5,
+        "11.5": 10
+      },
+      "cards_over": {
+        "2.5": 80,
+        "3.5": 70,
+        "4.5": 46.5,
+        "5.5": 23
+      },
+      "goals_odds": {
+        "2.5": 1.97,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.73,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 50,
+            "odds": 1.97,
+            "implied": 50.8,
+            "edge": -0.8,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Cheongju",
+          "ha": "A",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Paju Citizen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Ansan Greeners",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Gimhae City",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Suwon Bluewings",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Suwon Bluewings",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Gyeongnam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Jeonnam Dragons",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471159",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:00",
+      "home": {
+        "name": "Wuhan Three Towns",
+        "short": "WUH",
+        "logo": "https://cdn.footystats.org/img/teams/china-wuhan-three-towns-fc.png"
+      },
+      "away": {
+        "name": "Henan Jianye",
+        "short": "HEN",
+        "logo": "https://cdn.footystats.org/img/teams/china-henan-jianye-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 10.1,
+      "cards_avg": 4.6,
+      "btts_pct": 62,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 82,
+        "2.5": 59,
+        "3.5": 29.5,
+        "4.5": 12
+      },
+      "corners_over": {
+        "8.5": 59,
+        "9.5": 41,
+        "10.5": 29.5,
+        "11.5": 29.5
+      },
+      "cards_over": {
+        "2.5": 76,
+        "3.5": 62,
+        "4.5": 35.5,
+        "5.5": 15
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 5,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shenyang Urban",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Henan Jianye",
+          "away": "Wuhan Three Towns",
+          "hg": 1,
+          "ag": 1,
+          "corners": 19,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8471302",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:00",
+      "home": {
+        "name": "Zhejiang FC",
+        "short": "ZHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-zhejiang-professional-fc.png"
+      },
+      "away": {
+        "name": "Qingdao Jonoon",
+        "short": "QIN",
+        "logo": "https://cdn.footystats.org/img/teams/china-qingdao-jonoon-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.2,
+      "corners_avg": 10,
+      "cards_avg": 4.3,
+      "btts_pct": 62,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 82,
+        "2.5": 59,
+        "3.5": 47,
+        "4.5": 26.5
+      },
+      "corners_over": {
+        "8.5": 62,
+        "9.5": 50,
+        "10.5": 44,
+        "11.5": 41
+      },
+      "cards_over": {
+        "2.5": 73.5,
+        "3.5": 68,
+        "4.5": 53,
+        "5.5": 34.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shenyang Urban",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Shanghai SIPG",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Wuhan Three Towns",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-20",
+          "home": "Qingdao Jonoon",
+          "away": "Zhejiang FC",
+          "hg": 1,
+          "ag": 4,
+          "corners": 12,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8483549",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:00",
+      "home": {
+        "name": "Wuxi Wugou",
+        "short": "WUX",
+        "logo": "https://cdn.footystats.org/img/teams/china-wuxi-wugou-fc.png"
+      },
+      "away": {
+        "name": "Guangxi Hengchen",
+        "short": "GUA",
+        "logo": "https://cdn.footystats.org/img/teams/china-guangxi-hengchen-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 10.8,
+      "cards_avg": 3.4,
+      "btts_pct": 62,
+      "goals_over": {
+        "0.5": 92,
+        "1.5": 73,
+        "2.5": 50,
+        "3.5": 26.5,
+        "4.5": 15.5
+      },
+      "corners_over": {
+        "8.5": 73.5,
+        "9.5": 61.5,
+        "10.5": 50,
+        "11.5": 38.5
+      },
+      "cards_over": {
+        "2.5": 73,
+        "3.5": 38,
+        "4.5": 23,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shaanxi Union",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 15,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Shenzhen Juniors",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Dongguan United",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483587",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:00",
+      "home": {
+        "name": "Dalian Huayi",
+        "short": "DAL",
+        "logo": "https://cdn.footystats.org/img/teams/china-dalian-huayi-fc.png"
+      },
+      "away": {
+        "name": "Nanjing City",
+        "short": "NAN",
+        "logo": "https://cdn.footystats.org/img/teams/china-nanjing-city-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 9.4,
+      "cards_avg": 3.7,
+      "btts_pct": 64.5,
+      "goals_over": {
+        "0.5": 92,
+        "1.5": 68.5,
+        "2.5": 48,
+        "3.5": 24,
+        "4.5": 8.5
+      },
+      "corners_over": {
+        "8.5": 60.5,
+        "9.5": 44,
+        "10.5": 32,
+        "11.5": 24
+      },
+      "cards_over": {
+        "2.5": 71,
+        "3.5": 52,
+        "4.5": 31.5,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Guangxi Hengchen",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shenzhen Juniors",
+          "ha": "H",
+          "gf": 5,
+          "ga": 4,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Shanghai Jiading",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Guangzhou E-Power",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Dongguan United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Dongguan United",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shaanxi Union",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Wuxi Wugou",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Suzhou Dongwu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Guangxi Hengchen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483641",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:00",
+      "home": {
+        "name": "Shaanxi Union",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shaanxi-union-fc.png"
+      },
+      "away": {
+        "name": "Meizhou Hakka",
+        "short": "MEI",
+        "logo": "https://cdn.footystats.org/img/teams/china-meizhou-hakka-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 8.7,
+      "cards_avg": 3,
+      "btts_pct": 48,
+      "goals_over": {
+        "0.5": 91.5,
+        "1.5": 71.5,
+        "2.5": 55.5,
+        "3.5": 19.5,
+        "4.5": 8
+      },
+      "corners_over": {
+        "8.5": 48,
+        "9.5": 39.5,
+        "10.5": 35.5,
+        "11.5": 19.5
+      },
+      "cards_over": {
+        "2.5": 72.5,
+        "3.5": 51.5,
+        "4.5": 28,
+        "5.5": 16
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 4,
+          "cards": 7,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Nantong Zhiyun",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Wuxi Wugou",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Hebei Kungfu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 4,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Shenzhen Juniors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Shanghai Jiading",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 0,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8465962",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-11",
+      "time": "12:30",
+      "home": {
+        "name": "Vaprus",
+        "short": "VAP",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-parnu-jk-vaprus.png"
+      },
+      "away": {
+        "name": "Tammeka",
+        "short": "TAM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-tammeka-tartu.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 10.9,
+      "cards_avg": 5,
+      "btts_pct": 54,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 65.5,
+        "2.5": 57,
+        "3.5": 31,
+        "4.5": 20
+      },
+      "corners_over": {
+        "8.5": 80,
+        "9.5": 71.5,
+        "10.5": 54.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 85.5,
+        "3.5": 74,
+        "4.5": 51.5,
+        "5.5": 37.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Kuressaare",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 16,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 6,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Harju Jalgpallikool",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Nõmme Kalju",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Vaprus",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Kuressaare",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-13",
+          "home": "Tammeka",
+          "away": "Vaprus",
+          "hg": 0,
+          "ag": 0,
+          "corners": 9,
+          "cards": 4
+        },
+        {
+          "date": "2026-04-18",
+          "home": "Vaprus",
+          "away": "Tammeka",
+          "hg": 0,
+          "ag": 0,
+          "corners": 6,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8483583",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:30",
+      "home": {
+        "name": "Guangzhou E-Power",
+        "short": "GUA",
+        "logo": "https://cdn.footystats.org/img/teams/china-guangdong-gz-power-fc.png"
+      },
+      "away": {
+        "name": "Hebei Kungfu",
+        "short": "HEB",
+        "logo": "https://cdn.footystats.org/img/teams/china-hebei-kungfu-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 9.3,
+      "cards_avg": 4.5,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 65.5,
+        "2.5": 50,
+        "3.5": 19,
+        "4.5": 7.5
+      },
+      "corners_over": {
+        "8.5": 54,
+        "9.5": 42.5,
+        "10.5": 34.5,
+        "11.5": 34.5
+      },
+      "cards_over": {
+        "2.5": 88.5,
+        "3.5": 77,
+        "4.5": 34.5,
+        "5.5": 19
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 5,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shenzhen Juniors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Yanbian Longding",
+          "ha": "H",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shanghai Jiading",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Nanjing City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Suzhou Dongwu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shenzhen Juniors",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Wuxi Wugou",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471157",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:35",
+      "home": {
+        "name": "Sichuan Jiuniu",
+        "short": "SIC",
+        "logo": "https://cdn.footystats.org/img/teams/china-sichuan-jiuniu-fc.png"
+      },
+      "away": {
+        "name": "Qingdao Youth Island",
+        "short": "QIN",
+        "logo": "https://cdn.footystats.org/img/teams/china-qingdao-youth-island-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 10.9,
+      "cards_avg": 4.3,
+      "btts_pct": 67.5,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 76.5,
+        "2.5": 47,
+        "3.5": 32,
+        "4.5": 26.5
+      },
+      "corners_over": {
+        "8.5": 76.5,
+        "9.5": 59,
+        "10.5": 47,
+        "11.5": 43.5
+      },
+      "cards_over": {
+        "2.5": 82.5,
+        "3.5": 76.5,
+        "4.5": 44,
+        "5.5": 21
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Shanghai SIPG",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Beijing Guoan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Qingdao Youth Island",
+          "away": "Sichuan Jiuniu",
+          "hg": 1,
+          "ag": 0,
+          "corners": 14,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8471158",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "12:35",
+      "home": {
+        "name": "Shanghai Shenhua",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shanghai-shenhua-fc.png"
+      },
+      "away": {
+        "name": "Beijing Guoan",
+        "short": "BEI",
+        "logo": "https://cdn.footystats.org/img/teams/china-beijing-guoan-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 11.3,
+      "cards_avg": 4.2,
+      "btts_pct": 70.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 85,
+        "2.5": 65,
+        "3.5": 44,
+        "4.5": 29.5
+      },
+      "corners_over": {
+        "8.5": 79,
+        "9.5": 65,
+        "10.5": 59,
+        "11.5": 56
+      },
+      "cards_over": {
+        "2.5": 76.5,
+        "3.5": 65,
+        "4.5": 38,
+        "5.5": 20
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": 1.84,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": 1.87
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": {
+            "prob": 44,
+            "odds": 1.84,
+            "implied": 54.3,
+            "edge": -10.3,
+            "flag": null
+          },
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Yunnan Yukun",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Beijing Guoan",
+          "away": "Shanghai Shenhua",
+          "hg": 1,
+          "ag": 1,
+          "corners": 13,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8411875",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-11",
+      "time": "13:00",
+      "home": {
+        "name": "Fredrikstad",
+        "short": "FRE",
+        "logo": "https://cdn.footystats.org/img/teams/norway-fredrikstad-fk.png"
+      },
+      "away": {
+        "name": "Lillestrøm",
+        "short": "LIL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-lillestrom-sk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 9.6,
+      "cards_avg": 4.2,
+      "btts_pct": 59,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 91,
+        "2.5": 59,
+        "3.5": 36,
+        "4.5": 4.5
+      },
+      "corners_over": {
+        "8.5": 68.5,
+        "9.5": 50,
+        "10.5": 36,
+        "11.5": 22.5
+      },
+      "cards_over": {
+        "2.5": 64,
+        "3.5": 45,
+        "4.5": 36,
+        "5.5": 22.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Start",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Sandefjord",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "HamKam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Sarpsborg 08",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Brann",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Viking",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Kristiansund",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Vålerenga",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-25",
+          "opp": "HamKam",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 10,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sandefjord",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Rosenborg",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "FK Bodo - Glimt",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Vålerenga",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 19,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-15",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8419955",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "13:00",
+      "home": {
+        "name": "Lahti",
+        "short": "LAH",
+        "logo": "https://cdn.footystats.org/img/teams/finland-fc-lahti.png"
+      },
+      "away": {
+        "name": "HJK",
+        "short": "HJK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-helsingin-jalkapalloklubi.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 10.1,
+      "cards_avg": 4.2,
+      "btts_pct": 46.5,
+      "goals_over": {
+        "0.5": 96.5,
+        "1.5": 67.5,
+        "2.5": 46.5,
+        "3.5": 25,
+        "4.5": 14
+      },
+      "corners_over": {
+        "8.5": 63.5,
+        "9.5": 50,
+        "10.5": 46.5,
+        "11.5": 35.5
+      },
+      "cards_over": {
+        "2.5": 89.5,
+        "3.5": 64.5,
+        "4.5": 36,
+        "5.5": 24.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "TPS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Gnistan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "SJK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Ilves",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "KuPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 17,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Mariehamn",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Jaro",
+          "ha": "A",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Mariehamn",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "VPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Ilves",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "TPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-04",
+          "home": "HJK",
+          "away": "Lahti",
+          "hg": 1,
+          "ag": 0,
+          "corners": 14,
+          "cards": 7
+        }
+      ]
+    },
+    {
+      "id": "8471301",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-11",
+      "time": "13:00",
+      "home": {
+        "name": "Chengdu Better City FC",
+        "short": "CHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-chengdu-better-city-fc.png"
+      },
+      "away": {
+        "name": "Chongqing Tongliang Long",
+        "short": "CHO",
+        "logo": "https://cdn.footystats.org/img/teams/china-chongqing-tongliang-long-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 10.4,
+      "cards_avg": 5.2,
+      "btts_pct": 53,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 65,
+        "2.5": 50,
+        "3.5": 32,
+        "4.5": 20.5
+      },
+      "corners_over": {
+        "8.5": 65,
+        "9.5": 50,
+        "10.5": 47,
+        "11.5": 41
+      },
+      "cards_over": {
+        "2.5": 79,
+        "3.5": 68,
+        "4.5": 50,
+        "5.5": 32.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 14,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Dalian Zhixing",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 11,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Beijing Guoan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Shandong Luneng",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Shanghai Shenhua",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Chongqing Tongliang Long",
+          "away": "Chengdu Better City FC",
+          "hg": 3,
+          "ag": 3,
+          "corners": 15,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8420398",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-11",
+      "time": "14:00",
+      "home": {
+        "name": "Mjällby",
+        "short": "MJÄ",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-mjallby-aif.png"
+      },
+      "away": {
+        "name": "AIK",
+        "short": "AIK",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-aik-fotboll.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 10.5,
+      "cards_avg": 4.2,
+      "btts_pct": 59,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 82,
+        "2.5": 54.5,
+        "3.5": 22.5,
+        "4.5": 18
+      },
+      "corners_over": {
+        "8.5": 68,
+        "9.5": 50,
+        "10.5": 45.5,
+        "11.5": 40.5
+      },
+      "cards_over": {
+        "2.5": 73,
+        "3.5": 68.5,
+        "4.5": 41,
+        "5.5": 27
+      },
+      "goals_odds": {
+        "2.5": 1.72,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.98,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 54.5,
+            "odds": 1.72,
+            "implied": 58.1,
+            "edge": -3.6,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Sirius",
+          "ha": "A",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "IFK Göteborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Halmstad",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "IFK Göteborg",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Sirius",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Västerås SK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Djurgården",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Malmö FF",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 22,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8431910",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "14:00",
+      "home": {
+        "name": "SJK Akatemia",
+        "short": "SJK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-kerho-07-sjk-ii.png"
+      },
+      "away": {
+        "name": "MP",
+        "short": "MP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-mikkelin-palloilijat.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 1.8,
+      "corners_avg": 9.9,
+      "cards_avg": 3,
+      "btts_pct": 26.5,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 46,
+        "2.5": 26.5,
+        "3.5": 15.5,
+        "4.5": 0
+      },
+      "corners_over": {
+        "8.5": 54,
+        "9.5": 50,
+        "10.5": 42.5,
+        "11.5": 38.5
+      },
+      "cards_over": {
+        "2.5": 46,
+        "3.5": 26.5,
+        "4.5": 19.5,
+        "5.5": 11.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Klubi-04",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-09",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "EIF",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "JäPS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Haka",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "PK-35",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "EIF",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "EIF",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "JäPS",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-07",
+          "opp": "PK-35",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-06",
+          "home": "SJK Akatemia",
+          "away": "MP",
+          "hg": 1,
+          "ag": 0,
+          "corners": 14,
+          "cards": 1
+        }
+      ]
+    },
+    {
+      "id": "8431960",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "14:00",
+      "home": {
+        "name": "Haka",
+        "short": "HAK",
+        "logo": "https://cdn.footystats.org/img/teams/finland-valkeakosken-haka.png"
+      },
+      "away": {
+        "name": "EIF",
+        "short": "EIF",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ekenas-if.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 10.3,
+      "cards_avg": 4.2,
+      "btts_pct": 50,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 77,
+        "2.5": 57.5,
+        "3.5": 27,
+        "4.5": 23
+      },
+      "corners_over": {
+        "8.5": 61.5,
+        "9.5": 50,
+        "10.5": 38,
+        "11.5": 31
+      },
+      "cards_over": {
+        "2.5": 81,
+        "3.5": 54,
+        "4.5": 34.5,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-08",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "JäPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "JIPPO",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 16,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "MP",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "KäPa",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-08",
+          "home": "Haka",
+          "away": "EIF",
+          "hg": 4,
+          "ag": 3,
+          "corners": 15,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8411877",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-11",
+      "time": "15:00",
+      "home": {
+        "name": "Aalesund",
+        "short": "AAL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-aalesunds-fk.png"
+      },
+      "away": {
+        "name": "Molde",
+        "short": "MOL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-molde-fk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 11,
+      "cards_avg": 3.7,
+      "btts_pct": 68.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 82,
+        "2.5": 54.5,
+        "3.5": 36,
+        "4.5": 22.5
+      },
+      "corners_over": {
+        "8.5": 82,
+        "9.5": 68,
+        "10.5": 50,
+        "11.5": 36
+      },
+      "cards_over": {
+        "2.5": 77.5,
+        "3.5": 50,
+        "4.5": 27,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "HamKam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Rosenborg",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Sandefjord",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 18,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Sandefjord",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Sarpsborg 08",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Vålerenga",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Start",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "HamKam",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8419732",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "15:00",
+      "home": {
+        "name": "TPS",
+        "short": "TPS",
+        "logo": "https://cdn.footystats.org/img/teams/finland-turun-palloseura.png"
+      },
+      "away": {
+        "name": "Oulu",
+        "short": "OUL",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ac-oulu.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 9.4,
+      "cards_avg": 3.9,
+      "btts_pct": 53.5,
+      "goals_over": {
+        "0.5": 93,
+        "1.5": 60.5,
+        "2.5": 43,
+        "3.5": 21,
+        "4.5": 14
+      },
+      "corners_over": {
+        "8.5": 53,
+        "9.5": 38.5,
+        "10.5": 35.5,
+        "11.5": 24.5
+      },
+      "cards_over": {
+        "2.5": 89.5,
+        "3.5": 57,
+        "4.5": 46.5,
+        "5.5": 25
+      },
+      "goals_odds": {
+        "2.5": 1.82,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.89,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 43,
+            "odds": 1.82,
+            "implied": 54.9,
+            "edge": -11.9,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "SJK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Inter Turku",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-06-27",
+          "opp": "Lahti",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "VPS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Mariehamn",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Inter Turku",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "SJK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "TPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-16",
+          "home": "Oulu",
+          "away": "TPS",
+          "hg": 1,
+          "ag": 0,
+          "corners": 7,
+          "cards": 6
+        }
+      ]
+    },
+    {
+      "id": "8419932",
+      "league": "Veikkausliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "15:00",
+      "home": {
+        "name": "Gnistan",
+        "short": "GNI",
+        "logo": "https://cdn.footystats.org/img/teams/finland-if-gnistan.png"
+      },
+      "away": {
+        "name": "Mariehamn",
+        "short": "MAR",
+        "logo": "https://cdn.footystats.org/img/teams/finland-ifk-mariehamn.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 10.2,
+      "cards_avg": 3.7,
+      "btts_pct": 39.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 79,
+        "2.5": 43,
+        "3.5": 21,
+        "4.5": 10.5
+      },
+      "corners_over": {
+        "8.5": 71,
+        "9.5": 56,
+        "10.5": 46.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 56,
+        "3.5": 46.5,
+        "4.5": 25,
+        "5.5": 14
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Lahti",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "VPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "Jaro",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Lahti",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Mariehamn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "SJK",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Ilves",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Jaro",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "VPS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Inter Turku",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-23",
+          "opp": "HJK",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Oulu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Gnistan",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "HJK",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Jaro",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "KuPS",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-13",
+          "home": "Mariehamn",
+          "away": "Gnistan",
+          "hg": 0,
+          "ag": 3,
+          "corners": 13,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8465964",
+      "league": "Meistriliiga",
+      "region": "Estonia",
+      "date": "2026-07-11",
+      "time": "15:00",
+      "home": {
+        "name": "Nõmme United",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-nomme-united.png"
+      },
+      "away": {
+        "name": "Kuressaare",
+        "short": "KUR",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-kuressaare.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 11.1,
+      "cards_avg": 3.5,
+      "btts_pct": 69.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 86,
+        "2.5": 75,
+        "3.5": 41.5,
+        "4.5": 25
+      },
+      "corners_over": {
+        "8.5": 86,
+        "9.5": 66.5,
+        "10.5": 58.5,
+        "11.5": 47
+      },
+      "cards_over": {
+        "2.5": 67,
+        "3.5": 39,
+        "4.5": 30.5,
+        "5.5": 19.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-20",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-17",
+          "opp": "Tallinna FC Levadia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Trans",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Kuressaare",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Paide",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "Tallinna FC Flora",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Vaprus",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 16,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Trans",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Harju Jalgpallikool",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 16,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Paide",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Nõmme United",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Nõmme Kalju",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Tammeka",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-20",
+          "home": "Kuressaare",
+          "away": "Nõmme United",
+          "hg": 2,
+          "ag": 1,
+          "corners": 12,
+          "cards": 3
+        },
+        {
+          "date": "2026-04-25",
+          "home": "Nõmme United",
+          "away": "Kuressaare",
+          "hg": 2,
+          "ag": 1,
+          "corners": 9,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8420462",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-11",
+      "time": "16:30",
+      "home": {
+        "name": "Örgryte",
+        "short": "ÖRG",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-orgryte-is.png"
+      },
+      "away": {
+        "name": "Häcken",
+        "short": "HÄC",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-bk-hacken.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 10.1,
+      "cards_avg": 3.4,
+      "btts_pct": 67.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 95,
+        "2.5": 57.5,
+        "3.5": 43,
+        "4.5": 24
+      },
+      "corners_over": {
+        "8.5": 62.5,
+        "9.5": 47.5,
+        "10.5": 43,
+        "11.5": 43
+      },
+      "cards_over": {
+        "2.5": 72.5,
+        "3.5": 48.5,
+        "4.5": 29,
+        "5.5": 15
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Elfsborg",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Halmstad",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "IFK Göteborg",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-11",
+          "opp": "Sirius",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Degerfors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 3,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "Hammarby",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Mjällby",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Malmö FF",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Sirius",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Västerås SK",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 14,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 9,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8408005",
+      "league": "Premier Division",
+      "region": "Republic of Ireland",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "Galway United",
+        "short": "GAL",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-galway-united-fc.png"
+      },
+      "away": {
+        "name": "Sligo Rovers",
+        "short": "SLI",
+        "logo": "https://cdn.footystats.org/img/teams/republic-of-ireland-sligo-rovers-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 10.9,
+      "cards_avg": 3.5,
+      "btts_pct": 55.5,
+      "goals_over": {
+        "0.5": 93.5,
+        "1.5": 73.5,
+        "2.5": 51.5,
+        "3.5": 31,
+        "4.5": 13.5
+      },
+      "corners_over": {
+        "8.5": 71,
+        "9.5": 57.5,
+        "10.5": 49,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 78,
+        "3.5": 46.5,
+        "4.5": 33,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-26",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "Derry City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Dundalk",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sligo Rovers",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Shamrock Rovers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shelbourne",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-19",
+          "opp": "St Patrick's Athl.",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 21,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-12",
+          "opp": "Waterford",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Bohemians",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Shamrock Rovers",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Galway United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Shelbourne",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 18,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-16",
+          "home": "Sligo Rovers",
+          "away": "Galway United",
+          "hg": 1,
+          "ag": 4,
+          "corners": 15,
+          "cards": 5
+        },
+        {
+          "date": "2026-02-27",
+          "home": "Galway United",
+          "away": "Sligo Rovers",
+          "hg": 1,
+          "ag": 0,
+          "corners": 6,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8411878",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "Tromsø",
+        "short": "TRO",
+        "logo": "https://cdn.footystats.org/img/teams/norway-tromso-il.png"
+      },
+      "away": {
+        "name": "Vålerenga",
+        "short": "VÅL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-valerenga-fotball.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.6,
+      "corners_avg": 11.2,
+      "cards_avg": 3.3,
+      "btts_pct": 38,
+      "goals_over": {
+        "0.5": 92.5,
+        "1.5": 75,
+        "2.5": 37,
+        "3.5": 33.5,
+        "4.5": 16.5
+      },
+      "corners_over": {
+        "8.5": 63.5,
+        "9.5": 51,
+        "10.5": 51,
+        "11.5": 43
+      },
+      "cards_over": {
+        "2.5": 58.5,
+        "3.5": 38,
+        "4.5": 22,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "KFUM",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Aalesund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 5,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Molde",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Start",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-29",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Sandefjord",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 16,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Sarpsborg 08",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Start",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "HamKam",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Molde",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Lillestrøm",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 19,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Fredrikstad",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8431959",
+      "league": "Ykkösliiga",
+      "region": "Finland",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "Klubi-04",
+        "short": "KLU",
+        "logo": "https://cdn.footystats.org/img/teams/finland-talenttiklubi-04.png"
+      },
+      "away": {
+        "name": "JIPPO",
+        "short": "JIP",
+        "logo": "https://cdn.footystats.org/img/teams/finland-jippo-joensuu.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2,
+      "corners_avg": 9.1,
+      "cards_avg": 4.2,
+      "btts_pct": 52,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 64.5,
+        "2.5": 31.5,
+        "3.5": 11.5,
+        "4.5": 4
+      },
+      "corners_over": {
+        "8.5": 43.5,
+        "9.5": 31.5,
+        "10.5": 31.5,
+        "11.5": 24
+      },
+      "cards_over": {
+        "2.5": 84,
+        "3.5": 68.5,
+        "4.5": 32.5,
+        "5.5": 24
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-26",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 16,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "PK-35",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "KTP",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 4,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "JIPPO",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "SJK Akatemia",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "KTP",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "EIF",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "KäPa",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-09",
+          "opp": "SJK Akatemia",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Haka",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "PK-35",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "MP",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Klubi-04",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-09",
+          "home": "JIPPO",
+          "away": "Klubi-04",
+          "hg": 1,
+          "ag": 1,
+          "corners": 4,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8464274",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "Tallinna FC Levadia U21",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-levadia-u21.png"
+      },
+      "away": {
+        "name": "Tallinna Kalev",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-jk-tallinna-kalev.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.8,
+      "corners_avg": 10.6,
+      "cards_avg": 2.3,
+      "btts_pct": 69.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 94.5,
+        "2.5": 78,
+        "3.5": 55.5,
+        "4.5": 33
+      },
+      "corners_over": {
+        "8.5": 66.5,
+        "9.5": 58.5,
+        "10.5": 53,
+        "11.5": 38.5
+      },
+      "cards_over": {
+        "2.5": 47,
+        "3.5": 47,
+        "4.5": 17.5,
+        "5.5": 3
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "FC Tallinn",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Elva",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "H",
+          "gf": 5,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-14",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-31",
+          "home": "Tallinna Kalev",
+          "away": "Tallinna FC Levadia U21",
+          "hg": 1,
+          "ag": 2,
+          "corners": 11,
+          "cards": 0
+        },
+        {
+          "date": "2026-04-23",
+          "home": "Tallinna FC Levadia U21",
+          "away": "Tallinna Kalev",
+          "hg": 3,
+          "ag": 2,
+          "corners": 12,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8464286",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "Viimsi",
+        "short": "VII",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-viimsi-jk.png"
+      },
+      "away": {
+        "name": "Nõmme Kalju FC U21",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-nomme-kalju-fc-u21.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 9.6,
+      "cards_avg": 2.5,
+      "btts_pct": 56,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 82,
+        "2.5": 58.5,
+        "3.5": 44.5,
+        "4.5": 23.5
+      },
+      "corners_over": {
+        "8.5": 53,
+        "9.5": 46.5,
+        "10.5": 38.5,
+        "11.5": 20
+      },
+      "cards_over": {
+        "2.5": 47,
+        "3.5": 29.5,
+        "4.5": 19.5,
+        "5.5": 16.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Elva",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "FC Tallinn",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 16,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-11",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-16",
+          "home": "Nõmme Kalju FC U21",
+          "away": "Viimsi",
+          "hg": 1,
+          "ag": 1,
+          "corners": 14,
+          "cards": 3
+        },
+        {
+          "date": "2026-03-14",
+          "home": "Nõmme Kalju FC U21",
+          "away": "Viimsi",
+          "hg": 0,
+          "ag": 0,
+          "corners": 5,
+          "cards": -2
+        }
+      ]
+    },
+    {
+      "id": "8464504",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-11",
+      "time": "17:00",
+      "home": {
+        "name": "FC Tallinn",
+        "short": "FC ",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-tallinn.png"
+      },
+      "away": {
+        "name": "Elva",
+        "short": "ELV",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-elva.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.7,
+      "corners_avg": 10.5,
+      "cards_avg": 2.8,
+      "btts_pct": 61,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 88.5,
+        "2.5": 64,
+        "3.5": 55.5,
+        "4.5": 30.5
+      },
+      "corners_over": {
+        "8.5": 72.5,
+        "9.5": 53,
+        "10.5": 41.5,
+        "11.5": 33
+      },
+      "cards_over": {
+        "2.5": 58,
+        "3.5": 42.5,
+        "4.5": 19.5,
+        "5.5": 13
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 19,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 2,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 15,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-14",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 17,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-11",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 0,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-05-07",
+          "home": "Elva",
+          "away": "FC Tallinn",
+          "hg": 2,
+          "ag": 0,
+          "corners": 12,
+          "cards": 4
+        },
+        {
+          "date": "2026-03-07",
+          "home": "FC Tallinn",
+          "away": "Elva",
+          "hg": 1,
+          "ag": 1,
+          "corners": 9,
+          "cards": -2
+        }
+      ]
+    },
+    {
+      "id": "8436172",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-12",
+      "time": "11:30",
+      "home": {
+        "name": "Incheon United",
+        "short": "INC",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-incheon-united-fc.png"
+      },
+      "away": {
+        "name": "Anyang",
+        "short": "ANY",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-fc-anyang.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 8.4,
+      "cards_avg": 4.4,
+      "btts_pct": 62.5,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 69,
+        "2.5": 47,
+        "3.5": 22,
+        "4.5": 9.5
+      },
+      "corners_over": {
+        "8.5": 47,
+        "9.5": 25,
+        "10.5": 19,
+        "11.5": 12.5
+      },
+      "cards_over": {
+        "2.5": 91,
+        "3.5": 75,
+        "4.5": 56.5,
+        "5.5": 28.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Gwangju",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Sangju Sangmu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Gangwon",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 3,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Jeju United",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "FC Seoul",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Bucheon 1995",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-22",
+          "home": "Anyang",
+          "away": "Incheon United",
+          "hg": 0,
+          "ag": 1,
+          "corners": 9,
+          "cards": 7
+        }
+      ]
+    },
+    {
+      "id": "8436173",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-12",
+      "time": "11:30",
+      "home": {
+        "name": "Jeju United",
+        "short": "JEJ",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-jeju-united-fc.png"
+      },
+      "away": {
+        "name": "Daejeon Citizen",
+        "short": "DAE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-daejeon-citizen-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.1,
+      "corners_avg": 8.6,
+      "cards_avg": 3.8,
+      "btts_pct": 47,
+      "goals_over": {
+        "0.5": 94,
+        "1.5": 69,
+        "2.5": 31,
+        "3.5": 12.5,
+        "4.5": 6.5
+      },
+      "corners_over": {
+        "8.5": 47,
+        "9.5": 34.5,
+        "10.5": 28,
+        "11.5": 22
+      },
+      "cards_over": {
+        "2.5": 84.5,
+        "3.5": 66,
+        "4.5": 41,
+        "5.5": 16
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Sangju Sangmu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 4,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Anyang",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Bucheon 1995",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Jeonbuk Motors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Bucheon 1995",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 2,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Ulsan",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Jeju United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-22",
+          "home": "Daejeon Citizen",
+          "away": "Jeju United",
+          "hg": 0,
+          "ag": 1,
+          "corners": 7,
+          "cards": 5
+        }
+      ]
+    },
+    {
+      "id": "8436272",
+      "league": "K League 1",
+      "region": "South Korea",
+      "date": "2026-07-12",
+      "time": "11:30",
+      "home": {
+        "name": "FC Seoul",
+        "short": "FC ",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-fc-seoul.png"
+      },
+      "away": {
+        "name": "Gangwon",
+        "short": "GAN",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gangwon-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.2,
+      "corners_avg": 8.9,
+      "cards_avg": 5.2,
+      "btts_pct": 47,
+      "goals_over": {
+        "0.5": 91,
+        "1.5": 69,
+        "2.5": 43.5,
+        "3.5": 12.5,
+        "4.5": 9.5
+      },
+      "corners_over": {
+        "8.5": 56.5,
+        "9.5": 50,
+        "10.5": 28,
+        "11.5": 19
+      },
+      "cards_over": {
+        "2.5": 91,
+        "3.5": 72,
+        "4.5": 56.5,
+        "5.5": 37.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Incheon United",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Daejeon Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Jeju United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Anyang",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Sangju Sangmu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Gangwon",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Bucheon 1995",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Jeonbuk Motors",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Ulsan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-12",
+          "opp": "Daejeon Citizen",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Gwangju",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Pohang Steelers",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Incheon United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "FC Seoul",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-04-21",
+          "opp": "Sangju Sangmu",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-25",
+          "home": "Gangwon",
+          "away": "FC Seoul",
+          "hg": 1,
+          "ag": 2,
+          "corners": 10,
+          "cards": 9
+        }
+      ]
+    },
+    {
+      "id": "8471625",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-12",
+      "time": "11:30",
+      "home": {
+        "name": "Busan I'Park",
+        "short": "BUS",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-busan-ipark.png"
+      },
+      "away": {
+        "name": "Gimpo Citizen",
+        "short": "GIM",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gimpo-citizen-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 9.2,
+      "cards_avg": 4.2,
+      "btts_pct": 66.5,
+      "goals_over": {
+        "0.5": 96.5,
+        "1.5": 73.5,
+        "2.5": 56.5,
+        "3.5": 40,
+        "4.5": 20
+      },
+      "corners_over": {
+        "8.5": 60,
+        "9.5": 40,
+        "10.5": 26.5,
+        "11.5": 20
+      },
+      "cards_over": {
+        "2.5": 73.5,
+        "3.5": 53.5,
+        "4.5": 30,
+        "5.5": 16.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Jeonnam Dragons",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Paju Citizen",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Gimhae City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Suwon Bluewings",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Asan Mugunghwa",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-07",
+          "opp": "Jeonnam Dragons",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Gimhae City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Paju Citizen",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Ansan Greeners",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Cheongju",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Seoul E-Land",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 10,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Suwon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471628",
+      "league": "K League 2",
+      "region": "South Korea",
+      "date": "2026-07-12",
+      "time": "11:30",
+      "home": {
+        "name": "Asan Mugunghwa",
+        "short": "ASA",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-asan-mugunghwa-fc.png"
+      },
+      "away": {
+        "name": "Gyeongnam",
+        "short": "GYE",
+        "logo": "https://cdn.footystats.org/img/teams/south-korea-gyeongnam-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 8.2,
+      "cards_avg": 4.7,
+      "btts_pct": 63.5,
+      "goals_over": {
+        "0.5": 93.5,
+        "1.5": 76.5,
+        "2.5": 56.5,
+        "3.5": 36.5,
+        "4.5": 16.5
+      },
+      "corners_over": {
+        "8.5": 40,
+        "9.5": 33.5,
+        "10.5": 26.5,
+        "11.5": 20
+      },
+      "cards_over": {
+        "2.5": 70,
+        "3.5": 63,
+        "4.5": 37,
+        "5.5": 23.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Gimpo Citizen",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-05",
+          "opp": "Busan I'Park",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Suwon Bluewings",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Yongin City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Seoul E-Land",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Cheonan City",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Cheongju",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Cheonan City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-06",
+          "opp": "Yongin City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Hwaseong",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Suwon",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Seongnam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Gimhae City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Daegu",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Paju Citizen",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 3,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471300",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-12",
+      "time": "12:00",
+      "home": {
+        "name": "Tianjin Teda",
+        "short": "TIA",
+        "logo": "https://cdn.footystats.org/img/teams/china-tianjin-teda-fc.png"
+      },
+      "away": {
+        "name": "Shenyang Urban",
+        "short": "SHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-shenyang-urban-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 9.7,
+      "cards_avg": 3.6,
+      "btts_pct": 56,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 76,
+        "2.5": 62,
+        "3.5": 29.5,
+        "4.5": 15
+      },
+      "corners_over": {
+        "8.5": 56,
+        "9.5": 35,
+        "10.5": 26,
+        "11.5": 26
+      },
+      "cards_over": {
+        "2.5": 68,
+        "3.5": 53,
+        "4.5": 44,
+        "5.5": 24
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Dalian Zhixing",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 16,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Shanghai SIPG",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Henan Jianye",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Chongqing Tongliang Long",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Shandong Luneng",
+          "ha": "H",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shanghai SIPG",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Zhejiang FC",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Qingdao Jonoon",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Wuhan Three Towns",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Yunnan Yukun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-05",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-21",
+          "home": "Shenyang Urban",
+          "away": "Tianjin Teda",
+          "hg": 3,
+          "ag": 0,
+          "corners": 15,
+          "cards": 2
+        }
+      ]
+    },
+    {
+      "id": "8483548",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-12",
+      "time": "12:00",
+      "home": {
+        "name": "Shanghai Jiading",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shanghai-jiading-city-development.png"
+      },
+      "away": {
+        "name": "Dongguan United",
+        "short": "DON",
+        "logo": "https://cdn.footystats.org/img/teams/china-dongguan-united-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.9,
+      "corners_avg": 9.1,
+      "cards_avg": 3.2,
+      "btts_pct": 58,
+      "goals_over": {
+        "0.5": 96,
+        "1.5": 85,
+        "2.5": 58,
+        "3.5": 30.5,
+        "4.5": 15.5
+      },
+      "corners_over": {
+        "8.5": 54,
+        "9.5": 42.5,
+        "10.5": 34.5,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 69.5,
+        "3.5": 50,
+        "4.5": 30.5,
+        "5.5": 15.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Shaanxi Union",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 2,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 0,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Nanjing City",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Yanbian Longding",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Guangxi Hengchen",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Suzhou Dongwu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Shenzhen Juniors",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483562",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-12",
+      "time": "12:00",
+      "home": {
+        "name": "Shenzhen Juniors",
+        "short": "SHE",
+        "logo": "https://cdn.footystats.org/img/teams/china-shenzhen-juniors-fc.png"
+      },
+      "away": {
+        "name": "Heilongjiang Lava Spring",
+        "short": "HEI",
+        "logo": "https://cdn.footystats.org/img/teams/china-heilongjiang-lava-spring-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 10.7,
+      "cards_avg": 4,
+      "btts_pct": 58,
+      "goals_over": {
+        "0.5": 92.5,
+        "1.5": 80.5,
+        "2.5": 54,
+        "3.5": 34.5,
+        "4.5": 15
+      },
+      "corners_over": {
+        "8.5": 73.5,
+        "9.5": 53.5,
+        "10.5": 50,
+        "11.5": 38.5
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 53.5,
+        "4.5": 38,
+        "5.5": 8
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Nantong Zhiyun",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Dalian Huayi",
+          "ha": "A",
+          "gf": 4,
+          "ga": 5,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Changchun Yatai",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Hebei Kungfu",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Dongguan United",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 15,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Guangzhou E-Power",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Dongguan United",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Changchun Yatai",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Shaanxi Union",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Suzhou Dongwu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8483586",
+      "league": "China League One",
+      "region": "China",
+      "date": "2026-07-12",
+      "time": "12:30",
+      "home": {
+        "name": "Nantong Zhiyun",
+        "short": "NAN",
+        "logo": "https://cdn.footystats.org/img/teams/china-nantong-zhiyun-fc.png"
+      },
+      "away": {
+        "name": "Changchun Yatai",
+        "short": "CHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-changchun-yatai-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.4,
+      "corners_avg": 9,
+      "cards_avg": 3.5,
+      "btts_pct": 57.5,
+      "goals_over": {
+        "0.5": 88.5,
+        "1.5": 65.5,
+        "2.5": 54,
+        "3.5": 30.5,
+        "4.5": 4
+      },
+      "corners_over": {
+        "8.5": 53.5,
+        "9.5": 38.5,
+        "10.5": 34.5,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 61.5,
+        "4.5": 42.5,
+        "5.5": 15
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Shenzhen Juniors",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Meizhou Hakka",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Yanbian Longding",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shanghai Jiading",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Guangxi Hengchen",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Wuxi Wugou",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Guangzhou E-Power",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Meizhou Hakka",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Guangxi Hengchen",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-13",
+          "opp": "Dalian Huayi",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Yanbian Longding",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Shenzhen Juniors",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Heilongjiang Lava Spring",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Shanghai Jiading",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 2,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Guangzhou E-Power",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8471299",
+      "league": "Chinese Super League",
+      "region": "China",
+      "date": "2026-07-12",
+      "time": "12:35",
+      "home": {
+        "name": "Shanghai SIPG",
+        "short": "SHA",
+        "logo": "https://cdn.footystats.org/img/teams/china-shanghai-sipg-fc.png"
+      },
+      "away": {
+        "name": "Dalian Zhixing",
+        "short": "DAL",
+        "logo": "https://cdn.footystats.org/img/teams/china-dalian-zhixing-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 10.4,
+      "cards_avg": 5,
+      "btts_pct": 67.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 79,
+        "2.5": 65,
+        "3.5": 38,
+        "4.5": 20.5
+      },
+      "corners_over": {
+        "8.5": 62,
+        "9.5": 53,
+        "10.5": 41,
+        "11.5": 34.5
+      },
+      "cards_over": {
+        "2.5": 85,
+        "3.5": 76,
+        "4.5": 47,
+        "5.5": 26
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Qingdao Youth Island",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-27",
+          "opp": "Henan Jianye",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Shenyang Urban",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Tianjin Teda",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Chengdu Better City FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 11,
+          "btts": false
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Zhejiang FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Sichuan Jiuniu",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Wuhan Three Towns",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Shanghai Shenhua",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Tianjin Teda",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Chengdu Better City FC",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Sichuan Jiuniu",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-15",
+          "opp": "Qingdao Youth Island",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Qingdao Jonoon",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-06",
+          "opp": "Beijing Guoan",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-03-20",
+          "home": "Dalian Zhixing",
+          "away": "Shanghai SIPG",
+          "hg": 1,
+          "ag": 0,
+          "corners": 12,
+          "cards": 4
+        }
+      ]
+    },
+    {
+      "id": "8420329",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-12",
+      "time": "13:00",
+      "home": {
+        "name": "Västerås SK",
+        "short": "VÄS",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-vasteras-sk-fotboll.png"
+      },
+      "away": {
+        "name": "Degerfors",
+        "short": "DEG",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-degerfors-if.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 9.8,
+      "cards_avg": 3.5,
+      "btts_pct": 68.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 82,
+        "2.5": 64,
+        "3.5": 36.5,
+        "4.5": 22.5
+      },
+      "corners_over": {
+        "8.5": 59,
+        "9.5": 54.5,
+        "10.5": 41,
+        "11.5": 22.5
+      },
+      "cards_over": {
+        "2.5": 73,
+        "3.5": 36,
+        "4.5": 18,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": 1.99,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.79,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 64,
+            "odds": 1.99,
+            "implied": 50.3,
+            "edge": 13.7,
+            "flag": "value"
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Halmstad",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "IFK Göteborg",
+          "ha": "H",
+          "gf": 4,
+          "ga": 5,
+          "res": "L",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Brommapojkarna",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 14,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Malmö FF",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Örgryte",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420428",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-12",
+      "time": "13:00",
+      "home": {
+        "name": "Hammarby",
+        "short": "HAM",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-hammarby-if.png"
+      },
+      "away": {
+        "name": "Kalmar",
+        "short": "KAL",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-kalmar-ff.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 9.8,
+      "cards_avg": 3.3,
+      "btts_pct": 51.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 82.5,
+        "2.5": 56.5,
+        "3.5": 21.5,
+        "4.5": 21.5
+      },
+      "corners_over": {
+        "8.5": 65,
+        "9.5": 44,
+        "10.5": 44,
+        "11.5": 35
+      },
+      "cards_over": {
+        "2.5": 66,
+        "3.5": 43.5,
+        "4.5": 25.5,
+        "5.5": 8.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Häcken",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Malmö FF",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "IFK Göteborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Västerås SK",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 3,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Örgryte",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "GAIS",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Degerfors",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Brommapojkarna",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Halmstad",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Sirius",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Elfsborg",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 4,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "IFK Göteborg",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420450",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-12",
+      "time": "13:00",
+      "home": {
+        "name": "Malmö FF",
+        "short": "MAL",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-malmo-ff.png"
+      },
+      "away": {
+        "name": "IFK Göteborg",
+        "short": "IFK",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-ifk-goteborg.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.6,
+      "corners_avg": 10.8,
+      "cards_avg": 3,
+      "btts_pct": 68.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 82,
+        "2.5": 54.5,
+        "3.5": 50,
+        "4.5": 41
+      },
+      "corners_over": {
+        "8.5": 73,
+        "9.5": 59.5,
+        "10.5": 55,
+        "11.5": 45.5
+      },
+      "cards_over": {
+        "2.5": 64,
+        "3.5": 50,
+        "4.5": 22.5,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "Halmstad",
+          "ha": "H",
+          "gf": 5,
+          "ga": 2,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Västerås SK",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Hammarby",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Häcken",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "AIK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 22,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Sirius",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Västerås SK",
+          "ha": "A",
+          "gf": 5,
+          "ga": 4,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-05-19",
+          "opp": "Örgryte",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Hammarby",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 0,
+          "ga": 6,
+          "res": "L",
+          "corners": 14,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8411881",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-12",
+      "time": "13:30",
+      "home": {
+        "name": "KFUM",
+        "short": "KFU",
+        "logo": "https://cdn.footystats.org/img/teams/norway-kfum-fotball.png"
+      },
+      "away": {
+        "name": "FK Bodo - Glimt",
+        "short": "FK ",
+        "logo": "https://cdn.footystats.org/img/teams/norway-fk-bodo-glimt.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.1,
+      "corners_avg": 9,
+      "cards_avg": 3.1,
+      "btts_pct": 40.5,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 86.5,
+        "2.5": 64,
+        "3.5": 45.5,
+        "4.5": 18
+      },
+      "corners_over": {
+        "8.5": 59.5,
+        "9.5": 50,
+        "10.5": 31.5,
+        "11.5": 22.5
+      },
+      "cards_over": {
+        "2.5": 68.5,
+        "3.5": 27,
+        "4.5": 13.5,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Tromsø",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Rosenborg",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Brann",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Viking",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Vålerenga",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "HamKam",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 3,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Aalesund",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Rosenborg",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Start",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Tromsø",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Molde",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-30",
+          "opp": "Start",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Lillestrøm",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Aalesund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420275",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-12",
+      "time": "15:30",
+      "home": {
+        "name": "Brommapojkarna",
+        "short": "BRO",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-if-brommapojkarna.png"
+      },
+      "away": {
+        "name": "Sirius",
+        "short": "SIR",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-ik-sirius-fotboll.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.6,
+      "corners_avg": 9.7,
+      "cards_avg": 3.2,
+      "btts_pct": 67,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 95,
+        "2.5": 81,
+        "3.5": 47.5,
+        "4.5": 22.5
+      },
+      "corners_over": {
+        "8.5": 71,
+        "9.5": 56.5,
+        "10.5": 47.5,
+        "11.5": 37.5
+      },
+      "cards_over": {
+        "2.5": 52.5,
+        "3.5": 42.5,
+        "4.5": 23.5,
+        "5.5": 9.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "Degerfors",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Kalmar",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Elfsborg",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-04",
+          "opp": "Halmstad",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Västerås SK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Örgryte",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 3,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Mjällby",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-30",
+          "opp": "AIK",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "GAIS",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-18",
+          "opp": "Djurgården",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-11",
+          "opp": "Örgryte",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 9,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Kalmar",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Häcken",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Malmö FF",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8420427",
+      "league": "Allsvenskan",
+      "region": "Sweden",
+      "date": "2026-07-12",
+      "time": "15:30",
+      "home": {
+        "name": "GAIS",
+        "short": "GAI",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-gais.png"
+      },
+      "away": {
+        "name": "Elfsborg",
+        "short": "ELF",
+        "logo": "https://cdn.footystats.org/img/teams/sweden-if-elfsborg.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 9,
+      "cards_avg": 3,
+      "btts_pct": 60,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 82.5,
+        "2.5": 48.5,
+        "3.5": 22,
+        "4.5": 0
+      },
+      "corners_over": {
+        "8.5": 60.5,
+        "9.5": 43.5,
+        "10.5": 34.5,
+        "11.5": 13
+      },
+      "cards_over": {
+        "2.5": 69.5,
+        "3.5": 47.5,
+        "4.5": 25.5,
+        "5.5": 13
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Kalmar",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Sirius",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Hammarby",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Degerfors",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Västerås SK",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Örgryte",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "IFK Göteborg",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-23",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Hammarby",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Örgryte",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Häcken",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "Mjällby",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Halmstad",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Brommapojkarna",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "AIK",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-04-27",
+          "opp": "Kalmar",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 4,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8411871",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-12",
+      "time": "16:00",
+      "home": {
+        "name": "Rosenborg",
+        "short": "ROS",
+        "logo": "https://cdn.footystats.org/img/teams/norway-rosenborg-bk.png"
+      },
+      "away": {
+        "name": "Kristiansund",
+        "short": "KRI",
+        "logo": "https://cdn.footystats.org/img/teams/norway-kristiansund-bk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.5,
+      "corners_avg": 11.2,
+      "cards_avg": 4.3,
+      "btts_pct": 45.5,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 91,
+        "2.5": 40.5,
+        "3.5": 18,
+        "4.5": 9
+      },
+      "corners_over": {
+        "8.5": 73,
+        "9.5": 59.5,
+        "10.5": 50,
+        "11.5": 27
+      },
+      "cards_over": {
+        "2.5": 82,
+        "3.5": 54.5,
+        "4.5": 31.5,
+        "5.5": 18
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "FK Bodo - Glimt",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "KFUM",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Aalesund",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Lillestrøm",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Viking",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 18,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Sandefjord",
+          "ha": "A",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 18,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Vålerenga",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Viking",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Lillestrøm",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 10,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Molde",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Sandefjord",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "HamKam",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Aalesund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 18,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Fredrikstad",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8411876",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-12",
+      "time": "16:00",
+      "home": {
+        "name": "Brann",
+        "short": "BRA",
+        "logo": "https://cdn.footystats.org/img/teams/norway-sk-brann.png"
+      },
+      "away": {
+        "name": "Start",
+        "short": "STA",
+        "logo": "https://cdn.footystats.org/img/teams/norway-ik-start.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.5,
+      "corners_avg": 10.3,
+      "cards_avg": 3.5,
+      "btts_pct": 79,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 96,
+        "2.5": 66.5,
+        "3.5": 41.5,
+        "4.5": 29
+      },
+      "corners_over": {
+        "8.5": 58.5,
+        "9.5": 50,
+        "10.5": 50,
+        "11.5": 45
+      },
+      "cards_over": {
+        "2.5": 75,
+        "3.5": 54.5,
+        "4.5": 25,
+        "5.5": 12.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Aalesund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Fredrikstad",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-29",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Rosenborg",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 18,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Viking",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Fredrikstad",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 3,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Vålerenga",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "FK Bodo - Glimt",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Viking",
+          "ha": "A",
+          "gf": 3,
+          "ga": 6,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Tromsø",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 5,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-30",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 17,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "HamKam",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Molde",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8411879",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-12",
+      "time": "16:00",
+      "home": {
+        "name": "Sandefjord",
+        "short": "SAN",
+        "logo": "https://cdn.footystats.org/img/teams/norway-sandefjord-fotball.png"
+      },
+      "away": {
+        "name": "HamKam",
+        "short": "HAM",
+        "logo": "https://cdn.footystats.org/img/teams/norway-hamarkameratene-fotball.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.7,
+      "corners_avg": 11.5,
+      "cards_avg": 3.5,
+      "btts_pct": 57.5,
+      "goals_over": {
+        "0.5": 95.5,
+        "1.5": 77,
+        "2.5": 53,
+        "3.5": 29,
+        "4.5": 10
+      },
+      "corners_over": {
+        "8.5": 75,
+        "9.5": 70.5,
+        "10.5": 61.5,
+        "11.5": 57
+      },
+      "cards_over": {
+        "2.5": 66.5,
+        "3.5": 47.5,
+        "4.5": 19,
+        "5.5": 5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Molde",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 16,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Fredrikstad",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Lillestrøm",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Aalesund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 16,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Rosenborg",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 18,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Brann",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 3,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Aalesund",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Lillestrøm",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Fredrikstad",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Vålerenga",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Kristiansund",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Start",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 3,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Molde",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8464283",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-12",
+      "time": "17:00",
+      "home": {
+        "name": "Nõmme United II",
+        "short": "NÕM",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-nomme-united-u21-nomme-united-ii.png"
+      },
+      "away": {
+        "name": "Tallinna FC Flora U21",
+        "short": "TAL",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-tallinna-fc-flora-u21.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4.5,
+      "corners_avg": 10.6,
+      "cards_avg": 2.5,
+      "btts_pct": 75.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 94,
+        "2.5": 94,
+        "3.5": 79.5,
+        "4.5": 42.5
+      },
+      "corners_over": {
+        "8.5": 63.5,
+        "9.5": 48.5,
+        "10.5": 45.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 49.5,
+        "3.5": 32.5,
+        "4.5": 23,
+        "5.5": 13.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 19,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-30",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 2,
+          "ga": 5,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 9,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Elva",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 13,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 0,
+          "btts": false
+        },
+        {
+          "date": "2026-06-30",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 2,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Nõmme United II",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-30",
+          "home": "Nõmme United II",
+          "away": "Tallinna FC Flora U21",
+          "hg": 3,
+          "ag": 3,
+          "corners": 7,
+          "cards": 1
+        },
+        {
+          "date": "2026-05-13",
+          "home": "Tallinna FC Flora U21",
+          "away": "Nõmme United II",
+          "hg": 2,
+          "ag": 2,
+          "corners": 15,
+          "cards": 1
+        }
+      ]
+    },
+    {
+      "id": "8411874",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-12",
+      "time": "18:15",
+      "home": {
+        "name": "Sarpsborg 08",
+        "short": "SAR",
+        "logo": "https://cdn.footystats.org/img/teams/norway-sarpsborg-08-ff.png"
+      },
+      "away": {
+        "name": "Viking",
+        "short": "VIK",
+        "logo": "https://cdn.footystats.org/img/teams/norway-viking-fk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 10.9,
+      "cards_avg": 4,
+      "btts_pct": 62,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 86,
+        "2.5": 67.5,
+        "3.5": 29,
+        "4.5": 24.5
+      },
+      "corners_over": {
+        "8.5": 81.5,
+        "9.5": 72,
+        "10.5": 47.5,
+        "11.5": 43
+      },
+      "cards_over": {
+        "2.5": 77,
+        "3.5": 53,
+        "4.5": 44,
+        "5.5": 19
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Brann",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Molde",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Vålerenga",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Fredrikstad",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 14,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Lillestrøm",
+          "ha": "A",
+          "gf": 0,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "KFUM",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 3,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Tromsø",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-15",
+          "opp": "FK Bodo - Glimt",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-24",
+          "opp": "Kristiansund",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Start",
+          "ha": "H",
+          "gf": 6,
+          "ga": 3,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "KFUM",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-01",
+          "opp": "Rosenborg",
+          "ha": "H",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Fredrikstad",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 13,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "FK Bodo - Glimt",
+          "ha": "H",
+          "gf": 5,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-06",
+          "opp": "Vålerenga",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 15,
+          "cards": 6,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8447165",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-12",
+      "time": "19:00",
+      "home": {
+        "name": "KR",
+        "short": "KR",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-kr-reykjavik.png"
+      },
+      "away": {
+        "name": "ÍBV",
+        "short": "ÍBV",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-ib-vestmannaeyja.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4.8,
+      "corners_avg": 11.8,
+      "cards_avg": 4.2,
+      "btts_pct": 85,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 96,
+        "2.5": 77.5,
+        "3.5": 65.5,
+        "4.5": 55
+      },
+      "corners_over": {
+        "8.5": 74,
+        "9.5": 66,
+        "10.5": 62,
+        "11.5": 55
+      },
+      "cards_over": {
+        "2.5": 81,
+        "3.5": 70,
+        "4.5": 48,
+        "5.5": 37
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Keflavík",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "ÍA",
+          "ha": "H",
+          "gf": 5,
+          "ga": 3,
+          "res": "W",
+          "corners": 17,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Víkingur Reykjavík",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "KA",
+          "ha": "H",
+          "gf": 5,
+          "ga": 3,
+          "res": "W",
+          "corners": 19,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-26",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 17,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Breidablik",
+          "ha": "A",
+          "gf": 3,
+          "ga": 6,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Stjarnan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Keflavík",
+          "ha": "H",
+          "gf": 6,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "ÍA",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Víkingur Reykjavík",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "KA",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-23",
+          "home": "ÍBV",
+          "away": "KR",
+          "hg": 2,
+          "ag": 6,
+          "corners": 6,
+          "cards": 8
+        }
+      ]
+    },
+    {
+      "id": "8447166",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-12",
+      "time": "19:00",
+      "home": {
+        "name": "Fram",
+        "short": "FRA",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-fram-reykjavik.png"
+      },
+      "away": {
+        "name": "Thór",
+        "short": "THÓ",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-thor-akureyri.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 4.2,
+      "corners_avg": 12.2,
+      "cards_avg": 4.3,
+      "btts_pct": 64.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 80,
+        "2.5": 72,
+        "3.5": 64.5,
+        "4.5": 48
+      },
+      "corners_over": {
+        "8.5": 80,
+        "9.5": 80,
+        "10.5": 80,
+        "11.5": 68
+      },
+      "cards_over": {
+        "2.5": 80,
+        "3.5": 56,
+        "4.5": 24,
+        "5.5": 24
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-06-29",
+          "opp": "ÍA",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Víkingur Reykjavík",
+          "ha": "H",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "KA",
+          "ha": "A",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "Breidablik",
+          "ha": "H",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Stjarnan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 6,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "KR",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 12,
+          "cards": 3,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "KR",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 6,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Stjarnan",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 14,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Keflavík",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 16,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "ÍA",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 20,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Víkingur Reykjavík",
+          "ha": "A",
+          "gf": 0,
+          "ga": 6,
+          "res": "L",
+          "corners": 8,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-23",
+          "home": "Thór",
+          "away": "Fram",
+          "hg": 1,
+          "ag": 0,
+          "corners": 13,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8447227",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-12",
+      "time": "19:00",
+      "home": {
+        "name": "KA",
+        "short": "KA",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-ka-akureyri.png"
+      },
+      "away": {
+        "name": "ÍA",
+        "short": "ÍA",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-ia-akranes.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.4,
+      "corners_avg": 13,
+      "cards_avg": 4.2,
+      "btts_pct": 65.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 81,
+        "2.5": 62,
+        "3.5": 42,
+        "4.5": 23
+      },
+      "corners_over": {
+        "8.5": 96,
+        "9.5": 85,
+        "10.5": 81,
+        "11.5": 61.5
+      },
+      "cards_over": {
+        "2.5": 80.5,
+        "3.5": 61.5,
+        "4.5": 34.5,
+        "5.5": 31
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "Víkingur Reykjavík",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 17,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Stjarnan",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 20,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Breidablik",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-06-15",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 3,
+          "ga": 4,
+          "res": "L",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "KR",
+          "ha": "A",
+          "gf": 3,
+          "ga": 5,
+          "res": "L",
+          "corners": 19,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 14,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "Breidablik",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-29",
+          "opp": "Fram",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "KR",
+          "ha": "A",
+          "gf": 3,
+          "ga": 5,
+          "res": "L",
+          "corners": 17,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "Valur",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "FH",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-21",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 20,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Keflavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-22",
+          "home": "ÍA",
+          "away": "KA",
+          "hg": 1,
+          "ag": 1,
+          "corners": 9,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8447283",
+      "league": "Úrvalsdeild",
+      "region": "Iceland",
+      "date": "2026-07-12",
+      "time": "21:05",
+      "home": {
+        "name": "FH",
+        "short": "FH",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-fh-hafnarfjordur.png"
+      },
+      "away": {
+        "name": "Valur",
+        "short": "VAL",
+        "logo": "https://cdn.footystats.org/img/teams/iceland-valur-reykjavik.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.7,
+      "corners_avg": 13.2,
+      "cards_avg": 4.3,
+      "btts_pct": 74,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 85.5,
+        "2.5": 70,
+        "3.5": 48,
+        "4.5": 40.5
+      },
+      "corners_over": {
+        "8.5": 82,
+        "9.5": 82,
+        "10.5": 82,
+        "11.5": 70
+      },
+      "cards_over": {
+        "2.5": 66.5,
+        "3.5": 63,
+        "4.5": 45,
+        "5.5": 29.5
+      },
+      "goals_odds": {
+        "2.5": 1.36,
+        "3.5": 1.9,
+        "4.5": 2.88
+      },
+      "corners_odds": {
+        "8.5": 1.17,
+        "9.5": 1.37,
+        "10.5": 1.66,
+        "11.5": 2.03
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": 1.32,
+      "goals_under_odds": {
+        "0.5": 23.0,
+        "1.5": 6.15,
+        "2.5": 2.9,
+        "3.5": 1.85
+      },
+      "corners_under_odds": {
+        "8.5": 3.86,
+        "9.5": 2.72,
+        "10.5": 2.09,
+        "11.5": 1.7
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": 3.0,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 70,
+            "odds": 1.36,
+            "implied": 73.5,
+            "edge": -3.5,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 48,
+            "odds": 1.9,
+            "implied": 52.6,
+            "edge": -4.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 40.5,
+            "odds": 2.88,
+            "implied": 34.7,
+            "edge": 5.8,
+            "flag": null
+          }
+        },
+        "corners": {
+          "8.5": {
+            "prob": 82,
+            "odds": 1.17,
+            "implied": 85.5,
+            "edge": -3.5,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 82,
+            "odds": 1.37,
+            "implied": 73,
+            "edge": 9,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 82,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": 21.8,
+            "flag": "strong"
+          },
+          "11.5": {
+            "prob": 70,
+            "odds": 2.03,
+            "implied": 49.3,
+            "edge": 20.7,
+            "flag": "strong"
+          }
+        },
+        "btts": {
+          "prob": 74,
+          "odds": 1.32,
+          "implied": 75.8,
+          "edge": -1.8,
+          "flag": null
+        }
+      },
+      "home_form": [
+        {
+          "date": "2026-07-03",
+          "opp": "Stjarnan",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 22,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "ÍBV",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Thór",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Keflavík",
+          "ha": "A",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-29",
+          "opp": "ÍA",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 14,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "Víkingur Reykjavík",
+          "ha": "A",
+          "gf": 0,
+          "ga": 5,
+          "res": "L",
+          "corners": 12,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "KA",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "Breidablik",
+          "ha": "A",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 21,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-04",
+          "opp": "ÍBV",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 5,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-28",
+          "opp": "Thór",
+          "ha": "A",
+          "gf": 4,
+          "ga": 2,
+          "res": "W",
+          "corners": 6,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-06-21",
+          "opp": "Keflavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 17,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-06-16",
+          "opp": "ÍA",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-31",
+          "opp": "Víkingur Reykjavík",
+          "ha": "H",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-26",
+          "opp": "KR",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 17,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-22",
+          "opp": "KA",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Breidablik",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 17,
+          "cards": 1,
+          "btts": true
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-04-23",
+          "home": "Valur",
+          "away": "FH",
+          "hg": 3,
+          "ag": 0,
+          "corners": 15,
+          "cards": 2
         }
       ]
     }

--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -465,8 +465,9 @@ export default function FormTables() {
 
   // TODAY only (UK date). Snapshot dates are real fixture dates.
   const today = useMemo(() => new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/London' }), []);
-  // 3-day window: today, tomorrow, day after — today's games highlighted.
-  const windowDates = useMemo(() => [0, 1, 2].map((n) => addDays(today, n)), [today]);
+  // 7-day window: today plus the coming week — past days never shown, and a
+  // quiet midweek still surfaces the weekend card. Only today's games glow.
+  const windowDates = useMemo(() => [0, 1, 2, 3, 4, 5, 6].map((n) => addDays(today, n)), [today]);
 
   const rows = useMemo(() => {
     // Rank by the SELECTED line's form probability (over-% or, in unders, the


### PR DESCRIPTION
- `generate-board.py` fetches a **7-day fixture window** (was 3) so a quiet midweek still shows the coming weekend card, and keeps only **2 past days** in the file (enough for the settlement job) instead of 8.
- `FormTables.tsx` widens its display window to the same week — past fixtures are never rendered, every row carries its day label ("Today", "11 Jul"…), and only today's games get the Gaffer/value highlights.
- Includes today's regenerated snapshot: 3 games today + Thu/Fri/Sat/Sun (124 fixtures, 13 leagues).

Homepage board selection is unaffected — `gafferSelection.ts` filters to today's date before picking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_