### PR TITLE
Value Board: speak human, show football

### DIFF
--- a/src/components/valueboard/GafferDailyCardSection.tsx
+++ b/src/components/valueboard/GafferDailyCardSection.tsx
@@ -1,30 +1,78 @@
-import { Star, Layers, Bell, Clock, ShieldAlert } from 'lucide-react';
+import { Star, Layers, Bell, Clock, Trophy, ShieldAlert } from 'lucide-react';
+import { TeamAvatar } from '@/components/TeamAvatar';
 import type { GafferDailyCardData, DailyCardSelection } from '@/lib/valueBoard';
 
-/** One selection row inside the daily card — solid panel, gold accent bar. */
-function SelectionRow({ s }: { s: DailyCardSelection }) {
+/** One selection — the homepage leg-card language: crests, gold odds,
+ *  confidence bar, emerald edge chip, one short line from the Gaffer. */
+function SelectionCard({ s }: { s: DailyCardSelection }) {
   return (
-    <div className="relative overflow-hidden rounded-[13px] border border-white/[0.1] bg-gradient-to-b from-[#1c1338] to-[#110a26]">
-      <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[#ffe487] to-[#b8860b]" />
-      <div className="flex items-center justify-between gap-2 border-b border-white/[0.08] py-2 pl-4 pr-3">
-        <span className="min-w-0 truncate text-[13px] font-semibold text-white">{s.fixture}</span>
-        <span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-black text-[#f8e7a1] [font-variant-numeric:tabular-nums]">
-          <Clock className="h-3 w-3 text-[#f5c542]/80" /> {s.kickoffLabel}
-        </span>
+    <div
+      className="relative rounded-[15px] p-px shadow-[0_2px_4px_-1px_rgba(0,0,0,0.7),0_24px_44px_-20px_rgba(0,0,0,0.95)]"
+      style={{ background: 'linear-gradient(160deg,#f5c542 0%,#8b5cf6 48%,#22d3ee 100%)' }}
+    >
+      <div className="relative overflow-hidden rounded-[14px] bg-gradient-to-b from-[#1c1338] to-[#110a26]">
+        <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/45 to-transparent" />
+
+        {/* teams */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 px-3.5 pb-2.5 pt-3">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <TeamAvatar name={s.homeTeam} logoUrl={s.homeLogo} size={36} className="shrink-0 rounded-[10px] bg-black/45 p-1 ring-1 ring-white/12" />
+            <div className="line-clamp-2 min-w-0 text-[13px] font-semibold leading-[1.15] text-white">{s.homeTeam}</div>
+          </div>
+          <span className="shrink-0 font-display text-[11px] uppercase text-white/25">vs</span>
+          <div className="flex min-w-0 flex-row-reverse items-center gap-2.5 text-right">
+            <TeamAvatar name={s.awayTeam} logoUrl={s.awayLogo} size={36} className="shrink-0 rounded-[10px] bg-black/45 p-1 ring-1 ring-white/12" />
+            <div className="line-clamp-2 min-w-0 text-[13px] font-semibold leading-[1.15] text-white">{s.awayTeam}</div>
+          </div>
+        </div>
+
+        {/* league + kickoff */}
+        <div className="flex items-center justify-between gap-2 border-y border-white/[0.1] bg-black/20 px-3.5 py-1.5">
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <Trophy className="h-2.5 w-2.5 shrink-0 text-[#f5c542]/70" />
+            <span className="truncate text-[9px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]/70">{s.league}</span>
+          </span>
+          <span className="inline-flex shrink-0 items-center gap-1 text-[12px] font-black text-[#f8e7a1] [font-variant-numeric:tabular-nums]">
+            <Clock className="h-3 w-3 text-[#f5c542]/80" /> {s.kickoffLabel} <span className="text-[8px] font-black uppercase tracking-[0.18em] text-white/35">KO</span>
+          </span>
+        </div>
+
+        {/* the pick */}
+        <div className="flex items-center justify-between gap-3 bg-gradient-to-r from-emerald-500/[0.14] via-emerald-500/[0.05] to-transparent px-3.5 py-2.5">
+          <div className="min-w-0">
+            <div className="text-[8.5px] font-black uppercase tracking-[0.22em] text-emerald-300/80">The pick</div>
+            <div className="mt-0.5 truncate font-display text-[17px] uppercase leading-none tracking-tight text-white">{s.marketLabel}</div>
+          </div>
+          {s.oddsSnapshot != null && (
+            <div className="flex shrink-0 items-baseline gap-1.5">
+              <span className="font-display text-[26px] leading-none text-[#f5c542] [font-variant-numeric:tabular-nums] drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">{s.oddsSnapshot.toFixed(2)}</span>
+              <span className="text-[8.5px] font-black uppercase tracking-[0.18em] text-white/35">odds</span>
+            </div>
+          )}
+        </div>
+
+        {/* form bar + edge — homepage vocabulary, no jargon */}
+        <div className="border-t border-white/[0.1] px-3.5 pb-3 pt-2.5">
+          <div className="mb-1.5 flex items-baseline justify-between">
+            <span className="text-[8.5px] font-black uppercase tracking-[0.22em] text-white/40">Form says</span>
+            <span className="font-display text-[15px] leading-none text-white [font-variant-numeric:tabular-nums]">{Math.round(s.modelProbability)}%</span>
+          </div>
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-white/10 ring-1 ring-inset ring-white/5">
+            <div className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-amber-300 to-[#f5c542] shadow-[0_0_10px_rgba(245,197,66,0.55)]" style={{ width: `${Math.max(4, Math.min(100, s.modelProbability))}%` }} />
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-2 text-[10.5px] text-white/55">
+            <span className="[font-variant-numeric:tabular-nums]">Bookies' price says {Math.round(s.impliedProbability)}%</span>
+            <span className="inline-flex items-center rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">+{s.valueGap.toFixed(1)}% edge</span>
+          </div>
+        </div>
+
+        {/* one short line from the Gaffer — the full read lives in the breakdown */}
+        <p className="border-t border-white/[0.1] px-3.5 py-2.5 text-[12px] italic leading-snug text-white/70">
+          <span aria-hidden className="mr-1 font-display text-base leading-none text-violet-300/70">“</span>
+          {s.gafferShortVerdict}
+          <span aria-hidden className="ml-0.5 font-display text-base leading-none text-violet-300/70">”</span>
+        </p>
       </div>
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2 pl-4 pr-3 text-[11px] text-white/60">
-        <span className="font-display text-[14px] uppercase tracking-tight text-white">{s.marketLabel}</span>
-        {s.oddsSnapshot != null && <span className="font-display text-[15px] text-[#f5c542] [font-variant-numeric:tabular-nums]">{s.oddsSnapshot.toFixed(2)}</span>}
-        <span className="[font-variant-numeric:tabular-nums]">model <b className="text-white/90">{Math.round(s.modelProbability)}%</b></span>
-        <span className="[font-variant-numeric:tabular-nums]">implied <b className="text-white/90">{Math.round(s.impliedProbability)}%</b></span>
-        <span className="ml-auto inline-flex items-center rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">+{s.valueGap.toFixed(1)} gap</span>
-        <span className={`inline-flex items-center rounded-[6px] px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide ring-1 ring-inset ${s.confidence === 'high' ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/25' : s.confidence === 'medium' ? 'bg-amber-500/10 text-amber-300 ring-amber-400/25' : 'bg-white/[0.06] text-white/55 ring-white/15'}`}>{s.confidence}</span>
-      </div>
-      <p className="border-t border-white/[0.08] py-2 pl-4 pr-3 text-[12px] italic leading-relaxed text-white/70">
-        <span aria-hidden className="mr-1 font-display text-base leading-none text-violet-300/70">“</span>
-        {s.gafferVerdict}
-        <span aria-hidden className="ml-0.5 font-display text-base leading-none text-violet-300/70">”</span>
-      </p>
     </div>
   );
 }
@@ -35,27 +83,26 @@ export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDail
   return (
     <section id="gaffer-daily-card" className="relative overflow-hidden rounded-[1.6rem] border border-[#f5c542]/25 bg-[#130321]">
       <div className="h-[3px] bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)]" />
-      <div className="p-5 md:p-7">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-[#f5c542]/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]">
-              <Star className="h-3.5 w-3.5 fill-current" /> Today's Gaffer Card
-            </span>
-            <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">The double is mine. The rest is yours to explore.</h2>
-            <p className="mt-1 text-xs text-white/55">Curated by the tipping engine every morning — the board below is where you browse the rest.</p>
-          </div>
-          <button
-            onClick={onEmailCard}
-            className="inline-flex items-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-4 py-2.5 text-[11px] font-black uppercase tracking-wide text-violet-200 transition-colors hover:bg-violet-500/20"
-          >
-            <Bell className="h-3.5 w-3.5" /> Email me the Gaffer card
-          </button>
+      {/* the Gaffer keeps an eye on his card */}
+      <img
+        src="/images/gaffer/opt/gaffer-pointing-you.webp"
+        alt=""
+        loading="lazy"
+        draggable={false}
+        className="pointer-events-none absolute -right-3 top-1 z-0 h-28 w-auto select-none opacity-80 md:right-4 md:h-36"
+      />
+      <div className="relative z-[1] p-5 md:p-7">
+        <div className="max-w-[72%] md:max-w-none">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#f5c542]/50 bg-[#f5c542]/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]">
+            <Star className="h-3.5 w-3.5 fill-current" /> Today's Gaffer Card
+          </span>
+          <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">The double is mine.<br className="md:hidden" /> The rest is yours.</h2>
         </div>
 
         {card.quietDay ? (
           <div className="mt-5 rounded-2xl border border-white/10 bg-black/25 p-6 text-center">
-            <h3 className="font-display text-2xl uppercase text-white">{card.quietDayMessage.split('—')[0].trim()}</h3>
-            <p className="mx-auto mt-1.5 max-w-md text-sm text-white/60">No forced picks today. Discipline is part of the game — the board below still shows anything the scan did find.</p>
+            <h3 className="font-display text-2xl uppercase text-white">Powder dry today.</h3>
+            <p className="mx-auto mt-1.5 max-w-md text-sm text-white/60">No forced picks — discipline is part of the game. Anything the scan did find is on the board below.</p>
           </div>
         ) : (
           <div className="mt-5 grid gap-4 lg:grid-cols-2">
@@ -63,8 +110,8 @@ export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDail
               <div className="mb-2 flex items-center gap-2 text-[11px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]">
                 <Star className="h-3.5 w-3.5" /> Daily Double
               </div>
-              <div className="space-y-2.5">
-                {card.double.selections.map((s) => <SelectionRow key={s.fixtureId} s={s} />)}
+              <div className="space-y-3">
+                {card.double.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} />)}
               </div>
             </div>
             <div>
@@ -72,21 +119,29 @@ export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDail
                 <Layers className="h-3.5 w-3.5" /> Daily Treble
               </div>
               {card.treble.available ? (
-                <div className="space-y-2.5">
-                  {card.treble.selections.map((s) => <SelectionRow key={s.fixtureId} s={s} />)}
+                <div className="space-y-3">
+                  {card.treble.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} />)}
                 </div>
               ) : (
                 <div className="rounded-[13px] border border-white/10 bg-black/25 p-5 text-sm text-white/55">
-                  Not enough qualifying selections for a treble today — the Gaffer doesn't pad a card to make it look busy.
+                  Not enough qualifying games for a treble today — I don't pad a card to make it look busy. Back at full strength when the fixtures allow.
                 </div>
               )}
             </div>
           </div>
         )}
 
-        <p className="mt-4 flex items-start gap-2 text-[11px] leading-relaxed text-white/45">
-          <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#f5c542]/70" /> {card.riskNote}
-        </p>
+        <div className="mt-4 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+          <p className="flex items-start gap-2 text-[11px] leading-relaxed text-white/45">
+            <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#f5c542]/70" /> {card.riskNote}
+          </p>
+          <button
+            onClick={onEmailCard}
+            className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-4 py-2.5 text-[11px] font-black uppercase tracking-wide text-violet-200 transition-colors hover:bg-violet-500/20"
+          >
+            <Bell className="h-3.5 w-3.5" /> Email me the Gaffer card
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/components/valueboard/MarketBoard.tsx
+++ b/src/components/valueboard/MarketBoard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { X, ArrowDownWideNarrow, BellPlus, Swords, TrendingUp, Activity } from 'lucide-react';
+import { X, BellPlus, Swords, TrendingUp, Activity, Search } from 'lucide-react';
 import { TeamAvatar } from '@/components/TeamAvatar';
 import {
   FAMILIES, VALUE_MARKETS, type HubSummary, type MarketSummary,
@@ -15,6 +15,10 @@ const confTone = (c: Confidence) =>
 const statusTone: Record<FixtureStatus, string> = {
   scheduled: 'text-white/50', live: 'text-emerald-300', finished: 'text-white/40', stale: 'text-rose-300',
 };
+
+// 'Over 2.5 Goals' → 'O 2.5' for tight chips.
+const shortLabel = (s: MarketSummary): string =>
+  s.family === 'btts' ? s.label.replace('Both Teams To Score — ', 'BTTS ') : s.label.replace(/^Over /, 'O ').replace(/^Under /, 'U ').replace(/ (Goals|Corners|Cards)$/, '');
 
 /* ── Market family tabs ─────────────────────────────────────────────────── */
 function MarketFamilyTabs({ family, counts, onChange }: {
@@ -33,47 +37,38 @@ function MarketFamilyTabs({ family, counts, onChange }: {
             : 'border border-white/12 bg-white/[0.04] text-white/65 hover:bg-white/[0.08]'}`}
         >
           {f.label}
-          <span className={`rounded-full px-1.5 py-px text-[10px] [font-variant-numeric:tabular-nums] ${family === f.family ? 'bg-black/20' : 'bg-white/10'}`}>{counts[f.family]}</span>
+          {counts[f.family] > 0 && (
+            <span className={`rounded-full px-1.5 py-px text-[10px] [font-variant-numeric:tabular-nums] ${family === f.family ? 'bg-black/20' : 'bg-emerald-500/20 text-emerald-300'}`}>{counts[f.family]}</span>
+          )}
         </button>
       ))}
     </div>
   );
 }
 
-/* ── One exact-market card ──────────────────────────────────────────────── */
+/* ── A market with value today — a proper card ──────────────────────────── */
 function ValueMarketCard({ s, active, onOpen }: { s: MarketSummary; active: boolean; onOpen: () => void }) {
   return (
-    <button
-      onClick={onOpen}
-      className={`group relative overflow-hidden rounded-[14px] text-left transition-transform hover:-translate-y-0.5 ${active ? '' : ''}`}
-    >
-      <div className={`relative overflow-hidden rounded-[14px] border bg-gradient-to-b from-[#1c1338] to-[#110a26] ${active ? 'border-[#f5c542]/60' : s.status === 'value' ? 'border-emerald-400/30' : 'border-white/[0.09]'}`}>
-        <div aria-hidden className={`h-[3px] ${s.status === 'value' ? 'bg-[linear-gradient(90deg,#065f46,#34d399,#065f46)]' : 'bg-[linear-gradient(90deg,#5b1b8f_0%,#f5c542_48%,#5b1b8f_100%)] opacity-50'}`} />
-        <div className="p-3.5">
+    <button onClick={onOpen} className="group text-left transition-transform hover:-translate-y-0.5">
+      <div
+        className="relative rounded-[14px] p-px shadow-[0_2px_4px_-1px_rgba(0,0,0,0.7),0_18px_36px_-18px_rgba(0,0,0,0.95)]"
+        style={{ background: active
+          ? 'linear-gradient(160deg,#f5c542 0%,#8b5cf6 48%,#22d3ee 100%)'
+          : 'linear-gradient(160deg,#6ee7b7 0%,#065f46 55%,#34d399 100%)' }}
+      >
+        <div className="relative overflow-hidden rounded-[13px] bg-gradient-to-b from-[#1c1338] to-[#110a26] p-3.5">
           <div className="flex items-start justify-between gap-2">
-            <span className="font-display text-[15px] uppercase leading-tight tracking-tight text-white">{s.label}</span>
-            {s.status === 'value'
-              ? <span className="shrink-0 rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">{s.fixturesFoundToday} value</span>
-              : <span className="shrink-0 rounded-[6px] bg-white/[0.06] px-1.5 py-[3px] text-[9px] font-black uppercase tracking-wide text-white/45 ring-1 ring-inset ring-white/10">{s.status === 'priced' ? 'no edge' : 'unpriced'}</span>}
+            <span className="font-display text-[16px] uppercase leading-tight tracking-tight text-white">{s.label}</span>
+            <span className="shrink-0 rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[10px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">
+              +{s.biggestValueGap?.toFixed(1)}% edge
+            </span>
           </div>
-          {s.status === 'value' ? (
-            <div className="mt-2 space-y-1 text-[11px] text-white/55">
-              <div className="truncate">Strongest: <b className="text-white/85">{s.strongestFixture}</b></div>
-              <div className="flex flex-wrap gap-x-3 [font-variant-numeric:tabular-nums]">
-                <span>biggest gap <b className="text-emerald-300">+{s.biggestValueGap?.toFixed(1)}</b></span>
-                <span>avg score <b className="text-white/85">{s.averageValueScore?.toFixed(1)}</b></span>
-                {s.confidenceRange && <span>conf <b className="text-white/85">{s.confidenceRange}</b></span>}
-              </div>
-            </div>
-          ) : (
-            <p className="mt-2 text-[11px] leading-snug text-white/40">
-              {s.status === 'priced'
-                ? 'No strong edge found for this market today.'
-                : 'No bookmaker prices for this market in today’s leagues.'}
-            </p>
-          )}
-          <div className={`mt-2.5 text-[10px] font-black uppercase tracking-[0.14em] ${active ? 'text-[#f8e7a1]' : 'text-white/35 group-hover:text-white/60'}`}>
-            {active ? '▾ Showing fixtures below' : s.fixturesPriced > 0 ? `View ${s.fixturesPriced} priced fixture${s.fixturesPriced === 1 ? '' : 's'} →` : 'View →'}
+          <div className="mt-1.5 truncate text-[12px] font-semibold text-white/80">{s.strongestFixture}</div>
+          <div className="mt-1 text-[10.5px] text-white/45 [font-variant-numeric:tabular-nums]">
+            {s.fixturesFoundToday} value pick{s.fixturesFoundToday === 1 ? '' : 's'} today · {s.confidenceRange} confidence
+          </div>
+          <div className={`mt-2 text-[10px] font-black uppercase tracking-[0.14em] ${active ? 'text-[#f8e7a1]' : 'text-emerald-300/80 group-hover:text-emerald-200'}`}>
+            {active ? '▾ Fixtures below' : 'See the fixtures →'}
           </div>
         </div>
       </div>
@@ -84,69 +79,52 @@ function ValueMarketCard({ s, active, onOpen }: { s: MarketSummary; active: bool
 /* ── Ranked fixtures for the selected market ────────────────────────────── */
 function MarketFixtureTable({ marketKey, onRowClick }: { marketKey: ValueMarketKey; onRowClick: (fixtureId: string) => void }) {
   const [league, setLeague] = useState('all');
-  const [minConf, setMinConf] = useState<Confidence | 'any'>('any');
-  const [sort, setSort] = useState<'valueGap' | 'confidence' | 'kickoff'>('valueGap');
   const leagues = useValueBoardLeagues();
-  const res = useValueMarketFixtures({ marketKey, league, minConfidence: minConf === 'any' ? undefined : minConf });
+  const res = useValueMarketFixtures({ marketKey, league });
   if (!res.ok) return null;
-  const order: Confidence[] = ['low', 'medium', 'high'];
-  const rows = [...res.data.fixtures].sort((a, b) =>
-    sort === 'valueGap' ? b.valueGap - a.valueGap
-    : sort === 'confidence' ? order.indexOf(b.confidence) - order.indexOf(a.confidence) || b.valueGap - a.valueGap
-    : a.kickoff.localeCompare(b.kickoff));
+  const rows = res.data.fixtures;
 
-  const sel = 'rounded-lg border border-white/12 bg-[#160b2e] px-2.5 py-1.5 text-[11px] font-bold text-white/75 outline-none focus:border-[#f5c542]/50';
   return (
-    <div className="mt-4 overflow-hidden rounded-[14px] border border-white/[0.09] bg-gradient-to-b from-[#170e2e] to-[#0f0821]">
-      <div className="flex flex-wrap items-center gap-2 border-b border-white/[0.08] px-3.5 py-2.5">
-        <span className="font-display text-[14px] uppercase tracking-tight text-white">{res.data.marketLabel}</span>
-        <span className="text-[10px] font-black uppercase tracking-[0.14em] text-white/35">ranked by {sort === 'valueGap' ? 'value gap' : sort}</span>
-        <div className="ml-auto flex flex-wrap gap-1.5">
-          <select value={league} onChange={(e) => setLeague(e.target.value)} className={sel} aria-label="Filter by league">
+    <div className="mt-4 overflow-hidden rounded-[14px] border border-white/[0.1] bg-gradient-to-b from-[#170e2e] to-[#0f0821]">
+      <div className="flex flex-wrap items-center gap-2 border-b border-white/[0.1] px-3.5 py-2.5">
+        <span className="font-display text-[15px] uppercase tracking-tight text-white">{res.data.marketLabel}</span>
+        <span className="text-[10px] font-black uppercase tracking-[0.14em] text-white/35">best edge first</span>
+        {leagues.length > 1 && (
+          <select
+            value={league}
+            onChange={(e) => setLeague(e.target.value)}
+            className="ml-auto rounded-lg border border-white/12 bg-[#160b2e] px-2.5 py-1.5 text-[11px] font-bold text-white/75 outline-none focus:border-[#f5c542]/50"
+            aria-label="Filter by league"
+          >
             <option value="all">All leagues</option>
             {leagues.map((l) => <option key={l} value={l}>{l}</option>)}
           </select>
-          <select value={minConf} onChange={(e) => setMinConf(e.target.value as Confidence | 'any')} className={sel} aria-label="Minimum confidence">
-            <option value="any">Any confidence</option>
-            <option value="medium">Medium +</option>
-            <option value="high">High only</option>
-          </select>
-          <select value={sort} onChange={(e) => setSort(e.target.value as typeof sort)} className={sel} aria-label="Sort">
-            <option value="valueGap">Sort: value gap</option>
-            <option value="confidence">Sort: confidence</option>
-            <option value="kickoff">Sort: kickoff</option>
-          </select>
-        </div>
+        )}
       </div>
 
       {rows.length === 0 ? (
         <div className="px-4 py-8 text-center text-sm text-white/50">{res.data.emptyStateMessage}</div>
       ) : (
-        <div className="divide-y divide-white/[0.06]">
+        <div className="divide-y divide-white/[0.07]">
           {rows.map((r) => (
-            <button key={r.id} onClick={() => onRowClick(r.id)} className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-white/[0.03]">
-              <div className="flex shrink-0 items-center -space-x-1">
-                <TeamAvatar name={r.homeTeam} logoUrl={r.homeLogo} size={26} className="rounded-md bg-black/45 p-0.5 ring-1 ring-white/12" />
-                <TeamAvatar name={r.awayTeam} logoUrl={r.awayLogo} size={26} className="rounded-md bg-black/45 p-0.5 ring-1 ring-white/12" />
+            <button key={r.id} onClick={() => onRowClick(r.id)} className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-3.5 py-3 text-left transition-colors hover:bg-white/[0.03]">
+              <div className="flex shrink-0 items-center -space-x-1.5">
+                <TeamAvatar name={r.homeTeam} logoUrl={r.homeLogo} size={32} className="rounded-lg bg-black/45 p-0.5 ring-1 ring-white/12" />
+                <TeamAvatar name={r.awayTeam} logoUrl={r.awayLogo} size={32} className="rounded-lg bg-black/45 p-0.5 ring-1 ring-white/12" />
               </div>
               <div className="min-w-0">
-                <div className="flex items-baseline gap-2">
-                  <span className="truncate text-[13px] font-semibold text-white">{r.fixture}</span>
-                  {r.qualifies && <span className="shrink-0 rounded-[5px] bg-emerald-500/15 px-1 py-px text-[8.5px] font-black uppercase text-emerald-300 ring-1 ring-inset ring-emerald-400/30">value</span>}
-                </div>
-                <div className="mt-0.5 flex flex-wrap items-center gap-x-2.5 text-[10.5px] text-white/45 [font-variant-numeric:tabular-nums]">
+                <div className="truncate text-[13.5px] font-semibold text-white">{r.fixture}</div>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[10.5px] text-white/45 [font-variant-numeric:tabular-nums]">
                   <span className="truncate">{r.league}</span>
-                  <span className={statusTone[r.status]}>{r.status === 'scheduled' ? `${r.kickoffLabel} KO` : r.status}</span>
-                  <span>form <b className="text-white/75">{Math.round(r.formScore)}%</b></span>
-                  <span>implied <b className="text-white/75">{Math.round(r.impliedProbability)}%</b></span>
+                  <span className={statusTone[r.status]}>{r.status === 'scheduled' ? `${r.kickoffLabel} KO` : r.status.toUpperCase()}</span>
+                  <span>Form <b className="text-white/80">{Math.round(r.formScore)}%</b> · price says <b className="text-white/80">{Math.round(r.impliedProbability)}%</b></span>
                 </div>
               </div>
-              <div className="shrink-0 text-right [font-variant-numeric:tabular-nums]">
-                <div className={`text-[13px] font-black ${r.valueGap >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>{r.valueGap >= 0 ? '+' : ''}{r.valueGap.toFixed(1)}</div>
-                <div className="mt-0.5 flex items-center justify-end gap-1">
-                  {r.oddsSnapshot != null && <span className="font-display text-[13px] text-[#f5c542]">{r.oddsSnapshot.toFixed(2)}</span>}
-                  <span className={`rounded-[5px] px-1 py-px text-[8.5px] font-black uppercase ring-1 ring-inset ${confTone(r.confidence)}`}>{r.confidence[0]}</span>
-                </div>
+              <div className="shrink-0 text-right">
+                {r.oddsSnapshot != null && <div className="font-display text-[19px] leading-none text-[#f5c542] [font-variant-numeric:tabular-nums] drop-shadow-[0_2px_5px_rgba(0,0,0,0.6)]">{r.oddsSnapshot.toFixed(2)}</div>}
+                {r.qualifies
+                  ? <div className="mt-1 inline-flex items-center rounded-[6px] bg-emerald-500/15 px-1.5 py-[3px] text-[9.5px] font-black uppercase tracking-wide text-emerald-300 ring-1 ring-inset ring-emerald-400/30 [font-variant-numeric:tabular-nums]">+{r.valueGap.toFixed(1)}% edge</div>
+                  : <div className="mt-1 text-[10px] font-bold text-white/35 [font-variant-numeric:tabular-nums]">{r.valueGap >= 0 ? '+' : ''}{r.valueGap.toFixed(1)}% · no edge</div>}
               </div>
             </button>
           ))}
@@ -181,24 +159,29 @@ function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="text-[10px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]/70">{b.league} · {b.status === 'scheduled' ? `${b.kickoffLabel} KO` : b.status}</div>
-                  <h3 className="mt-1 font-display text-xl uppercase leading-tight tracking-tight text-white">{b.fixture}</h3>
-                  <div className="mt-1 font-display text-[14px] uppercase tracking-tight text-[#f8e7a1]">{b.market}</div>
+                  <div className="mt-2 flex items-center gap-2.5">
+                    <TeamAvatar name={b.homeTeam} logoUrl={b.homeLogo} size={40} className="shrink-0 rounded-[10px] bg-black/45 p-1 ring-1 ring-white/12" />
+                    <span className="font-display text-[13px] uppercase text-white/30">vs</span>
+                    <TeamAvatar name={b.awayTeam} logoUrl={b.awayLogo} size={40} className="shrink-0 rounded-[10px] bg-black/45 p-1 ring-1 ring-white/12" />
+                  </div>
+                  <h3 className="mt-2 font-display text-xl uppercase leading-tight tracking-tight text-white">{b.fixture}</h3>
+                  <div className="mt-0.5 font-display text-[14px] uppercase tracking-tight text-[#f8e7a1]">{b.market}</div>
                 </div>
                 <button onClick={onClose} className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-white/15 text-white/60 hover:bg-white/[0.06]" aria-label="Close">
                   <X className="h-4 w-4" />
                 </button>
               </div>
 
-              {/* numbers strip */}
-              <div className="mt-4 grid grid-cols-4 divide-x divide-white/[0.08] overflow-hidden rounded-[12px] border border-white/[0.1] bg-black/25 text-center [font-variant-numeric:tabular-nums]">
+              {/* the honest numbers, in plain English */}
+              <div className="mt-4 grid grid-cols-4 divide-x divide-white/[0.1] overflow-hidden rounded-[12px] border border-white/[0.12] bg-black/25 text-center [font-variant-numeric:tabular-nums]">
                 {[
-                  { l: 'Model', v: `${Math.round(b.modelProbability)}%` },
-                  { l: 'Implied', v: `${Math.round(b.impliedProbability)}%` },
-                  { l: 'Gap', v: `${b.valueGap >= 0 ? '+' : ''}${b.valueGap.toFixed(1)}`, tone: b.valueGap >= 0 ? 'text-emerald-300' : 'text-rose-300' },
+                  { l: 'Form says', v: `${Math.round(b.modelProbability)}%` },
+                  { l: 'Price says', v: `${Math.round(b.impliedProbability)}%` },
+                  { l: 'Edge', v: `${b.valueGap >= 0 ? '+' : ''}${b.valueGap.toFixed(1)}%`, tone: b.valueGap >= 0 ? 'text-emerald-300' : 'text-rose-300' },
                   { l: 'Odds', v: b.oddsSnapshot?.toFixed(2) ?? '—', tone: 'text-[#f5c542]' },
                 ].map((c) => (
                   <div key={c.l} className="px-1 py-2.5">
-                    <div className="text-[8.5px] font-black uppercase tracking-[0.14em] text-white/40">{c.l}</div>
+                    <div className="text-[8.5px] font-black uppercase tracking-[0.12em] text-white/40">{c.l}</div>
                     <div className={`mt-0.5 font-display text-[18px] leading-none ${c.tone ?? 'text-white'}`}>{c.v}</div>
                   </div>
                 ))}
@@ -208,7 +191,7 @@ function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
               <div className="mt-3 rounded-[12px] border border-white/[0.1] bg-black/20 p-3.5 text-[12px] text-white/65">
                 <div className="flex flex-wrap items-center gap-x-4 gap-y-1 [font-variant-numeric:tabular-nums]">
                   {b.marketStats.hitRate && (
-                    <span className="inline-flex items-center gap-1.5"><TrendingUp className="h-3.5 w-3.5 text-emerald-300" /> Landed <b className="text-emerald-300">{b.marketStats.hitRate.hits}/{b.marketStats.hitRate.total}</b> recent</span>
+                    <span className="inline-flex items-center gap-1.5"><TrendingUp className="h-3.5 w-3.5 text-emerald-300" /> Landed <b className="text-emerald-300">{b.marketStats.hitRate.hits}/{b.marketStats.hitRate.total}</b> recent games</span>
                   )}
                   <span className="inline-flex items-center gap-1.5"><Activity className="h-3.5 w-3.5 text-violet-300" /> {b.marketStats.averages.label}: home <b className="text-white/90">{b.marketStats.averages.home ?? '—'}</b> · away <b className="text-white/90">{b.marketStats.averages.away ?? '—'}</b></span>
                 </div>
@@ -238,11 +221,11 @@ function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
               {/* the Gaffer's read */}
               <div className="relative mt-3 overflow-hidden rounded-[12px] border border-white/[0.1] bg-gradient-to-b from-[#171029] to-[#0f0a1e]">
                 <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-fuchsia-400 via-violet-500 to-violet-700" />
-                <p className="py-3 pl-4 pr-3.5 text-[13px] italic leading-relaxed text-white/80">
-                  <span aria-hidden className="mr-1 font-display text-lg leading-none text-violet-300/70">“</span>
-                  {b.gafferVerdict}
-                  <span aria-hidden className="ml-0.5 font-display text-lg leading-none text-violet-300/70">”</span>
-                </p>
+                <div className="flex items-center gap-2 border-b border-white/[0.08] py-2 pl-4 pr-3.5">
+                  <img src="/images/the-gaffer.png" alt="" loading="lazy" className="h-7 w-7 rounded-full object-cover object-top ring-1 ring-violet-400/50" />
+                  <span className="text-[10px] font-black uppercase tracking-[0.16em] text-violet-300">The Gaffer's read</span>
+                </div>
+                <p className="py-2.5 pl-4 pr-3.5 text-[13px] italic leading-relaxed text-white/80">{b.gafferVerdict}</p>
               </div>
               <p className="mt-2 text-[10.5px] leading-relaxed text-white/40">{b.riskNote}</p>
 
@@ -260,19 +243,20 @@ function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
   );
 }
 
-/* ── The board: tabs → cards → table → breakdown ────────────────────────── */
+/* ── The board: tabs → value cards → quiet chips → table → breakdown ────── */
 export function MarketBoard({ summary, onAddAlert }: { summary: HubSummary; onAddAlert: (k: ValueMarketKey) => void }) {
   const [family, setFamily] = useState<ValueMarketFamily>('goals');
   const [marketKey, setMarketKey] = useState<ValueMarketKey | null>(null);
   const [breakdown, setBreakdown] = useState<{ fixtureId: string; marketKey: ValueMarketKey } | null>(null);
 
-  const familyMarkets = useMemo(
-    () => summary.allMarkets.filter((s) => s.family === family),
-    [summary, family],
-  );
+  const familyMarkets = useMemo(() => summary.allMarkets.filter((s) => s.family === family), [summary, family]);
+  const valueMarkets = familyMarkets.filter((s) => s.status === 'value');
+  const quietMarkets = familyMarkets.filter((s) => s.status === 'priced');
+  const unpricedMarkets = familyMarkets.filter((s) => s.status === 'unpriced');
+
   const activeKey = marketKey && VALUE_MARKETS.find((m) => m.key === marketKey)?.family === family
     ? marketKey
-    : familyMarkets.find((s) => s.status === 'value')?.marketKey ?? familyMarkets.find((s) => s.status === 'priced')?.marketKey ?? null;
+    : valueMarkets[0]?.marketKey ?? quietMarkets[0]?.marketKey ?? null;
 
   return (
     <section id="market-board" className="relative overflow-hidden rounded-[1.6rem] border border-violet-400/25 bg-[#130321]">
@@ -281,27 +265,51 @@ export function MarketBoard({ summary, onAddAlert }: { summary: HubSummary; onAd
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.16em] text-violet-200">
-              <ArrowDownWideNarrow className="h-3.5 w-3.5" /> Today's Markets
+              <Search className="h-3.5 w-3.5" /> Today's Markets
             </span>
-            <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">Browse the value, market by market</h2>
+            <h2 className="mt-2.5 font-display text-2xl uppercase tracking-tight text-white md:text-3xl">Pick your market. I've done the digging.</h2>
             <p className="mt-1 max-w-xl text-xs leading-relaxed text-white/55">
-              Some members love goals. Some love corners. Some are card merchants. Fine — I've sorted the lot.
-              Pick a family, pick your exact line, and see every priced fixture ranked by the gap.
+              Goals fan? Corner merchant? Card counter? The scan covers the lot — anything with a real edge today gets a green card below.
             </p>
-          </div>
-          <div className="text-right text-[11px] text-white/45 [font-variant-numeric:tabular-nums]">
-            <div><b className="text-white/85">{summary.totalFixturesScanned}</b> fixtures scanned</div>
-            <div><b className="text-white/85">{summary.totalMarketsScanned}</b> markets · <b className="text-emerald-300">{summary.totalValueFixtures}</b> value edges</div>
           </div>
         </div>
 
         <div className="mt-4"><MarketFamilyTabs family={family} counts={summary.marketFamilyCounts} onChange={(f) => { setFamily(f); setMarketKey(null); }} /></div>
 
-        <div className="mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
-          {familyMarkets.map((s) => (
-            <ValueMarketCard key={s.marketKey} s={s} active={s.marketKey === activeKey} onOpen={() => setMarketKey(s.marketKey)} />
-          ))}
-        </div>
+        {/* markets WITH value — proper cards */}
+        {valueMarkets.length > 0 ? (
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            {valueMarkets.map((s) => (
+              <ValueMarketCard key={s.marketKey} s={s} active={s.marketKey === activeKey} onOpen={() => setMarketKey(s.marketKey)} />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-2xl border border-white/10 bg-black/25 p-6 text-center">
+            <h3 className="font-display text-xl uppercase text-white">Nowt in {FAMILIES.find((f) => f.family === family)?.label} today.</h3>
+            <p className="mx-auto mt-1 max-w-md text-sm text-white/55">The bookies have this family priced right for once — check another tab, or browse the raw numbers below.</p>
+          </div>
+        )}
+
+        {/* quiet markets — one compact row, not a wall of grey boxes */}
+        {quietMarkets.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-1.5 rounded-xl border border-white/[0.08] bg-black/20 px-3 py-2.5">
+            <span className="mr-1 text-[9.5px] font-black uppercase tracking-[0.16em] text-white/35">No edge today</span>
+            {quietMarkets.map((s) => (
+              <button
+                key={s.marketKey}
+                onClick={() => setMarketKey(s.marketKey)}
+                className={`rounded-md px-2 py-1 text-[10.5px] font-bold transition-colors [font-variant-numeric:tabular-nums] ${s.marketKey === activeKey ? 'bg-[#f5c542]/15 text-[#f8e7a1] ring-1 ring-inset ring-[#f5c542]/40' : 'bg-white/[0.05] text-white/55 ring-1 ring-inset ring-white/10 hover:bg-white/[0.1]'}`}
+              >
+                {shortLabel(s)}
+              </button>
+            ))}
+          </div>
+        )}
+        {unpricedMarkets.length > 0 && (
+          <p className="mt-2 px-1 text-[10.5px] text-white/35">
+            No bookmaker prices in today's leagues for: {unpricedMarkets.map(shortLabel).join(', ')}.
+          </p>
+        )}
 
         {activeKey && <MarketFixtureTable marketKey={activeKey} onRowClick={(fixtureId) => setBreakdown({ fixtureId, marketKey: activeKey })} />}
       </div>

--- a/src/components/valueboard/ValueBoardHero.tsx
+++ b/src/components/valueboard/ValueBoardHero.tsx
@@ -23,9 +23,17 @@ export function ValueBoardHero({ updatedLabel, quietDay }: { updatedLabel: strin
           draggable={false}
           className="pointer-events-none absolute right-0 top-0 z-[1] hidden h-full w-auto select-none object-cover object-left [mask-image:linear-gradient(90deg,transparent_0%,#000_30%)] md:block md:max-w-[46%]"
         />
+        {/* mobile: the Gaffer celebrating in the corner — never a wall of text alone */}
+        <img
+          src="/images/gaffer/opt/gaffer-celebrating.webp"
+          alt=""
+          loading="eager"
+          draggable={false}
+          className="pointer-events-none absolute -right-4 -top-1 z-[1] h-36 w-auto select-none opacity-90 md:hidden"
+        />
 
         <div className="relative z-[2] p-5 md:max-w-[58%] md:p-9">
-          <div className="flex flex-wrap items-center gap-1.5">
+          <div className="flex flex-wrap items-center gap-1.5 pr-24 md:pr-0">
             {[
               { icon: Sparkles, text: 'Free Preview' },
               { icon: Lock, text: quietDay ? 'Quiet Day — No Forced Picks' : `Updated ${updatedLabel}` },

--- a/src/lib/valueBoard.ts
+++ b/src/lib/valueBoard.ts
@@ -105,6 +105,10 @@ export interface HubSummary {
 export interface DailyCardSelection {
   fixtureId: string;
   fixture: string;
+  homeTeam: string;
+  awayTeam: string;
+  homeLogo: string | null;
+  awayLogo: string | null;
   league: string;
   kickoff: string;
   kickoffLabel: string;
@@ -115,7 +119,8 @@ export interface DailyCardSelection {
   valueGap: number;
   confidence: Confidence;
   oddsSnapshot: number | null;
-  gafferVerdict: string;
+  gafferVerdict: string;      // full read (breakdowns, long formats)
+  gafferShortVerdict: string; // first beat only — card-friendly
 }
 
 export interface GafferDailyCardData {
@@ -366,12 +371,28 @@ const legMarketKey = (leg: Leg): ValueMarketKey | null => {
   return null;
 };
 
+// First sentence or two of a long read — cards want a punch, not a column.
+function firstBeat(text: string, max = 180): string {
+  const sentences = text.match(/[^.!?]+[.!?]+/g) ?? [text];
+  let out = '';
+  for (const s of sentences) {
+    if (out && (out + s).length > max) break;
+    out += s;
+    if (out.length >= max * 0.55) break;
+  }
+  return out.trim() || text.slice(0, max);
+}
+
 function legToSelection(leg: Leg): DailyCardSelection {
   const implied = leg.odds > 1 ? Math.round((100 / leg.odds) * 10) / 10 : 0;
   const date = todayUK();
+  const snap = SNAP.find((x) => x.id === leg.fixtureId);
   return {
     fixtureId: leg.fixtureId,
     fixture: `${leg.home.name} v ${leg.away.name}`,
+    homeTeam: leg.home.name, awayTeam: leg.away.name,
+    homeLogo: leg.home.logo ?? snap?.home.logo ?? null,
+    awayLogo: leg.away.logo ?? snap?.away.logo ?? null,
     league: [leg.region, leg.league].filter(Boolean).join(' · '),
     kickoff: ukWallToISO(date, leg.time), kickoffLabel: leg.time,
     marketKey: legMarketKey(leg), marketLabel: leg.selection,
@@ -380,6 +401,7 @@ function legToSelection(leg: Leg): DailyCardSelection {
     confidence: confidenceOf(leg.prob),
     oddsSnapshot: leg.odds,
     gafferVerdict: leg.placeholderReason,
+    gafferShortVerdict: firstBeat(leg.placeholderReason),
   };
 }
 


### PR DESCRIPTION
Fixes the four failures of the first cut:

- **Jargon killed.** "model 68% / implied 53% / +14.3 GAP / avg score / conf" → the site's own vocabulary everywhere: **Form says 68%**, **Bookies' price says 53%**, **+14.3% EDGE** in the homepage emerald chip. Breakdown strip reads Form says / Price says / Edge / Odds.
- **Walls of text gone.** Daily-card selections are homepage-style leg cards — crests, league line, pick row with big gold odds, form bar, edge chip — with **one short line** from the Gaffer (`gafferShortVerdict`, first beat of the read). The full read lives in the breakdown modal under a Gaffer-avatar header.
- **Images everywhere.** Crests on daily-card selections (with snapshot backfill), bigger crests on fixture rows, crest pair in the breakdown, Gaffer celebrating cutout on the mobile hero, Gaffer pointing cutout on the daily card.
- **Empty-state spam collapsed.** Markets WITH value get proper green-rimmed cards headlined by their best edge; the five grey "no edge" blocks become one compact chip row; unpriced markets are a single line of text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_