### PR TITLE
Visitor counter: per-country uniques + bot filter

### DIFF
--- a/functions/api/hit.ts
+++ b/functions/api/hit.ts
@@ -11,11 +11,18 @@ async function sha16(input: string): Promise<string> {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 16);
 }
 
+// Crawlers that execute JS (Googlebot & friends) fire the beacon like real
+// browsers — keep them out of the numbers.
+const BOT_RE = /bot|crawl|spider|slurp|preview|fetch|headless|lighthouse|monitor|scrape|python|curl|wget/i;
+
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   try {
+    const ua = request.headers.get('user-agent') ?? '';
+    if (!ua || BOT_RE.test(ua)) return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+
     const today = new Date().toISOString().slice(0, 10);
     const ip = request.headers.get('cf-connecting-ip') ?? '';
-    const ua = request.headers.get('user-agent') ?? '';
+    const country = (request.headers.get('cf-ipcountry') ?? '').toUpperCase() || 'XX';
 
     const hits = Number((await env.WAITLIST.get(`hits:${today}`)) ?? '0') + 1;
     await env.WAITLIST.put(`hits:${today}`, String(hits), { expirationTtl: DAY * 40 });
@@ -26,6 +33,12 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       await env.WAITLIST.put(uvKey, '1', { expirationTtl: 60 * 60 * 26 });
       const uniq = Number((await env.WAITLIST.get(`uniq:${today}`)) ?? '0') + 1;
       await env.WAITLIST.put(`uniq:${today}`, String(uniq), { expirationTtl: DAY * 40 });
+      // Per-country unique counts (aggregate only — no personal data).
+      const geoKey = `geo:${today}`;
+      let geo: Record<string, number> = {};
+      try { geo = JSON.parse((await env.WAITLIST.get(geoKey)) ?? '{}'); } catch { /* fresh */ }
+      geo[country] = (geo[country] ?? 0) + 1;
+      await env.WAITLIST.put(geoKey, JSON.stringify(geo), { expirationTtl: DAY * 40 });
     }
   } catch {
     // Counting must never break the site — swallow everything.

--- a/functions/api/stats.ts
+++ b/functions/api/stats.ts
@@ -19,15 +19,18 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const key = url.searchParams.get('key') ?? request.headers.get('x-admin-key') ?? '';
   if (!env.ADMIN_KEY || key !== env.ADMIN_KEY) return json({ ok: false, error: 'unauthorized' }, 401);
 
-  const days: { date: string; views: number; uniques: number }[] = [];
+  const days: { date: string; views: number; uniques: number; countries: Record<string, number> }[] = [];
   const now = Date.now();
   for (let i = 13; i >= 0; i--) {
     const date = new Date(now - i * 86_400_000).toISOString().slice(0, 10);
-    const [views, uniques] = await Promise.all([
+    const [views, uniques, geoRaw] = await Promise.all([
       env.WAITLIST.get(`hits:${date}`),
       env.WAITLIST.get(`uniq:${date}`),
+      env.WAITLIST.get(`geo:${date}`),
     ]);
-    days.push({ date, views: Number(views ?? 0), uniques: Number(uniques ?? 0) });
+    let countries: Record<string, number> = {};
+    try { countries = JSON.parse(geoRaw ?? '{}'); } catch { /* none */ }
+    days.push({ date, views: Number(views ?? 0), uniques: Number(uniques ?? 0), countries });
   }
 
   const signups = await env.WAITLIST.list({ prefix: 'signup:', limit: 1000 });


### PR DESCRIPTION
- `/api/hit` now skips JS-rendering crawlers (Googlebot etc.) via a user-agent filter, so counts reflect humans
- Records aggregate per-country unique counts (`geo:<date>` JSON in KV — country codes and counts only, no personal data)
- `/api/stats` returns the country breakdown per day

Verified in production end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-country visitor breakdowns to daily stats, so analytics now show where unique visitors come from.
* **Bug Fixes**
  * Bot-like requests are now ignored when counting hits and uniques, improving traffic accuracy.
  * Requests without a user-agent header are also excluded from visitor counts.
* **Other**
  * Stats responses now include country data alongside existing views and unique visitor totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->