### PR TITLE
Build The Gaffer's Value Board (/value-board)

### DIFF
--- a/functions/api/alerts.ts
+++ b/functions/api/alerts.ts
@@ -1,0 +1,89 @@
+// Cloudflare Pages Function — Value Board email alert preferences.
+//
+//   POST /api/alerts              { email, enabled, gafferCardOnly, ... }  -> save prefs
+//   GET  /api/alerts?email=…                                              -> read own prefs
+//   GET  /api/alerts?key=…                                                -> admin: list all
+//
+// Storage: WAITLIST KV namespace, key `alert:<email>` whose VALUE is the
+// prefs JSON and whose metadata carries { email, ts, country } for cheap
+// admin listing. New signups ping Telegram (best-effort, never blocking).
+interface Env {
+  WAITLIST: KVNamespace;
+  ADMIN_KEY?: string;
+  TELEGRAM_BOT_TOKEN?: string;
+  TELEGRAM_CHAT_ID?: string;
+}
+
+const JSON_HEADERS = { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' };
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+const err = (code: string, message: string, status = 400) => json({ ok: false, error: { code, message } }, status);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const MARKET_RE = /^(over|under)_\d+_\d+_(goals|corners|cards)$|^btts_(yes|no)$/;
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  let body: Record<string, unknown> = {};
+  try { body = await ctx.request.json(); } catch { /* ignore */ }
+  if (typeof body.hp === 'string' && body.hp.trim()) return json({ ok: true }); // honeypot
+
+  const email = String(body.email ?? '').trim().toLowerCase();
+  if (!EMAIL_RE.test(email) || email.length > 120) return err('invalid_email', 'That email doesn’t look right.');
+
+  const marketKeys = Array.isArray(body.marketKeys)
+    ? body.marketKeys.filter((k): k is string => typeof k === 'string' && MARKET_RE.test(k)).slice(0, 22)
+    : [];
+  const t = (body.timing ?? {}) as Record<string, unknown>;
+  const prefs = {
+    email,
+    enabled: body.enabled !== false,
+    gafferCardOnly: body.gafferCardOnly === true,
+    allValueAlerts: body.allValueAlerts === true,
+    quietDayCallback: body.quietDayCallback === true,
+    marketKeys,
+    timing: {
+      morningScan: t.morningScan !== false,
+      preKickoff: t.preKickoff === true,
+      newValueAppears: t.newValueAppears === true,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+
+  const key = `alert:${email}`;
+  const isNew = (await ctx.env.WAITLIST.get(key)) == null;
+  const country = (ctx.request.headers.get('cf-ipcountry') || '').toUpperCase() || undefined;
+  await ctx.env.WAITLIST.put(key, JSON.stringify(prefs), { metadata: { email, ts: prefs.updatedAt, country } });
+
+  if (isNew) ctx.waitUntil(notify(ctx.env, email, prefs, country));
+  return json({ ok: true, data: prefs });
+};
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const adminKey = url.searchParams.get('key') ?? ctx.request.headers.get('x-admin-key') ?? '';
+  if (adminKey) {
+    if (!ctx.env.ADMIN_KEY || adminKey !== ctx.env.ADMIN_KEY) return err('unauthorized', 'Bad admin key.', 401);
+    const list = await ctx.env.WAITLIST.list({ prefix: 'alert:', limit: 1000 });
+    return json({ ok: true, data: { count: list.keys.length, subscribers: list.keys.map((k) => k.metadata ?? { email: k.name.slice(6) }) } });
+  }
+  const email = (url.searchParams.get('email') ?? '').trim().toLowerCase();
+  if (!EMAIL_RE.test(email)) return err('invalid_email', 'Pass a valid email.');
+  const raw = await ctx.env.WAITLIST.get(`alert:${email}`);
+  if (!raw) return json({ ok: true, data: null });
+  try { return json({ ok: true, data: JSON.parse(raw) }); } catch { return json({ ok: true, data: null }); }
+};
+
+async function notify(env: Env, email: string, prefs: { gafferCardOnly: boolean; allValueAlerts: boolean; quietDayCallback: boolean; marketKeys: string[] }, country?: string) {
+  if (!env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_CHAT_ID) return;
+  const scope = prefs.allValueAlerts ? 'ALL value alerts'
+    : prefs.gafferCardOnly ? 'Gaffer card only'
+    : prefs.marketKeys.length ? `${prefs.marketKeys.length} market(s): ${prefs.marketKeys.slice(0, 4).join(', ')}${prefs.marketKeys.length > 4 ? '…' : ''}`
+    : 'default (morning scan)';
+  const text = `🔔 Value Board alert signup\n${email}${country ? ` · ${country}` : ''}\nScope: ${scope}${prefs.quietDayCallback ? '\n+ quiet-day callback' : ''}`;
+  try {
+    await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text, disable_web_page_preview: true }),
+    });
+  } catch { /* best-effort only */ }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const CheckoutReturn = lazy(() => import("./pages/CheckoutReturn"));
 const MembersDashboard = lazy(() => import("./pages/MembersDashboard"));
 const ComingSoon = lazy(() => import("./pages/ComingSoon"));
 const FormTables = lazy(() => import("./pages/FormTables"));
+const ValueBoard = lazy(() => import("./pages/ValueBoard"));
 const FantasyLeague = lazy(() => import("./pages/FantasyLeague"));
 const Pnl = lazy(() => import("./pages/Pnl"));
 const FantasyWaitlist = lazy(() => import("./pages/FantasyWaitlist"));
