### PR TITLE
Value Board: switch off all paid options until 1st August

### DIFF
--- a/src/components/valueboard/EmailAlertPreferences.tsx
+++ b/src/components/valueboard/EmailAlertPreferences.tsx
@@ -134,7 +134,7 @@ export function EmailAlertPreferences({ pendingMarket, onConsumedPending }: {
             </div>
           )}
           {error && <div className="text-sm font-bold text-rose-300">{error}</div>}
-          <p className="text-[10.5px] text-white/35">Alerts start with the membership on 1st August — preferences saved now carry over. No spam, ever.</p>
+          <p className="text-[10.5px] text-white/35">Alerts go live 1st August — preferences saved now carry over. No spam, ever.</p>
         </form>
       </div>
     </section>

--- a/src/components/valueboard/ValueBoardHero.tsx
+++ b/src/components/valueboard/ValueBoardHero.tsx
@@ -27,8 +27,8 @@ export function ValueBoardHero({ updatedLabel, quietDay }: { updatedLabel: strin
         <div className="relative z-[2] p-5 md:max-w-[58%] md:p-9">
           <div className="flex flex-wrap items-center gap-1.5">
             {[
-              { icon: Lock, text: 'Members Only' },
-              { icon: Sparkles, text: quietDay ? 'Quiet Day — No Forced Picks' : `Updated ${updatedLabel}` },
+              { icon: Sparkles, text: 'Free Preview' },
+              { icon: Lock, text: quietDay ? 'Quiet Day — No Forced Picks' : `Updated ${updatedLabel}` },
               { icon: ShieldCheck, text: 'No Forced Picks' },
               { icon: BarChart3, text: 'Data-led Football Insights' },
             ].map((b) => (

--- a/src/pages/ValueBoard.tsx
+++ b/src/pages/ValueBoard.tsx
@@ -19,21 +19,10 @@ const SEO_DESC =
 function SubscriberLockPanel({ state, children }: { state: ReturnType<typeof useSubscriberState>; children: React.ReactNode }) {
   if (state === 'paid') return <>{children}</>;
 
-  if (state === 'preview') {
-    return (
-      <>
-        <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-[#f5c542]/35 bg-[#f5c542]/[0.07] px-4 py-3">
-          <span className="inline-flex items-center gap-2 text-[12px] font-black uppercase tracking-wide text-[#f8e7a1]">
-            <Sparkles className="h-4 w-4" /> Launch preview — free to explore until 1st August, then members only
-          </span>
-          <Link to="/#join" className="inline-flex items-center gap-1.5 text-[11px] font-black uppercase tracking-wide text-white/80 transition-colors hover:text-white">
-            Join the club · £8.99/month <ArrowRight className="h-3.5 w-3.5" />
-          </Link>
-        </div>
-        {children}
-      </>
-    );
-  }
+  // Preview (pre-launch): no paid gating, no membership CTAs — the whole board
+  // is simply open. The teaser/lock/expired states below stay built and ready
+  // to switch on come 1st August.
+  if (state === 'preview') return <>{children}</>;
 
   // free / expired: teaser — the real board, blurred, behind an honest lock.
   return (


### PR DESCRIPTION
- Hero badge "Members Only" → "Free Preview"
- The launch-preview banner with its "Join the club · £8.99/month" CTA is removed entirely — preview state now renders the open board with no gating chrome
- Alerts microcopy drops the membership wording ("Alerts go live 1st August — preferences saved now carry over")

The teaser lock, expired and paid states stay built and ready to switch on at launch (single flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_