### PR TITLE
Workflow deploy: wrangler v4 + explicit account id

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -80,12 +80,14 @@ jobs:
       - name: Deploy to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # wrangler v4 required: v3 hits /memberships, which this token can't read.
+          CLOUDFLARE_ACCOUNT_ID: 964cd8ee33ecf4e58a581f4806cd0cb5
         run: |
           if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
             echo "::error::CLOUDFLARE_API_TOKEN secret is not set — data was committed but the LIVE SITE WAS NOT UPDATED."
             exit 1
           fi
-          npx wrangler@3 pages deploy dist --project-name=golden-bet-ai --branch=main
+          npx wrangler@4 pages deploy dist --project-name=golden-bet-ai --branch=main
 
       # Morning report straight to the boss's pocket (skips if secrets unset).
       - name: Telegram report


### PR DESCRIPTION
The test dispatch of the daily workflow failed at the deploy step: wrangler v3 authenticates via `/memberships`, which the deploy token can't read (auth error 10000). v4 uses the accounts endpoint and works with this token — matching how manual deploys have been done all along. Also pins `CLOUDFLARE_ACCOUNT_ID` explicitly.

The Telegram failure alert from that run fired correctly — the alarm path is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_