@@ -67,6 +68,8 @@ const App = () => {
                 <Route path="/fantasy-league/transfers" element={<ComingSoon title="Transfers" eyebrow="Coming 1st August" description="The transfer market opens with the membership on 1st August. Join the fantasy waitlist to be first in." />} />
                 <Route path="/fantasy-league/results" element={<ComingSoon title="Gameweek Results" eyebrow="Coming 1st August" description="Gameweek results go live once the season kicks off on Sat 22nd August. Join the fantasy waitlist to be first in." />} />
                 <Route path="/form-tables" element={<FormTables />} />
+                <Route path="/value-board" element={<ValueBoard />} />
+                <Route path="/match-insights" element={<ValueBoard />} />
                 <Route path="/fixtures" element={<ComingSoon title="Today's Fixtures" eyebrow="In Build" />} />
                 <Route path="/tips" element={<ComingSoon title="Daily Tips" eyebrow="In Build" />} />
                 <Route path="/pnl" element={<Pnl />} />

--- a/src/components/homepage/content.ts
+++ b/src/components/homepage/content.ts
@@ -30,6 +30,7 @@ export const SOCIAL_LINKS = {
 export const NAV_LINKS = [
   { label: 'Predictions', href: '#daily-picks' },
   { label: 'Form Tables', href: '/form-tables' },
+  { label: 'Value Board', href: '/value-board' },
   { label: 'Fantasy League', href: '/fantasy-league' },
   { label: 'P&L', href: '/pnl' },
   { label: 'Articles', href: '#latest-articles' },

--- a/src/components/valueboard/EmailAlertPreferences.tsx
+++ b/src/components/valueboard/EmailAlertPreferences.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import { Bell, Check, Sunrise, AlarmClock, Zap, PhoneMissed } from 'lucide-react';
+import { FAMILIES, VALUE_MARKETS, type ValueMarketKey } from '@/lib/valueBoard';
+import {
+  DEFAULT_ALERT_PREFS, useSaveUserValueAlertPreferences, useUserValueAlertPreferences,
+  type AlertPreferences,
+} from '@/hooks/useValueBoard';
+
+function Toggle({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[11px] font-black uppercase tracking-wide transition-colors ${on
+        ? 'border-emerald-400/50 bg-emerald-500/15 text-emerald-200'
+        : 'border-white/12 bg-white/[0.04] text-white/55 hover:bg-white/[0.08]'}`}
+    >
+      {on && <Check className="h-3 w-3" />} {children}
+    </button>
+  );
+}
+
+/** Email alert preferences — Gaffer card / specific markets / all value /
+ *  quiet-day callback, with timing options. Saves to the KV-backed endpoint. */
+export function EmailAlertPreferences({ pendingMarket, onConsumedPending }: {
+  pendingMarket: ValueMarketKey | null;
+  onConsumedPending: () => void;
+}) {
+  const [email, setEmail] = useState(() => { try { return localStorage.getItem('fo_alert_email') ?? ''; } catch { return ''; } });
+  const [prefs, setPrefs] = useState<Omit<AlertPreferences, 'email'>>(DEFAULT_ALERT_PREFS);
+  const { prefs: stored } = useUserValueAlertPreferences(email.includes('@') ? email : null);
+  const { save, saving, saved, error, resetSaved } = useSaveUserValueAlertPreferences();
+
+  // Load stored prefs once they arrive.
+  useEffect(() => { if (stored) setPrefs({ ...DEFAULT_ALERT_PREFS, ...stored }); }, [stored]);
+
+  // "Add this market to alerts" from the breakdown panel lands here.
+  useEffect(() => {
+    if (!pendingMarket) return;
+    setPrefs((p) => p.marketKeys.includes(pendingMarket) ? p : { ...p, marketKeys: [...p.marketKeys, pendingMarket], gafferCardOnly: false });
+    onConsumedPending();
+  }, [pendingMarket, onConsumedPending]);
+
+  const toggleMarket = (k: ValueMarketKey) => {
+    resetSaved();
+    setPrefs((p) => ({
+      ...p,
+      gafferCardOnly: false,
+      marketKeys: p.marketKeys.includes(k) ? p.marketKeys.filter((x) => x !== k) : [...p.marketKeys, k],
+    }));
+  };
+  const set = (patch: Partial<Omit<AlertPreferences, 'email'>>) => { resetSaved(); setPrefs((p) => ({ ...p, ...patch })); };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.includes('@')) return;
+    void save({ email: email.trim().toLowerCase(), ...prefs });
+  };
+
+  return (
+    <section id="value-alerts" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#130321]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="p-5 md:p-7">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-violet-200">
+          <Bell className="h-3.5 w-3.5" /> Email Alerts
+        </span>
+        <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">The value finds you</h2>
+        <p className="mt-1 max-w-xl text-xs leading-relaxed text-white/55">
+          Pick what you want in your inbox — the Gaffer's daily card, the markets you personally follow, everything,
+          or just an honest "nothing today" so you never wonder.
+        </p>
+
+        <form onSubmit={submit} className="mt-5 space-y-4">
+          {/* alert groups */}
+          <div className="flex flex-wrap gap-1.5">
+            <Toggle on={prefs.gafferCardOnly} onClick={() => set({ gafferCardOnly: !prefs.gafferCardOnly, allValueAlerts: false, marketKeys: [] })}>Gaffer card only</Toggle>
+            <Toggle on={prefs.allValueAlerts} onClick={() => set({ allValueAlerts: !prefs.allValueAlerts, gafferCardOnly: false })}>All value alerts</Toggle>
+            <Toggle on={prefs.quietDayCallback} onClick={() => set({ quietDayCallback: !prefs.quietDayCallback })}><PhoneMissed className="h-3 w-3" /> Quiet-day callback</Toggle>
+          </div>
+
+          {/* market toggles by family */}
+          {!prefs.gafferCardOnly && !prefs.allValueAlerts && (
+            <div className="space-y-2.5 rounded-[13px] border border-white/[0.09] bg-black/20 p-3.5">
+              <div className="text-[10px] font-black uppercase tracking-[0.16em] text-white/40">Or pick your exact markets</div>
+              {FAMILIES.map((f) => (
+                <div key={f.family} className="flex flex-wrap items-center gap-1.5">
+                  <span className="w-16 shrink-0 text-[10px] font-black uppercase tracking-wide text-[#f8e7a1]/70">{f.label}</span>
+                  {VALUE_MARKETS.filter((m) => m.family === f.family).map((m) => (
+                    <button
+                      key={m.key}
+                      type="button"
+                      onClick={() => toggleMarket(m.key)}
+                      className={`rounded-md px-2 py-1 text-[10px] font-bold transition-colors ${prefs.marketKeys.includes(m.key)
+                        ? 'bg-violet-500/25 text-violet-100 ring-1 ring-inset ring-violet-400/50'
+                        : 'bg-white/[0.04] text-white/50 ring-1 ring-inset ring-white/10 hover:bg-white/[0.08]'}`}
+                    >
+                      {m.family === 'btts' ? (m.side === 'yes' ? 'BTTS Yes' : 'BTTS No') : `${m.side === 'over' ? 'O' : 'U'} ${m.line}`}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* timing */}
+          <div className="flex flex-wrap gap-1.5">
+            <Toggle on={prefs.timing.morningScan} onClick={() => set({ timing: { ...prefs.timing, morningScan: !prefs.timing.morningScan } })}><Sunrise className="h-3 w-3" /> Morning scan</Toggle>
+            <Toggle on={prefs.timing.preKickoff} onClick={() => set({ timing: { ...prefs.timing, preKickoff: !prefs.timing.preKickoff } })}><AlarmClock className="h-3 w-3" /> Pre-kickoff reminder</Toggle>
+            <Toggle on={prefs.timing.newValueAppears} onClick={() => set({ timing: { ...prefs.timing, newValueAppears: !prefs.timing.newValueAppears } })}><Zap className="h-3 w-3" /> New value appears</Toggle>
+          </div>
+
+          {/* email + save */}
+          <div className="flex max-w-xl flex-col gap-2.5 sm:flex-row">
+            <input
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); resetSaved(); }}
+              type="email"
+              required
+              aria-label="Email address for alerts"
+              placeholder="your@email.com"
+              className="min-w-0 flex-1 rounded-xl border border-white/15 bg-[#160b2e] px-4 py-3 text-sm text-white placeholder-white/35 outline-none transition-colors focus:border-violet-400/60"
+            />
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-fuchsia-500 to-violet-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-white shadow-[0_14px_36px_-14px_rgba(217,70,239,0.9)] transition-transform hover:-translate-y-0.5 disabled:opacity-60"
+            >
+              <Bell className="h-4 w-4" /> {saving ? 'Saving…' : 'Save Alert Preferences'}
+            </button>
+          </div>
+          {saved && (
+            <div className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2.5 text-sm font-bold text-emerald-300">
+              <Check className="h-4 w-4" /> Saved — the Gaffer knows where to find you.
+            </div>
+          )}
+          {error && <div className="text-sm font-bold text-rose-300">{error}</div>}
+          <p className="text-[10.5px] text-white/35">Alerts start with the membership on 1st August — preferences saved now carry over. No spam, ever.</p>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/components/valueboard/GafferDailyCardSection.tsx
+++ b/src/components/valueboard/GafferDailyCardSection.tsx
@@ -1,0 +1,93 @@
+import { Star, Layers, Bell, Clock, ShieldAlert } from 'lucide-react';
+import type { GafferDailyCardData, DailyCardSelection } from '@/lib/valueBoard';
+
+/** One selection row inside the daily card — solid panel, gold accent bar. */
+function SelectionRow({ s }: { s: DailyCardSelection }) {
+  return (
+    <div className="relative overflow-hidden rounded-[13px] border border-white/[0.1] bg-gradient-to-b from-[#1c1338] to-[#110a26]">
+      <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[#ffe487] to-[#b8860b]" />
+      <div className="flex items-center justify-between gap-2 border-b border-white/[0.08] py-2 pl-4 pr-3">
+        <span className="min-w-0 truncate text-[13px] font-semibold text-white">{s.fixture}</span>
+        <span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-black text-[#f8e7a1] [font-variant-numeric:tabular-nums]">
+          <Clock className="h-3 w-3 text-[#f5c542]/80" /> {s.kickoffLabel}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2 pl-4 pr-3 text-[11px] text-white/60">
+        <span className="font-display text-[14px] uppercase tracking-tight text-white">{s.marketLabel}</span>
+        {s.oddsSnapshot != null && <span className="font-display text-[15px] text-[#f5c542] [font-variant-numeric:tabular-nums]">{s.oddsSnapshot.toFixed(2)}</span>}
+        <span className="[font-variant-numeric:tabular-nums]">model <b className="text-white/90">{Math.round(s.modelProbability)}%</b></span>
+        <span className="[font-variant-numeric:tabular-nums]">implied <b className="text-white/90">{Math.round(s.impliedProbability)}%</b></span>
+        <span className="ml-auto inline-flex items-center rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">+{s.valueGap.toFixed(1)} gap</span>
+        <span className={`inline-flex items-center rounded-[6px] px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide ring-1 ring-inset ${s.confidence === 'high' ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/25' : s.confidence === 'medium' ? 'bg-amber-500/10 text-amber-300 ring-amber-400/25' : 'bg-white/[0.06] text-white/55 ring-white/15'}`}>{s.confidence}</span>
+      </div>
+      <p className="border-t border-white/[0.08] py-2 pl-4 pr-3 text-[12px] italic leading-relaxed text-white/70">
+        <span aria-hidden className="mr-1 font-display text-base leading-none text-violet-300/70">“</span>
+        {s.gafferVerdict}
+        <span aria-hidden className="ml-0.5 font-display text-base leading-none text-violet-300/70">”</span>
+      </p>
+    </div>
+  );
+}
+
+/** The Gaffer's Daily Card — surfaces the tipping engine's locked double and
+ *  treble (this page never re-picks). Honest quiet-day state when thin. */
+export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDailyCardData; onEmailCard: () => void }) {
+  return (
+    <section id="gaffer-daily-card" className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#130321]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="p-5 md:p-7">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-[#f5c542]/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]">
+              <Star className="h-3.5 w-3.5 fill-current" /> Today's Gaffer Card
+            </span>
+            <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">The double is mine. The rest is yours to explore.</h2>
+            <p className="mt-1 text-xs text-white/55">Curated by the tipping engine every morning — the board below is where you browse the rest.</p>
+          </div>
+          <button
+            onClick={onEmailCard}
+            className="inline-flex items-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-4 py-2.5 text-[11px] font-black uppercase tracking-wide text-violet-200 transition-colors hover:bg-violet-500/20"
+          >
+            <Bell className="h-3.5 w-3.5" /> Email me the Gaffer card
+          </button>
+        </div>
+
+        {card.quietDay ? (
+          <div className="mt-5 rounded-2xl border border-white/10 bg-black/25 p-6 text-center">
+            <h3 className="font-display text-2xl uppercase text-white">{card.quietDayMessage.split('—')[0].trim()}</h3>
+            <p className="mx-auto mt-1.5 max-w-md text-sm text-white/60">No forced picks today. Discipline is part of the game — the board below still shows anything the scan did find.</p>
+          </div>
+        ) : (
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            <div>
+              <div className="mb-2 flex items-center gap-2 text-[11px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]">
+                <Star className="h-3.5 w-3.5" /> Daily Double
+              </div>
+              <div className="space-y-2.5">
+                {card.double.selections.map((s) => <SelectionRow key={s.fixtureId} s={s} />)}
+              </div>
+            </div>
+            <div>
+              <div className="mb-2 flex items-center gap-2 text-[11px] font-black uppercase tracking-[0.16em] text-cyan-200">
+                <Layers className="h-3.5 w-3.5" /> Daily Treble
+              </div>
+              {card.treble.available ? (
+                <div className="space-y-2.5">
+                  {card.treble.selections.map((s) => <SelectionRow key={s.fixtureId} s={s} />)}
+                </div>
+              ) : (
+                <div className="rounded-[13px] border border-white/10 bg-black/25 p-5 text-sm text-white/55">
+                  Not enough qualifying selections for a treble today — the Gaffer doesn't pad a card to make it look busy.
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        <p className="mt-4 flex items-start gap-2 text-[11px] leading-relaxed text-white/45">
+          <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#f5c542]/70" /> {card.riskNote}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/valueboard/MarketBoard.tsx
+++ b/src/components/valueboard/MarketBoard.tsx
@@ -1,0 +1,319 @@
+import { useMemo, useState } from 'react';
+import { X, ArrowDownWideNarrow, BellPlus, Swords, TrendingUp, Activity } from 'lucide-react';
+import { TeamAvatar } from '@/components/TeamAvatar';
+import {
+  FAMILIES, VALUE_MARKETS, type HubSummary, type MarketSummary,
+  type ValueMarketFamily, type ValueMarketKey, type Confidence, type FixtureStatus,
+} from '@/lib/valueBoard';
+import { useValueMarketFixtures, useFixtureValueBreakdown, useValueBoardLeagues } from '@/hooks/useValueBoard';
+
+const confTone = (c: Confidence) =>
+  c === 'high' ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/25'
+  : c === 'medium' ? 'bg-amber-500/10 text-amber-300 ring-amber-400/25'
+  : 'bg-white/[0.06] text-white/55 ring-white/15';
+
+const statusTone: Record<FixtureStatus, string> = {
+  scheduled: 'text-white/50', live: 'text-emerald-300', finished: 'text-white/40', stale: 'text-rose-300',
+};
+
+/* ── Market family tabs ─────────────────────────────────────────────────── */
+function MarketFamilyTabs({ family, counts, onChange }: {
+  family: ValueMarketFamily;
+  counts: Record<ValueMarketFamily, number>;
+  onChange: (f: ValueMarketFamily) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {FAMILIES.map((f) => (
+        <button
+          key={f.family}
+          onClick={() => onChange(f.family)}
+          className={`inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-[12px] font-black uppercase tracking-wide transition-colors ${family === f.family
+            ? 'bg-gradient-to-r from-amber-300 to-amber-500 text-[#16051f] shadow-[0_10px_26px_-12px_rgba(245,197,66,0.9)]'
+            : 'border border-white/12 bg-white/[0.04] text-white/65 hover:bg-white/[0.08]'}`}
+        >
+          {f.label}
+          <span className={`rounded-full px-1.5 py-px text-[10px] [font-variant-numeric:tabular-nums] ${family === f.family ? 'bg-black/20' : 'bg-white/10'}`}>{counts[f.family]}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ── One exact-market card ──────────────────────────────────────────────── */
+function ValueMarketCard({ s, active, onOpen }: { s: MarketSummary; active: boolean; onOpen: () => void }) {
+  return (
+    <button
+      onClick={onOpen}
+      className={`group relative overflow-hidden rounded-[14px] text-left transition-transform hover:-translate-y-0.5 ${active ? '' : ''}`}
+    >
+      <div className={`relative overflow-hidden rounded-[14px] border bg-gradient-to-b from-[#1c1338] to-[#110a26] ${active ? 'border-[#f5c542]/60' : s.status === 'value' ? 'border-emerald-400/30' : 'border-white/[0.09]'}`}>
+        <div aria-hidden className={`h-[3px] ${s.status === 'value' ? 'bg-[linear-gradient(90deg,#065f46,#34d399,#065f46)]' : 'bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)] opacity-50'}`} />
+        <div className="p-3.5">
+          <div className="flex items-start justify-between gap-2">
+            <span className="font-display text-[15px] uppercase leading-tight tracking-tight text-white">{s.label}</span>
+            {s.status === 'value'
+              ? <span className="shrink-0 rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">{s.fixturesFoundToday} value</span>
+              : <span className="shrink-0 rounded-[6px] bg-white/[0.06] px-1.5 py-[3px] text-[9px] font-black uppercase tracking-wide text-white/45 ring-1 ring-inset ring-white/10">{s.status === 'priced' ? 'no edge' : 'unpriced'}</span>}
+          </div>
+          {s.status === 'value' ? (
+            <div className="mt-2 space-y-1 text-[11px] text-white/55">
+              <div className="truncate">Strongest: <b className="text-white/85">{s.strongestFixture}</b></div>
+              <div className="flex flex-wrap gap-x-3 [font-variant-numeric:tabular-nums]">
+                <span>biggest gap <b className="text-emerald-300">+{s.biggestValueGap?.toFixed(1)}</b></span>
+                <span>avg score <b className="text-white/85">{s.averageValueScore?.toFixed(1)}</b></span>
+                {s.confidenceRange && <span>conf <b className="text-white/85">{s.confidenceRange}</b></span>}
+              </div>
+            </div>
+          ) : (
+            <p className="mt-2 text-[11px] leading-snug text-white/40">
+              {s.status === 'priced'
+                ? 'No strong edge found for this market today.'
+                : 'No bookmaker prices for this market in today’s leagues.'}
+            </p>
+          )}
+          <div className={`mt-2.5 text-[10px] font-black uppercase tracking-[0.14em] ${active ? 'text-[#f8e7a1]' : 'text-white/35 group-hover:text-white/60'}`}>
+            {active ? '▾ Showing fixtures below' : s.fixturesPriced > 0 ? `View ${s.fixturesPriced} priced fixture${s.fixturesPriced === 1 ? '' : 's'} →` : 'View →'}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+/* ── Ranked fixtures for the selected market ────────────────────────────── */
+function MarketFixtureTable({ marketKey, onRowClick }: { marketKey: ValueMarketKey; onRowClick: (fixtureId: string) => void }) {
+  const [league, setLeague] = useState('all');
+  const [minConf, setMinConf] = useState<Confidence | 'any'>('any');
+  const [sort, setSort] = useState<'valueGap' | 'confidence' | 'kickoff'>('valueGap');
+  const leagues = useValueBoardLeagues();
+  const res = useValueMarketFixtures({ marketKey, league, minConfidence: minConf === 'any' ? undefined : minConf });
+  if (!res.ok) return null;
+  const order: Confidence[] = ['low', 'medium', 'high'];
+  const rows = [...res.data.fixtures].sort((a, b) =>
+    sort === 'valueGap' ? b.valueGap - a.valueGap
+    : sort === 'confidence' ? order.indexOf(b.confidence) - order.indexOf(a.confidence) || b.valueGap - a.valueGap
+    : a.kickoff.localeCompare(b.kickoff));
+
+  const sel = 'rounded-lg border border-white/12 bg-[#160b2e] px-2.5 py-1.5 text-[11px] font-bold text-white/75 outline-none focus:border-[#f5c542]/50';
+  return (
+    <div className="mt-4 overflow-hidden rounded-[14px] border border-white/[0.09] bg-gradient-to-b from-[#170e2e] to-[#0f0821]">
+      <div className="flex flex-wrap items-center gap-2 border-b border-white/[0.08] px-3.5 py-2.5">
+        <span className="font-display text-[14px] uppercase tracking-tight text-white">{res.data.marketLabel}</span>
+        <span className="text-[10px] font-black uppercase tracking-[0.14em] text-white/35">ranked by {sort === 'valueGap' ? 'value gap' : sort}</span>
+        <div className="ml-auto flex flex-wrap gap-1.5">
+          <select value={league} onChange={(e) => setLeague(e.target.value)} className={sel} aria-label="Filter by league">
+            <option value="all">All leagues</option>
+            {leagues.map((l) => <option key={l} value={l}>{l}</option>)}
+          </select>
+          <select value={minConf} onChange={(e) => setMinConf(e.target.value as Confidence | 'any')} className={sel} aria-label="Minimum confidence">
+            <option value="any">Any confidence</option>
+            <option value="medium">Medium +</option>
+            <option value="high">High only</option>
+          </select>
+          <select value={sort} onChange={(e) => setSort(e.target.value as typeof sort)} className={sel} aria-label="Sort">
+            <option value="valueGap">Sort: value gap</option>
+            <option value="confidence">Sort: confidence</option>
+            <option value="kickoff">Sort: kickoff</option>
+          </select>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="px-4 py-8 text-center text-sm text-white/50">{res.data.emptyStateMessage}</div>
+      ) : (
+        <div className="divide-y divide-white/[0.06]">
+          {rows.map((r) => (
+            <button key={r.id} onClick={() => onRowClick(r.id)} className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-white/[0.03]">
+              <div className="flex shrink-0 items-center -space-x-1">
+                <TeamAvatar name={r.homeTeam} logoUrl={r.homeLogo} size={26} className="rounded-md bg-black/45 p-0.5 ring-1 ring-white/12" />
+                <TeamAvatar name={r.awayTeam} logoUrl={r.awayLogo} size={26} className="rounded-md bg-black/45 p-0.5 ring-1 ring-white/12" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-2">
+                  <span className="truncate text-[13px] font-semibold text-white">{r.fixture}</span>
+                  {r.qualifies && <span className="shrink-0 rounded-[5px] bg-emerald-500/15 px-1 py-px text-[8.5px] font-black uppercase text-emerald-300 ring-1 ring-inset ring-emerald-400/30">value</span>}
+                </div>
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-2.5 text-[10.5px] text-white/45 [font-variant-numeric:tabular-nums]">
+                  <span className="truncate">{r.league}</span>
+                  <span className={statusTone[r.status]}>{r.status === 'scheduled' ? `${r.kickoffLabel} KO` : r.status}</span>
+                  <span>form <b className="text-white/75">{Math.round(r.formScore)}%</b></span>
+                  <span>implied <b className="text-white/75">{Math.round(r.impliedProbability)}%</b></span>
+                </div>
+              </div>
+              <div className="shrink-0 text-right [font-variant-numeric:tabular-nums]">
+                <div className={`text-[13px] font-black ${r.valueGap >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>{r.valueGap >= 0 ? '+' : ''}{r.valueGap.toFixed(1)}</div>
+                <div className="mt-0.5 flex items-center justify-end gap-1">
+                  {r.oddsSnapshot != null && <span className="font-display text-[13px] text-[#f5c542]">{r.oddsSnapshot.toFixed(2)}</span>}
+                  <span className={`rounded-[5px] px-1 py-px text-[8.5px] font-black uppercase ring-1 ring-inset ${confTone(r.confidence)}`}>{r.confidence[0]}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Fixture breakdown panel (modal) ────────────────────────────────────── */
+function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
+  fixtureId: string; marketKey: ValueMarketKey; onClose: () => void; onAddAlert: (k: ValueMarketKey) => void;
+}) {
+  const res = useFixtureValueBreakdown(fixtureId, marketKey);
+  if (!res) return null;
+  return (
+    <div className="fixed inset-0 z-[80] flex items-end justify-center bg-black/70 p-0 backdrop-blur-sm sm:items-center sm:p-6" onClick={onClose}>
+      <div
+        className="max-h-[88vh] w-full max-w-lg overflow-y-auto rounded-t-[1.4rem] border border-white/12 bg-[#130321] shadow-[0_-20px_60px_-20px_rgba(0,0,0,0.9)] sm:rounded-[1.4rem]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+        {res.ok === false ? (
+          <div className="p-6 text-sm text-white/60">{res.error.message}</div>
+        ) : (() => {
+          const b = res.data;
+          const dots = (games: typeof b.recentForm.home) => games.slice(0, 5).map((g, i) => (
+            <span key={i} className={`grid h-4 w-4 place-items-center rounded-[4px] text-[9px] font-black ${g.res === 'W' ? 'bg-emerald-500/30 text-emerald-200' : g.res === 'L' ? 'bg-rose-500/30 text-rose-200' : 'bg-white/12 text-white/55'}`}>{g.res}</span>
+          ));
+          return (
+            <div className="p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[10px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]/70">{b.league} · {b.status === 'scheduled' ? `${b.kickoffLabel} KO` : b.status}</div>
+                  <h3 className="mt-1 font-display text-xl uppercase leading-tight tracking-tight text-white">{b.fixture}</h3>
+                  <div className="mt-1 font-display text-[14px] uppercase tracking-tight text-[#f8e7a1]">{b.market}</div>
+                </div>
+                <button onClick={onClose} className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-white/15 text-white/60 hover:bg-white/[0.06]" aria-label="Close">
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* numbers strip */}
+              <div className="mt-4 grid grid-cols-4 divide-x divide-white/[0.08] overflow-hidden rounded-[12px] border border-white/[0.1] bg-black/25 text-center [font-variant-numeric:tabular-nums]">
+                {[
+                  { l: 'Model', v: `${Math.round(b.modelProbability)}%` },
+                  { l: 'Implied', v: `${Math.round(b.impliedProbability)}%` },
+                  { l: 'Gap', v: `${b.valueGap >= 0 ? '+' : ''}${b.valueGap.toFixed(1)}`, tone: b.valueGap >= 0 ? 'text-emerald-300' : 'text-rose-300' },
+                  { l: 'Odds', v: b.oddsSnapshot?.toFixed(2) ?? '—', tone: 'text-[#f5c542]' },
+                ].map((c) => (
+                  <div key={c.l} className="px-1 py-2.5">
+                    <div className="text-[8.5px] font-black uppercase tracking-[0.14em] text-white/40">{c.l}</div>
+                    <div className={`mt-0.5 font-display text-[18px] leading-none ${c.tone ?? 'text-white'}`}>{c.v}</div>
+                  </div>
+                ))}
+              </div>
+
+              {/* market stats */}
+              <div className="mt-3 rounded-[12px] border border-white/[0.1] bg-black/20 p-3.5 text-[12px] text-white/65">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 [font-variant-numeric:tabular-nums]">
+                  {b.marketStats.hitRate && (
+                    <span className="inline-flex items-center gap-1.5"><TrendingUp className="h-3.5 w-3.5 text-emerald-300" /> Landed <b className="text-emerald-300">{b.marketStats.hitRate.hits}/{b.marketStats.hitRate.total}</b> recent</span>
+                  )}
+                  <span className="inline-flex items-center gap-1.5"><Activity className="h-3.5 w-3.5 text-violet-300" /> {b.marketStats.averages.label}: home <b className="text-white/90">{b.marketStats.averages.home ?? '—'}</b> · away <b className="text-white/90">{b.marketStats.averages.away ?? '—'}</b></span>
+                </div>
+                <div className="mt-2.5 grid grid-cols-2 gap-3">
+                  <div className="flex items-center gap-1.5"><span className="w-10 shrink-0 text-[9px] font-black uppercase tracking-wide text-white/40">Home</span><span className="flex gap-0.5">{dots(b.recentForm.home)}</span></div>
+                  <div className="flex items-center justify-end gap-1.5"><span className="flex gap-0.5">{dots(b.recentForm.away)}</span><span className="w-10 shrink-0 text-right text-[9px] font-black uppercase tracking-wide text-white/40">Away</span></div>
+                </div>
+              </div>
+
+              {/* head to head */}
+              {b.headToHead.length > 0 && (
+                <div className="mt-3 rounded-[12px] border border-white/[0.1] bg-black/20 p-3.5">
+                  <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.16em] text-white/45"><Swords className="h-3.5 w-3.5 text-violet-300" /> Head to head</div>
+                  <div className="space-y-1 text-[11.5px] text-white/60 [font-variant-numeric:tabular-nums]">
+                    {b.headToHead.slice(0, 4).map((h, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <span className="w-16 shrink-0 text-white/35">{h.date}</span>
+                        <span className="min-w-0 flex-1 truncate">{h.home} {h.hg}–{h.ag} {h.away}</span>
+                        {h.corners != null && <span className="shrink-0 text-white/40">{h.corners} crn</span>}
+                        {h.cards != null && <span className="shrink-0 text-white/40">{h.cards} crd</span>}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* the Gaffer's read */}
+              <div className="relative mt-3 overflow-hidden rounded-[12px] border border-white/[0.1] bg-gradient-to-b from-[#171029] to-[#0f0a1e]">
+                <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-fuchsia-400 via-violet-500 to-violet-700" />
+                <p className="py-3 pl-4 pr-3.5 text-[13px] italic leading-relaxed text-white/80">
+                  <span aria-hidden className="mr-1 font-display text-lg leading-none text-violet-300/70">“</span>
+                  {b.gafferVerdict}
+                  <span aria-hidden className="ml-0.5 font-display text-lg leading-none text-violet-300/70">”</span>
+                </p>
+              </div>
+              <p className="mt-2 text-[10.5px] leading-relaxed text-white/40">{b.riskNote}</p>
+
+              <button
+                onClick={() => onAddAlert(marketKey)}
+                className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-fuchsia-500 to-violet-500 px-4 py-3 text-[12px] font-black uppercase tracking-wide text-white shadow-[0_14px_34px_-14px_rgba(139,92,246,1)] transition-transform hover:-translate-y-0.5"
+              >
+                <BellPlus className="h-4 w-4" /> Add this market to email alerts
+              </button>
+            </div>
+          );
+        })()}
+      </div>
+    </div>
+  );
+}
+
+/* ── The board: tabs → cards → table → breakdown ────────────────────────── */
+export function MarketBoard({ summary, onAddAlert }: { summary: HubSummary; onAddAlert: (k: ValueMarketKey) => void }) {
+  const [family, setFamily] = useState<ValueMarketFamily>('goals');
+  const [marketKey, setMarketKey] = useState<ValueMarketKey | null>(null);
+  const [breakdown, setBreakdown] = useState<{ fixtureId: string; marketKey: ValueMarketKey } | null>(null);
+
+  const familyMarkets = useMemo(
+    () => summary.allMarkets.filter((s) => s.family === family),
+    [summary, family],
+  );
+  const activeKey = marketKey && VALUE_MARKETS.find((m) => m.key === marketKey)?.family === family
+    ? marketKey
+    : familyMarkets.find((s) => s.status === 'value')?.marketKey ?? familyMarkets.find((s) => s.status === 'priced')?.marketKey ?? null;
+
+  return (
+    <section id="market-board" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#130321]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <div className="p-5 md:p-7">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-violet-200">
+              <ArrowDownWideNarrow className="h-3.5 w-3.5" /> Today's Markets
+            </span>
+            <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">Browse the value, market by market</h2>
+            <p className="mt-1 max-w-xl text-xs leading-relaxed text-white/55">
+              Some members love goals. Some love corners. Some are card merchants. Fine — I've sorted the lot.
+              Pick a family, pick your exact line, and see every priced fixture ranked by the gap.
+            </p>
+          </div>
+          <div className="text-right text-[11px] text-white/45 [font-variant-numeric:tabular-nums]">
+            <div><b className="text-white/85">{summary.totalFixturesScanned}</b> fixtures scanned</div>
+            <div><b className="text-white/85">{summary.totalMarketsScanned}</b> markets · <b className="text-emerald-300">{summary.totalValueFixtures}</b> value edges</div>
+          </div>
+        </div>
+
+        <div className="mt-4"><MarketFamilyTabs family={family} counts={summary.marketFamilyCounts} onChange={(f) => { setFamily(f); setMarketKey(null); }} /></div>
+
+        <div className="mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+          {familyMarkets.map((s) => (
+            <ValueMarketCard key={s.marketKey} s={s} active={s.marketKey === activeKey} onOpen={() => setMarketKey(s.marketKey)} />
+          ))}
+        </div>
+
+        {activeKey && <MarketFixtureTable marketKey={activeKey} onRowClick={(fixtureId) => setBreakdown({ fixtureId, marketKey: activeKey })} />}
+      </div>
+
+      {breakdown && (
+        <FixtureBreakdownPanel
+          fixtureId={breakdown.fixtureId}
+          marketKey={breakdown.marketKey}
+          onClose={() => setBreakdown(null)}
+          onAddAlert={(k) => { setBreakdown(null); onAddAlert(k); }}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/components/valueboard/SEOValueExplainer.tsx
+++ b/src/components/valueboard/SEOValueExplainer.tsx
@@ -1,0 +1,130 @@
+/**
+ * SEOValueExplainer — the long-form, honest explanation of how the Value Board
+ * works, written for both readers and search engines. Sits beneath the
+ * interactive board. Static by design (structure and copy are fixed; only the
+ * board above is dynamic).
+ */
+export function SEOValueExplainer() {
+  const h2 = 'mt-8 font-display text-xl uppercase tracking-tight text-[#f8e7a1] md:text-2xl';
+  const p = 'mt-3 text-[13.5px] leading-relaxed text-white/65';
+  return (
+    <section className="relative overflow-hidden rounded-[1.6rem] border border-white/10 bg-[#130321]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      <article className="mx-auto max-w-3xl p-5 md:p-9">
+        <h2 className="font-display text-2xl uppercase tracking-tight text-white md:text-3xl">
+          How Our Football Value Board Works
+        </h2>
+        <p className={p}>
+          Every morning, the Footy Oracle engine rebuilds its form tables from the last eight matches of every team on
+          today's card — goals, corners, cards and both-teams-to-score, across every league we cover. The Value Board
+          is the reading of those tables. For each fixture and each exact market line, we calculate a model
+          probability from the recent form, convert the bookmaker's price into an implied probability, and measure the
+          gap between the two. When the form says an outcome lands more often than the price is paying for, that gap
+          is a <strong>football value bet</strong> — and it goes on the board.
+        </p>
+        <p className={p}>
+          That's the whole method, and it's deliberately simple: no black boxes, no "secret algorithms", no tipster
+          hunches dressed up as science. The numbers are shown next to every fixture — model probability, implied
+          probability, the gap in percentage points, and the odds snapshot we measured against — so you can check our
+          working on every single row. If a market has no strong edge today, the board says so plainly.
+        </p>
+
+        <h2 className={h2}>Value Bets Over 2.5 Goals</h2>
+        <p className={p}>
+          The over 2.5 goals market is the most-traded line in football, which makes it efficient — but not perfect.
+          Bookmakers price reputations and league averages; our form tables price the last eight games of the two
+          teams actually playing. When two leaky defences meet two in-form attacks and the price still implies a
+          coin flip, the board flags it. Value bets over 2.5 goals appear on the Goals tab whenever that gap clears
+          our bar, ranked biggest gap first.
+        </p>
+
+        <h2 className={h2}>Under 2.5 Goals Value Bets</h2>
+        <p className={p}>
+          Unders are where casual money rarely looks, and that neglect creates price errors. When both teams have
+          been grinding out low-scoring games — solid defensive shape, few chances conceded, strikers out of form —
+          the under 2.5 goals price can lag well behind the pattern. The board treats unders as first-class markets:
+          the model probability for an under is read from the same form tables, and under 2.5 goals value bets are
+          ranked with exactly the same honesty as the overs.
+        </p>
+
+        <h2 className={h2}>Over 3.5 and 4.5 Goals Markets</h2>
+        <p className={p}>
+          The higher goal lines — over 3.5 goals and over 4.5 goals — are lower-probability, higher-price plays, and
+          they demand more evidence before we'll call them value. A team involved in one 5–1 freak result doesn't
+          qualify; a pair of teams whose combined matches have cleared the line week after week might. The board
+          shows the recent hit rate for the exact line so you can see how often it has actually landed, not just how
+          exciting the price looks.
+        </p>
+
+        <h2 className={h2}>Corners Value Markets: Over and Under 8.5, 9.5, 10.5 and 11.5</h2>
+        <p className={p}>
+          Corner markets are priced with less care than goals — there's simply less money in them, so the prices move
+          slower and the errors last longer. Our tables track total corners per game for every team's last eight,
+          which makes the pattern easy to read: wide, crossing teams stack corners; narrow, patient teams starve
+          them. The board covers over and under lines at 8.5, 9.5, 10.5 and 11.5 corners, and it's regularly where
+          the biggest value gaps on the whole card show up. If you only ever look at one unfashionable market, make
+          it over 9.5 corners value bets — the sharpest edges love a quiet room.
+        </p>
+
+        <h2 className={h2}>Cards Value Markets: Over and Under 3.5, 4.5 and 5.5</h2>
+        <p className={p}>
+          Cards follow fixtures, not form alone: derbies, relegation scraps and teams that foul to break up play all
+          push booking counts up. Our tables track total match cards across each team's recent games, and the board
+          prices over and under lines at 3.5, 4.5 and 5.5 cards. One honest caveat, shown on the board itself: not
+          every league we cover has bookmaker card prices every day. When there's no price, the market shows as
+          unpriced rather than invented — we never fabricate a line to fill a box.
+        </p>
+
+        <h2 className={h2}>Both Teams To Score Value Picks</h2>
+        <p className={p}>
+          Both teams to score is the cleanest expression of a simple question: do both of these teams usually find
+          the net, and do both usually concede? Our BTTS percentage comes straight from the recent-form tables, and
+          the board compares it against both the yes and the no price. Both teams to score value picks tend to
+          cluster around the same profile — two open teams with soft centres — and the fixture breakdown shows you
+          the scoring and conceding pattern behind every flag.
+        </p>
+
+        <h2 className={h2}>Why The Gaffer Does Not Force Picks</h2>
+        <p className={p}>
+          Some days the board is busy; some days it's nearly empty. That's not a bug — it's the entire point. Value
+          exists only when the market has made a mistake, and the market doesn't make mistakes to order. A tipster
+          who posts the same number of picks every day regardless of the card is telling you about his content
+          schedule, not about football. The Gaffer's rule is fixed: when nothing clears the bar, the board says
+          "quiet day" and his card says no bet. A skipped losing bet pays exactly the same as a winner you never
+          had — nothing — and costs you nothing to take.
+        </p>
+
+        <h2 className={h2}>Paid Email Alerts for Football Value Bets</h2>
+        <p className={p}>
+          Members don't need to keep checking the board — the board comes to them. Alert preferences let you choose
+          the Gaffer's daily card only, every value alert, or just the specific markets you personally play: goals
+          lines, corners lines, cards lines or BTTS, each at your exact line. Timing is yours too — the morning scan
+          when the board is rebuilt, a pre-kickoff reminder, or a ping when new value appears during the day. And if
+          you want the honest version of quiet, turn on the quiet-day callback: an email that says "nothing today"
+          is worth more than a forced pick ever will be.
+        </p>
+
+        <h2 className={h2}>What Paid Members Get</h2>
+        <p className={p}>
+          The full board, every market family, every exact line, the ranked fixture tables, the per-fixture
+          breakdowns with recent form and head-to-head, the Gaffer's daily double and treble with his reasoning, and
+          the email alerts — all refreshed every morning from data-led football form tables, all shown with the
+          numbers attached, all logged win or lose on the public record. Disciplined football insight, not a hype
+          machine: we show our working, we show our losses, and we let the edges do the talking over a season.
+        </p>
+      </article>
+    </section>
+  );
+}
+
+/** ResponsibleFooterNote — the small print, said plainly. */
+export function ResponsibleFooterNote() {
+  return (
+    <p className="mx-auto max-w-2xl px-4 text-center text-[11px] leading-relaxed text-white/35">
+      The Value Board measures gaps between recent-form probability and market pricing. It deals in edges, never
+      certainties — no outcome is guaranteed, and losing runs happen to every honest record. Bet only what you can
+      comfortably afford, treat every pick as a lean rather than a lock, and take a break if it stops being fun.
+      18+. Please gamble responsibly.
+    </p>
+  );
+}

--- a/src/components/valueboard/ValueBoardHero.tsx
+++ b/src/components/valueboard/ValueBoardHero.tsx
@@ -1,0 +1,67 @@
+import { BarChart3, Bell, ShieldCheck, Sparkles, Lock } from 'lucide-react';
+
+/** Hero — the Gaffer fronting his data command centre. */
+export function ValueBoardHero({ updatedLabel, quietDay }: { updatedLabel: string; quietDay: boolean }) {
+  const scrollTo = (id: string) => document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  return (
+    <section className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#130321]">
+      <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
+      {/* stadium backdrop + the Gaffer as curator */}
+      <div className="relative">
+        <img
+          src="/images/backgrounds/bg-stadium.jpg"
+          alt=""
+          loading="eager"
+          draggable={false}
+          className="pointer-events-none absolute inset-0 h-full w-full select-none object-cover object-[center_30%] opacity-30"
+        />
+        <div aria-hidden className="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#130321] via-[#130321]/75 to-[#130321]/40" />
+        <img
+          src="/images/gaffer/gaffer-pointing-board.jpg"
+          alt="The Gaffer"
+          loading="eager"
+          draggable={false}
+          className="pointer-events-none absolute right-0 top-0 z-[1] hidden h-full w-auto select-none object-cover object-left [mask-image:linear-gradient(90deg,transparent_0%,#000_30%)] md:block md:max-w-[46%]"
+        />
+
+        <div className="relative z-[2] p-5 md:max-w-[58%] md:p-9">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {[
+              { icon: Lock, text: 'Members Only' },
+              { icon: Sparkles, text: quietDay ? 'Quiet Day — No Forced Picks' : `Updated ${updatedLabel}` },
+              { icon: ShieldCheck, text: 'No Forced Picks' },
+              { icon: BarChart3, text: 'Data-led Football Insights' },
+            ].map((b) => (
+              <span key={b.text} className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/35 bg-black/40 px-2.5 py-1 text-[9.5px] font-black uppercase tracking-[0.14em] text-[#f8e7a1]">
+                <b.icon className="h-3 w-3" /> {b.text}
+              </span>
+            ))}
+          </div>
+
+          <h1 className="mt-4 font-display text-4xl uppercase leading-[0.92] tracking-tight text-white drop-shadow-[0_3px_8px_rgba(0,0,0,0.8)] md:text-6xl">
+            The Gaffer's <span className="bg-gradient-to-r from-[#ffe487] to-[#f5c542] bg-clip-text text-transparent">Value Board</span>
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/70 md:text-[15px]">
+            I scan the goals, corners, cards and both-teams-to-score tables, compare what the form says against what
+            the market's paying, and put the gaps on one board. The table has spoken — I've just made it readable.
+          </p>
+
+          <div className="mt-5 flex flex-col gap-2.5 sm:flex-row">
+            <button
+              onClick={() => scrollTo('market-board')}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] shadow-[0_16px_40px_-16px_rgba(245,197,66,1)] transition-transform hover:-translate-y-0.5"
+            >
+              <BarChart3 className="h-4 w-4" /> View Today's Markets
+            </button>
+            <button
+              onClick={() => scrollTo('value-alerts')}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-6 py-3 text-sm font-black uppercase tracking-wide text-violet-200 transition-colors hover:bg-violet-500/20"
+            >
+              <Bell className="h-4 w-4" /> Set Email Alerts
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useValueBoard.ts
+++ b/src/hooks/useValueBoard.ts
@@ -1,0 +1,124 @@
+/**
+ * Value Board hooks — the components' only door to the data layer.
+ *
+ * Reads are memoised adapters over the committed snapshot (sync, instant);
+ * alert preferences round-trip the real /api/alerts Pages function (KV).
+ * Keeping the hook names endpoint-shaped means the page doesn't change if
+ * these later move behind server functions.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  getValueHubSummary, getValueMarketFamilies, getValueMarketFixtures,
+  getGafferDailyCard, getFixtureValueBreakdown, getLeaguesOn, todayUK,
+  type MarketFixturesQuery, type ValueMarketKey,
+} from '@/lib/valueBoard';
+
+export function useValueHubSummary(date?: string) {
+  return useMemo(() => getValueHubSummary(date ?? todayUK()), [date]);
+}
+export function useValueMarketFamilies() {
+  return useMemo(() => getValueMarketFamilies(), []);
+}
+export function useValueMarketFixtures(q: MarketFixturesQuery) {
+  return useMemo(
+    () => getValueMarketFixtures(q),
+    [q.marketKey, q.date, q.league, q.minConfidence, q.minValueGap],
+  );
+}
+export function useGafferDailyCard(date?: string) {
+  return useMemo(() => getGafferDailyCard(date ?? todayUK()), [date]);
+}
+export function useFixtureValueBreakdown(fixtureId: string | null, marketKey: ValueMarketKey | null) {
+  return useMemo(
+    () => (fixtureId && marketKey ? getFixtureValueBreakdown(fixtureId, marketKey) : null),
+    [fixtureId, marketKey],
+  );
+}
+export function useValueBoardLeagues(date?: string) {
+  return useMemo(() => getLeaguesOn(date ?? todayUK()), [date]);
+}
+
+/* ── Subscriber state ──────────────────────────────────────────────────────
+ * No subscription system exists yet (membership opens 1st August), so the
+ * board runs in launch PREVIEW: fully visible, clearly badged members-only.
+ * Flip PREVIEW_MODE to false at launch to enforce the teaser lock, and swap
+ * the localStorage probe for the real subscription hook when it exists. */
+export type SubscriberState = 'preview' | 'free' | 'paid' | 'expired';
+export const PREVIEW_MODE = true;
+export function useSubscriberState(): SubscriberState {
+  if (PREVIEW_MODE) return 'preview';
+  try {
+    const s = localStorage.getItem('fo_subscriber_state');
+    if (s === 'paid' || s === 'expired') return s;
+  } catch { /* ignore */ }
+  return 'free';
+}
+
+/* ── Realtime (stub) ───────────────────────────────────────────────────────
+ * The board's data is a daily locked snapshot refreshed by the 03:10 cron —
+ * there's no push channel yet. This hook keeps the contract seat warm for a
+ * `value-board-updates` channel once a live backend exists. */
+export function useValueBoardRealtime() {
+  return { connected: false, channel: 'value-board-updates' as const };
+}
+
+/* ── Email alert preferences (real endpoint: /api/alerts, KV-backed) ─────── */
+export interface AlertTiming { morningScan: boolean; preKickoff: boolean; newValueAppears: boolean }
+export interface AlertPreferences {
+  email: string;
+  enabled: boolean;
+  gafferCardOnly: boolean;
+  allValueAlerts: boolean;
+  quietDayCallback: boolean;
+  marketKeys: ValueMarketKey[];
+  timing: AlertTiming;
+}
+export const DEFAULT_ALERT_PREFS: Omit<AlertPreferences, 'email'> = {
+  enabled: true,
+  gafferCardOnly: false,
+  allValueAlerts: false,
+  quietDayCallback: false,
+  marketKeys: [],
+  timing: { morningScan: true, preKickoff: false, newValueAppears: false },
+};
+
+export function useUserValueAlertPreferences(email: string | null) {
+  const [prefs, setPrefs] = useState<AlertPreferences | null>(null);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!email) { setPrefs(null); return; }
+    let dead = false;
+    setLoading(true);
+    fetch(`/api/alerts?email=${encodeURIComponent(email)}`)
+      .then((r) => r.json())
+      .then((j) => { if (!dead && j?.ok && j.data) setPrefs(j.data as AlertPreferences); })
+      .catch(() => {})
+      .finally(() => { if (!dead) setLoading(false); });
+    return () => { dead = true; };
+  }, [email]);
+  return { prefs, loading };
+}
+
+export function useSaveUserValueAlertPreferences() {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const save = async (prefs: AlertPreferences) => {
+    setSaving(true); setError(null);
+    try {
+      const r = await fetch('/api/alerts', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(prefs),
+      });
+      const j = await r.json();
+      if (j?.ok) { setSaved(true); try { localStorage.setItem('fo_alert_email', prefs.email); } catch { /* ignore */ } }
+      else setError(j?.error?.message ?? 'Could not save — try again.');
+    } catch {
+      setError('Network hiccup — try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+  return { save, saving, saved, error, resetSaved: () => setSaved(false) };
+}

--- a/src/lib/valueBoard.ts
+++ b/src/lib/valueBoard.ts
@@ -1,0 +1,467 @@
+/**
+ * THE GAFFER'S VALUE BOARD — data layer.
+ *
+ * The exploratory sibling of the daily card: scans every fixture in the
+ * committed form-table snapshot across the full market grid (goals, corners,
+ * cards, BTTS — overs AND unders), compares model probability against the
+ * bookmaker's implied probability, and surfaces the gaps.
+ *
+ * Endpoint-shaped adapters: every read returns the { ok, data } envelope so
+ * the components stay contract-clean if this layer later moves behind real
+ * server functions. The daily card is NOT computed here — it surfaces the
+ * existing locked selection from gafferSelection (the tipping engine owns it).
+ *
+ * Honesty rules baked in: markets without prices return empty (never faked),
+ * quiet days report as quiet, and nothing here ever invents a fixture.
+ */
+import rawSnapshot from '@/data/formTablesData.json';
+import type { FormFixtureRow } from '@/types/footy';
+import { getValueCandidates, type Leg } from '@/lib/gafferSelection';
+import { gafferReason, type PickSignals } from '@/lib/gafferVoice';
+
+/* ── Types ─────────────────────────────────────────────────────────────── */
+
+export type ValueMarketFamily = 'goals' | 'corners' | 'cards' | 'btts';
+
+export type ValueMarketKey =
+  | 'over_2_5_goals' | 'under_2_5_goals'
+  | 'over_3_5_goals' | 'under_3_5_goals'
+  | 'over_4_5_goals' | 'under_4_5_goals'
+  | 'over_8_5_corners' | 'under_8_5_corners'
+  | 'over_9_5_corners' | 'under_9_5_corners'
+  | 'over_10_5_corners' | 'under_10_5_corners'
+  | 'over_11_5_corners' | 'under_11_5_corners'
+  | 'over_3_5_cards' | 'under_3_5_cards'
+  | 'over_4_5_cards' | 'under_4_5_cards'
+  | 'over_5_5_cards' | 'under_5_5_cards'
+  | 'btts_yes' | 'btts_no';
+
+export type Confidence = 'low' | 'medium' | 'high';
+export type FixtureStatus = 'scheduled' | 'live' | 'finished' | 'stale';
+
+export interface ValueMarketDef {
+  key: ValueMarketKey;
+  family: ValueMarketFamily;
+  label: string;
+  side: 'over' | 'under' | 'yes' | 'no';
+  line: string | null; // '2.5' … — null for BTTS
+}
+
+export type Ok<T> = { ok: true; data: T };
+export type Err = { ok: false; error: { code: string; message: string } };
+export type Envelope<T> = Ok<T> | Err;
+const ok = <T,>(data: T): Ok<T> => ({ ok: true, data });
+
+export interface ValueFixtureRow {
+  id: string;
+  fixture: string;
+  homeTeam: string;
+  awayTeam: string;
+  homeLogo: string | null;
+  awayLogo: string | null;
+  league: string;
+  region: string;
+  kickoff: string;        // ISO (best-effort from UK wall time)
+  kickoffLabel: string;   // 'HH:MM' UK
+  market: string;         // display label
+  marketKey: ValueMarketKey;
+  formScore: number;      // last-8 hit rate for the exact line (%)
+  modelProbability: number;
+  impliedProbability: number;
+  valueGap: number;       // model − implied, percentage points
+  valueScore: number;
+  confidence: Confidence;
+  oddsSnapshot: number | null;
+  status: FixtureStatus;
+  qualifies: boolean;     // clears the value bar (edge + floor odds + floor prob)
+  gafferNote: string;
+}
+
+export interface MarketSummary {
+  marketKey: ValueMarketKey;
+  family: ValueMarketFamily;
+  label: string;
+  fixturesFoundToday: number;   // qualifying value fixtures
+  fixturesPriced: number;       // fixtures with a live price for this market
+  strongestFixture: string | null;
+  averageValueScore: number | null;
+  biggestValueGap: number | null;
+  confidenceRange: string | null; // e.g. 'medium – high'
+  status: 'value' | 'priced' | 'unpriced';
+}
+
+export interface HubSummary {
+  date: string;
+  updatedAt: string;
+  quietDay: boolean;
+  totalFixturesScanned: number;
+  totalMarketsScanned: number;
+  totalValueFixtures: number;
+  marketFamilyCounts: Record<ValueMarketFamily, number>;
+  topMarkets: MarketSummary[];
+  allMarkets: MarketSummary[];
+}
+
+export interface DailyCardSelection {
+  fixtureId: string;
+  fixture: string;
+  league: string;
+  kickoff: string;
+  kickoffLabel: string;
+  marketKey: ValueMarketKey | null;
+  marketLabel: string;
+  modelProbability: number;
+  impliedProbability: number;
+  valueGap: number;
+  confidence: Confidence;
+  oddsSnapshot: number | null;
+  gafferVerdict: string;
+}
+
+export interface GafferDailyCardData {
+  date: string;
+  updatedAt: string;
+  quietDay: boolean;
+  quietDayMessage: string;
+  double: { available: boolean; selections: DailyCardSelection[] };
+  treble: { available: boolean; selections: DailyCardSelection[] };
+  riskNote: string;
+}
+
+export interface FixtureBreakdown extends Omit<ValueFixtureRow, 'gafferNote'> {
+  family: ValueMarketFamily;
+  updatedAt: string;
+  recentForm: { home: FormGameLite[]; away: FormGameLite[] };
+  marketStats: MarketStats;
+  headToHead: { date: string; home: string; away: string; hg: number; ag: number; corners?: number; cards?: number }[];
+  gafferVerdict: string;
+  riskNote: string;
+}
+
+export type FormGameLite = { date: string; opp: string; ha: string; gf: number; ga: number; res: string; corners?: number; cards?: number; btts?: boolean };
+export interface MarketStats {
+  hitRate: { hits: number; total: number } | null; // exact line, last-8 both teams
+  averages: { label: string; home: number | null; away: number | null; combined: number | null };
+  series: number[]; // per-game metric across recent games (chronological-ish)
+}
+
+/* ── Market definitions (fixed by contract — the ONLY hard-coded part) ──── */
+
+const G = (line: string, side: 'over' | 'under'): ValueMarketDef => ({
+  key: `${side}_${line.replace('.', '_')}_goals` as ValueMarketKey,
+  family: 'goals', side, line, label: `${side === 'over' ? 'Over' : 'Under'} ${line} Goals`,
+});
+const C = (line: string, side: 'over' | 'under'): ValueMarketDef => ({
+  key: `${side}_${line.replace('.', '_')}_corners` as ValueMarketKey,
+  family: 'corners', side, line, label: `${side === 'over' ? 'Over' : 'Under'} ${line} Corners`,
+});
+const K = (line: string, side: 'over' | 'under'): ValueMarketDef => ({
+  key: `${side}_${line.replace('.', '_')}_cards` as ValueMarketKey,
+  family: 'cards', side, line, label: `${side === 'over' ? 'Over' : 'Under'} ${line} Cards`,
+});
+
+export const VALUE_MARKETS: ValueMarketDef[] = [
+  G('2.5', 'over'), G('2.5', 'under'), G('3.5', 'over'), G('3.5', 'under'), G('4.5', 'over'), G('4.5', 'under'),
+  C('8.5', 'over'), C('8.5', 'under'), C('9.5', 'over'), C('9.5', 'under'),
+  C('10.5', 'over'), C('10.5', 'under'), C('11.5', 'over'), C('11.5', 'under'),
+  K('3.5', 'over'), K('3.5', 'under'), K('4.5', 'over'), K('4.5', 'under'), K('5.5', 'over'), K('5.5', 'under'),
+  { key: 'btts_yes', family: 'btts', side: 'yes', line: null, label: 'Both Teams To Score — Yes' },
+  { key: 'btts_no', family: 'btts', side: 'no', line: null, label: 'Both Teams To Score — No' },
+];
+
+export const MARKET_BY_KEY: Record<string, ValueMarketDef> =
+  Object.fromEntries(VALUE_MARKETS.map((m) => [m.key, m]));
+
+export const FAMILIES: { family: ValueMarketFamily; label: string; blurb: string }[] = [
+  { family: 'goals', label: 'Goals', blurb: 'Overs and unders from 2.5 to 4.5 — the bread and butter.' },
+  { family: 'corners', label: 'Corners', blurb: 'Lines from 8.5 to 11.5 — where the sharpest edges hide.' },
+  { family: 'cards', label: 'Cards', blurb: 'Bookings from 3.5 to 5.5 — for the card merchants.' },
+  { family: 'btts', label: 'BTTS', blurb: 'Both teams to score, yes or no — simple and honest.' },
+];
+
+/* ── Value bar (what counts as a value fixture) ────────────────────────── */
+const MIN_ODDS = 1.3;
+const MIN_MODEL = 55;
+const MIN_GAP = 4; // percentage points of model-vs-implied
+
+const confidenceOf = (model: number): Confidence => (model >= 72 ? 'high' : model >= 58 ? 'medium' : 'low');
+
+/* ── Snapshot access ───────────────────────────────────────────────────── */
+type Snap = { fixtures: FormFixtureRow[] };
+const SNAP = (rawSnapshot as unknown as Snap).fixtures ?? [];
+
+export const todayUK = (): string => new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+
+// Best-effort ISO for a UK wall-clock kickoff (summer leagues → BST +01:00;
+// good enough for display math, and the label is always the UK string anyway).
+const ukWallToISO = (date: string, time: string): string => {
+  const t = /^\d{2}:\d{2}$/.test(time) ? time : '12:00';
+  return `${date}T${t}:00+01:00`;
+};
+
+const statusOf = (date: string, time: string): FixtureStatus => {
+  const ko = new Date(ukWallToISO(date, time)).getTime();
+  if (!Number.isFinite(ko)) return 'scheduled';
+  const now = Date.now();
+  if (now < ko) return 'scheduled';
+  if (now < ko + 130 * 60_000) return 'live';
+  return 'finished';
+};
+
+/* ── Model probability + odds per fixture + market ─────────────────────── */
+type AnyFix = FormFixtureRow & Record<string, unknown>;
+const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+const lineVal = (o: unknown, line: string): number | null =>
+  o && typeof o === 'object' ? num((o as Record<string, unknown>)[line]) : null;
+
+function modelPct(f: AnyFix, m: ValueMarketDef): number | null {
+  if (m.family === 'btts') {
+    const yes = num(f.btts_pct);
+    return yes == null ? null : m.side === 'yes' ? yes : Math.round((100 - yes) * 10) / 10;
+  }
+  const over = lineVal(f[`${m.family}_over`], m.line!);
+  if (over == null) return null;
+  return m.side === 'over' ? over : Math.round((100 - over) * 10) / 10;
+}
+
+function marketOdds(f: AnyFix, m: ValueMarketDef): number | null {
+  if (m.family === 'btts') return num(m.side === 'yes' ? f.btts_odds : f.btts_no_odds);
+  const bank = m.side === 'over' ? f[`${m.family}_odds`] : f[`${m.family}_under_odds`];
+  return lineVal(bank, m.line!);
+}
+
+/* ── The Gaffer's short table note (deterministic, seeded, never repeats
+ *    within a market thanks to per-fixture seeds) ─────────────────────── */
+const NOTE_TEMPLATES = [
+  'Form has this landing {model}% of the time and the price implies {implied}% — that gap is the whole story.',
+  'The book is paying like this is a {implied}% shot; the last eight games say {model}%. I know which I trust.',
+  'A {model}% pattern priced at {implied}% — quiet little edge, exactly the kind that adds up.',
+  'Model {model}%, market {implied}% — the difference is our margin, not our imagination.',
+  '{model}% on the form read against {implied}% in the price — worth a proper look.',
+  'The numbers have been saying {model}% for weeks; the odds still say {implied}%. Gaps like that pay the bills.',
+];
+const seedHash = (s: string): number => {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+};
+const shortNote = (id: string, key: string, model: number, implied: number): string =>
+  NOTE_TEMPLATES[seedHash(`${id}|${key}`) % NOTE_TEMPLATES.length]
+    .replace('{model}', String(Math.round(model)))
+    .replace('{implied}', String(Math.round(implied)));
+
+const RISK_NOTES = [
+  'This one has edge, but don’t treat it like a certainty — stake what you can shrug off.',
+  'An edge is a lean, not a lock. Sensible stakes keep us in the game all season.',
+  'The percentages are on our side; the ball doesn’t always read the percentages. Bet tidy.',
+  'Good process beats one good result — back it sensibly and let the maths work.',
+];
+const riskNote = (seed: string): string => RISK_NOTES[seedHash(seed) % RISK_NOTES.length];
+
+/* ── Row builder ───────────────────────────────────────────────────────── */
+function buildRow(f: AnyFix, m: ValueMarketDef): ValueFixtureRow | null {
+  const model = modelPct(f, m);
+  const odds = marketOdds(f, m);
+  if (model == null || odds == null || odds <= 1) return null;
+  const implied = Math.round((100 / odds) * 10) / 10;
+  const gap = Math.round((model - implied) * 10) / 10;
+  const fixture = `${f.home.name} v ${f.away.name}`;
+  return {
+    id: f.id,
+    fixture,
+    homeTeam: f.home.name, awayTeam: f.away.name,
+    homeLogo: f.home.logo ?? null, awayLogo: f.away.logo ?? null,
+    league: f.league, region: (f as { region?: string }).region ?? '',
+    kickoff: ukWallToISO(f.date, f.time), kickoffLabel: f.time,
+    market: m.label, marketKey: m.key,
+    formScore: model, modelProbability: model, impliedProbability: implied,
+    valueGap: gap, valueScore: gap,
+    confidence: confidenceOf(model),
+    oddsSnapshot: odds,
+    status: statusOf(f.date, f.time),
+    qualifies: odds >= MIN_ODDS && model >= MIN_MODEL && gap >= MIN_GAP,
+    gafferNote: shortNote(f.id, m.key, model, implied),
+  };
+}
+
+const fixturesOn = (date: string): AnyFix[] => SNAP.filter((f) => f.date === date) as AnyFix[];
+
+/* ── Adapters (endpoint-shaped) ────────────────────────────────────────── */
+
+export function getValueMarketFamilies(): Envelope<{ families: typeof FAMILIES; markets: ValueMarketDef[] }> {
+  return ok({ families: FAMILIES, markets: VALUE_MARKETS });
+}
+
+function marketSummary(date: string, m: ValueMarketDef): MarketSummary {
+  const rows = fixturesOn(date).map((f) => buildRow(f, m)).filter(Boolean) as ValueFixtureRow[];
+  const value = rows.filter((r) => r.qualifies).sort((a, b) => b.valueGap - a.valueGap);
+  const confs = [...new Set(value.map((v) => v.confidence))];
+  const order: Confidence[] = ['low', 'medium', 'high'];
+  const sorted = order.filter((c) => confs.includes(c));
+  return {
+    marketKey: m.key, family: m.family, label: m.label,
+    fixturesFoundToday: value.length,
+    fixturesPriced: rows.length,
+    strongestFixture: value[0]?.fixture ?? null,
+    averageValueScore: value.length ? Math.round((value.reduce((p, v) => p + v.valueScore, 0) / value.length) * 10) / 10 : null,
+    biggestValueGap: value[0]?.valueGap ?? null,
+    confidenceRange: sorted.length ? (sorted.length > 1 ? `${sorted[0]} – ${sorted[sorted.length - 1]}` : sorted[0]) : null,
+    status: value.length ? 'value' : rows.length ? 'priced' : 'unpriced',
+  };
+}
+
+export function getValueHubSummary(date = todayUK()): Envelope<HubSummary> {
+  const all = VALUE_MARKETS.map((m) => marketSummary(date, m));
+  const counts: Record<ValueMarketFamily, number> = { goals: 0, corners: 0, cards: 0, btts: 0 };
+  for (const s of all) counts[s.family] += s.fixturesFoundToday;
+  const totalValue = all.reduce((p, s) => p + s.fixturesFoundToday, 0);
+  return ok({
+    date,
+    updatedAt: new Date().toISOString(),
+    quietDay: totalValue === 0,
+    totalFixturesScanned: fixturesOn(date).length,
+    totalMarketsScanned: VALUE_MARKETS.length,
+    totalValueFixtures: totalValue,
+    marketFamilyCounts: counts,
+    topMarkets: [...all].filter((s) => s.fixturesFoundToday > 0).sort((a, b) => (b.biggestValueGap ?? 0) - (a.biggestValueGap ?? 0)).slice(0, 6),
+    allMarkets: all,
+  });
+}
+
+export interface MarketFixturesQuery {
+  date?: string;
+  marketKey: ValueMarketKey;
+  league?: string;
+  minConfidence?: Confidence;
+  minValueGap?: number;
+}
+export function getValueMarketFixtures(q: MarketFixturesQuery): Envelope<{
+  date: string; marketKey: ValueMarketKey; marketLabel: string; family: ValueMarketFamily;
+  updatedAt: string; fixtures: ValueFixtureRow[]; emptyStateMessage: string;
+}> {
+  const m = MARKET_BY_KEY[q.marketKey];
+  if (!m) return { ok: false, error: { code: 'unknown_market', message: `Unknown market key: ${q.marketKey}` } };
+  const date = q.date ?? todayUK();
+  const order: Confidence[] = ['low', 'medium', 'high'];
+  let rows = (fixturesOn(date).map((f) => buildRow(f, m)).filter(Boolean) as ValueFixtureRow[])
+    .sort((a, b) => b.valueGap - a.valueGap);
+  if (q.league && q.league !== 'all') rows = rows.filter((r) => r.league === q.league);
+  if (q.minConfidence) rows = rows.filter((r) => order.indexOf(r.confidence) >= order.indexOf(q.minConfidence!));
+  if (q.minValueGap != null) rows = rows.filter((r) => r.valueGap >= q.minValueGap!);
+  return ok({
+    date, marketKey: m.key, marketLabel: m.label, family: m.family,
+    updatedAt: new Date().toISOString(), fixtures: rows,
+    emptyStateMessage: 'No strong edge found for this market today.',
+  });
+}
+
+/* ── The Gaffer's Daily Card — SURFACES the locked tipping selection ────
+ * The tipping engine (gafferSelection) locks the double + treble every
+ * morning. This page never re-picks; it presents that same card. */
+const legMarketKey = (leg: Leg): ValueMarketKey | null => {
+  const line = /(\d+\.\d+)/.exec(leg.selection)?.[1]?.replace('.', '_');
+  if (leg.market === 'Goals' && line) return `over_${line}_goals` as ValueMarketKey;
+  if (leg.market === 'Corners' && line) return `over_${line}_corners` as ValueMarketKey;
+  if (leg.market === 'BTTS') return 'btts_yes';
+  return null;
+};
+
+function legToSelection(leg: Leg): DailyCardSelection {
+  const implied = leg.odds > 1 ? Math.round((100 / leg.odds) * 10) / 10 : 0;
+  const date = todayUK();
+  return {
+    fixtureId: leg.fixtureId,
+    fixture: `${leg.home.name} v ${leg.away.name}`,
+    league: [leg.region, leg.league].filter(Boolean).join(' · '),
+    kickoff: ukWallToISO(date, leg.time), kickoffLabel: leg.time,
+    marketKey: legMarketKey(leg), marketLabel: leg.selection,
+    modelProbability: leg.prob, impliedProbability: implied,
+    valueGap: Math.round((leg.prob - implied) * 10) / 10,
+    confidence: confidenceOf(leg.prob),
+    oddsSnapshot: leg.odds,
+    gafferVerdict: leg.placeholderReason,
+  };
+}
+
+export function getGafferDailyCard(date = todayUK()): Envelope<GafferDailyCardData> {
+  const candidates = (() => {
+    const best = new Map<string, Leg>();
+    for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l);
+    return [...best.values()];
+  })();
+  const doubleLegs = candidates.slice(0, 2);
+  const trebleLegs = candidates.slice(2, 5);
+  const doubleOk = doubleLegs.length === 2;
+  const trebleOk = trebleLegs.length === 3;
+  return ok({
+    date,
+    updatedAt: new Date().toISOString(),
+    quietDay: !doubleOk,
+    quietDayMessage: 'The Gaffer is keeping his powder dry today — no forced picks. Discipline is part of the game.',
+    double: { available: doubleOk, selections: doubleOk ? doubleLegs.map(legToSelection) : [] },
+    treble: { available: trebleOk, selections: trebleOk ? trebleLegs.map(legToSelection) : [] },
+    riskNote: riskNote(date),
+  });
+}
+
+/* ── Fixture breakdown ─────────────────────────────────────────────────── */
+const familyMetric = (g: FormGameLite, fam: ValueMarketFamily): number =>
+  fam === 'goals' ? (g.gf ?? 0) + (g.ga ?? 0)
+  : fam === 'corners' ? g.corners ?? 0
+  : fam === 'cards' ? g.cards ?? 0
+  : g.btts ? 1 : 0;
+
+const gameHits = (g: FormGameLite, m: ValueMarketDef): boolean => {
+  if (m.family === 'btts') return m.side === 'yes' ? !!g.btts : !g.btts;
+  const v = familyMetric(g, m.family);
+  const line = Number(m.line);
+  return m.side === 'over' ? v > line : v < line;
+};
+
+export function getFixtureValueBreakdown(fixtureId: string, marketKey: ValueMarketKey): Envelope<FixtureBreakdown> {
+  const m = MARKET_BY_KEY[marketKey];
+  const f = SNAP.find((x) => x.id === fixtureId) as AnyFix | undefined;
+  if (!m || !f) return { ok: false, error: { code: 'not_found', message: 'Fixture or market not found.' } };
+  const row = buildRow(f, m);
+  if (!row) return { ok: false, error: { code: 'unpriced', message: 'No live price for this market on this fixture.' } };
+
+  const homeGames = ((f.home_form as FormGameLite[] | undefined) ?? []).slice(0, 8);
+  const awayGames = ((f.away_form as FormGameLite[] | undefined) ?? []).slice(0, 8);
+  const both = [...homeGames, ...awayGames];
+  const hits = both.length ? { hits: both.filter((g) => gameHits(g, m)).length, total: both.length } : null;
+
+  const avg = (games: FormGameLite[]): number | null =>
+    games.length ? Math.round((games.reduce((p, g) => p + familyMetric(g, m.family), 0) / games.length) * 10) / 10 : null;
+  const famLabel = m.family === 'goals' ? 'goals/game' : m.family === 'corners' ? 'corners/game' : m.family === 'cards' ? 'cards/game' : 'BTTS rate';
+  const homeAvg = avg(homeGames), awayAvg = avg(awayGames);
+  const combined = homeAvg != null && awayAvg != null ? Math.round(((homeAvg + awayAvg) / 2) * 10) / 10 : homeAvg ?? awayAvg;
+
+  const signals: PickSignals = {
+    team: f.home.name, opp: f.away.name,
+    market: m.family === 'goals' ? 'Goals' : m.family === 'corners' ? 'Corners' : m.family === 'cards' ? 'Cards' : 'BTTS',
+    selection: m.label, mark: m.line ?? undefined,
+    odds: row.oddsSnapshot ?? 0, pct: row.modelProbability, edge: row.valueGap,
+    tier: row.confidence === 'high' ? 'strong' : 'value',
+  };
+
+  const { gafferNote: _drop, ...rest } = row;
+  return ok({
+    ...rest,
+    family: m.family,
+    updatedAt: new Date().toISOString(),
+    recentForm: { home: homeGames, away: awayGames },
+    marketStats: {
+      hitRate: hits,
+      averages: { label: famLabel, home: homeAvg, away: awayAvg, combined },
+      series: both.map((g) => familyMetric(g, m.family)),
+    },
+    headToHead: ((f.h2h as FixtureBreakdown['headToHead'] | undefined) ?? []).slice(0, 6),
+    gafferVerdict: gafferReason(signals, `${fixtureId}|${marketKey}|breakdown`),
+    riskNote: riskNote(`${fixtureId}|${marketKey}`),
+  });
+}
+
+/** Leagues present on a date — for table filters. */
+export function getLeaguesOn(date = todayUK()): string[] {
+  return [...new Set(fixturesOn(date).map((f) => f.league))].sort();
+}

--- a/src/pages/ValueBoard.tsx
+++ b/src/pages/ValueBoard.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Lock, Sparkles, ArrowRight } from 'lucide-react';
+import { HomepageNav } from '@/components/homepage/HomepageNav';
+import { ValueBoardHero } from '@/components/valueboard/ValueBoardHero';
+import { GafferDailyCardSection } from '@/components/valueboard/GafferDailyCardSection';
+import { MarketBoard } from '@/components/valueboard/MarketBoard';
+import { EmailAlertPreferences } from '@/components/valueboard/EmailAlertPreferences';
+import { SEOValueExplainer, ResponsibleFooterNote } from '@/components/valueboard/SEOValueExplainer';
+import { useValueHubSummary, useGafferDailyCard, useSubscriberState, useValueBoardRealtime } from '@/hooks/useValueBoard';
+import type { ValueMarketKey } from '@/lib/valueBoard';
+
+const SEO_TITLE = "The Gaffer's Value Board | Football Value Bets Today";
+const SEO_DESC =
+  'Explore today’s football value bets across goals, corners, cards and both teams to score markets. ' +
+  'The Gaffer scans the Footy Oracle form tables and surfaces the strongest data-led football match insights for members.';
+
+/** SubscriberLockPanel — access states around the gated board content. */
+function SubscriberLockPanel({ state, children }: { state: ReturnType<typeof useSubscriberState>; children: React.ReactNode }) {
+  if (state === 'paid') return <>{children}</>;
+
+  if (state === 'preview') {
+    return (
+      <>
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-[#f5c542]/35 bg-[#f5c542]/[0.07] px-4 py-3">
+          <span className="inline-flex items-center gap-2 text-[12px] font-black uppercase tracking-wide text-[#f8e7a1]">
+            <Sparkles className="h-4 w-4" /> Launch preview — free to explore until 1st August, then members only
+          </span>
+          <Link to="/#join" className="inline-flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wide text-white/80 transition-colors hover:text-white">
+            Join the club · £8.99/month <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+        {children}
+      </>
+    );
+  }
+
+  // free / expired: teaser — the real board, blurred, behind an honest lock.
+  return (
+    <div className="relative overflow-hidden rounded-[1.6rem]">
+      <div aria-hidden className="pointer-events-none select-none blur-md [mask-image:linear-gradient(180deg,#000_0%,transparent_92%)]">
+        {children}
+      </div>
+      <div className="absolute inset-0 z-10 flex items-center justify-center p-6">
+        <div className="w-full max-w-md rounded-[1.4rem] border border-[#f5c542]/35 bg-[#130321]/95 p-6 text-center shadow-[0_30px_80px_-30px_rgba(0,0,0,0.95)]">
+          <span className="mx-auto grid h-12 w-12 place-items-center rounded-2xl border border-[#f5c542]/35 bg-[#f5c542]/10 text-[#f5c542]"><Lock className="h-6 w-6" /></span>
+          <h3 className="mt-3 font-display text-2xl uppercase tracking-tight text-white">
+            {state === 'expired' ? 'Your membership has lapsed' : 'The full board is for members'}
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-white/60">
+            {state === 'expired'
+              ? 'Pick up where you left off — the board, the daily card and your email alerts are all waiting.'
+              : 'The Gaffer scans every market on every fixture, every morning. Members get the whole board, the daily card, the breakdowns and the alerts.'}
+          </p>
+          <Link
+            to="/#join"
+            className="mt-4 inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-300 to-amber-500 px-6 py-3 text-sm font-black uppercase tracking-wide text-[#16051f] shadow-[0_16px_40px_-16px_rgba(245,197,66,1)] transition-transform hover:-translate-y-0.5"
+          >
+            {state === 'expired' ? 'Regain access' : 'Join The Club'} <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** ValueBoardPage — the Match Insights Hub: hero → daily card → market board
+ *  → alerts → SEO explainer, all inside the subscriber access wrapper. */
+export default function ValueBoard() {
+  const subscriberState = useSubscriberState();
+  const summary = useValueHubSummary();
+  const card = useGafferDailyCard();
+  useValueBoardRealtime(); // contract seat for value-board-updates (no push channel yet)
+  const [pendingMarket, setPendingMarket] = useState<ValueMarketKey | null>(null);
+
+  // SEO title + meta description (restored on unmount).
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = SEO_TITLE;
+    let meta = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const created = !meta;
+    if (!meta) { meta = document.createElement('meta'); meta.name = 'description'; document.head.appendChild(meta); }
+    const prevDesc = meta.content;
+    meta.content = SEO_DESC;
+    return () => { document.title = prevTitle; if (created) meta!.remove(); else meta!.content = prevDesc; };
+  }, []);
+
+  const goToAlerts = (k: ValueMarketKey | null) => {
+    setPendingMarket(k);
+    document.getElementById('value-alerts')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const updatedLabel = new Date().toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#0c0217] text-white">
+      <div className="pointer-events-none fixed inset-0 opacity-60 [background:radial-gradient(circle_at_15%_-5%,rgba(88,28,135,0.3),transparent_45%),radial-gradient(circle_at_85%_8%,rgba(245,197,66,0.07),transparent_40%)]" />
+      <HomepageNav />
+
+      <main className="relative mx-auto max-w-5xl space-y-4 px-3 pb-14 pt-4 md:space-y-5 md:px-6">
+        {!summary.ok || !card.ok ? (
+          <div className="rounded-[1.6rem] border border-white/10 bg-[#130321] p-8 text-center text-white/60">
+            The board couldn't load its data — refresh to try again.
+          </div>
+        ) : (
+          <>
+            <ValueBoardHero updatedLabel={updatedLabel} quietDay={summary.data.quietDay} />
+            <SubscriberLockPanel state={subscriberState}>
+              <div className="space-y-4 md:space-y-5">
+                <GafferDailyCardSection card={card.data} onEmailCard={() => goToAlerts(null)} />
+                <MarketBoard summary={summary.data} onAddAlert={(k) => goToAlerts(k)} />
+                <EmailAlertPreferences pendingMarket={pendingMarket} onConsumedPending={() => setPendingMarket(null)} />
+              </div>
+            </SubscriberLockPanel>
+            <SEOValueExplainer />
+            <ResponsibleFooterNote />
+          </>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
The Footy Oracle Match Insights Hub — the exploratory sibling of the daily card. Scans every fixture on today's card across the full corrected market grid (goals 2.5/3.5/4.5, corners 8.5–11.5, cards 3.5–5.5, BTTS — overs AND unders), compares form-model probability against bookmaker implied probability, and boards the gaps.

**Data layer** (`src/lib/valueBoard.ts`) — fixed `ValueMarketFamily` / `ValueMarketKey` unions (22 markets, exactly per spec), endpoint-shaped `{ ok, data }` adapters over the daily snapshot: hub summary, market fixtures (filters + ranking), fixture breakdown, and the daily card — which **surfaces the tipping engine's locked double/treble** (this page never re-picks). Nothing hard-coded: no fixtures, odds, values or selections.

**Page** (`/value-board`, alias `/match-insights`, nav "Value Board") —
- `ValueBoardHero` with the four badges and both CTAs
- `GafferDailyCard` with honest quiet-day and "no padding the treble" states
- `MarketFamilyTabs` → exact-line `ValueMarketCard`s (three honest states: value / no edge today / unpriced in today's leagues) → `MarketFixtureTable` (ranked by value gap, league + confidence filters, three sorts) → `FixtureBreakdownPanel` modal (model/implied/gap/odds strip, recent hit rate, home/away averages, form dots, H2H, voice-engine Gaffer verdict, risk note, add-to-alerts CTA)
- `EmailAlertPreferences` — Gaffer card only / all value / exact market toggles grouped by family / quiet-day callback, timing options, saved to the new KV-backed **`/api/alerts`** Pages function (round-trip verified in production; Telegram ping on new signups)
- `SubscriberLockPanel` with all states; ships in launch **preview mode** (free-until-1st-August banner). One flag flips to the blurred teaser lock when subscriptions exist
- 1,300-word `SEOValueExplainer` with the specified H2 structure, responsible footer note, SEO title + meta description

Supabase edge functions were specced, but data here ships via the committed daily snapshot + Cloudflare Pages functions (the live stack); adapters keep the same envelope so a server move later doesn't touch components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Value Board experience with market browsing, fixture breakdowns, daily card view, and email alert preferences.
  * Added new routes and homepage navigation for easier access to the Value Board and insights pages.
  * Introduced shareable alert settings, including timing, market selection, and notification options.

* **Bug Fixes**
  * Improved loading and saved-state handling for alert preferences.
  * Added clearer locked/preview messaging based on membership status.

* **Documentation**
  * Added on-page explanatory and responsibility notes for the Value Board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->