### PR TITLE
Live scores: cross-feed team matching + never show placeholder 0-0

### DIFF
--- a/functions/api/inplay.ts
+++ b/functions/api/inplay.ts
@@ -37,9 +37,15 @@ function shape(m: Json, nowSec: number) {
   const cornersRaw = num(m.totalCornerCount);
   const cardsA = num(m.team_a_cards_num);
   const cardsB = num(m.team_b_cards_num);
+  // Does FootyStats actually have a live feed for this game? Some leagues only
+  // get their numbers at full time — until then the API returns a placeholder
+  // 0-0 with no minute and -1 corners, which must never be shown as a score.
+  const minuteRaw = m.game_minute ?? m.minute;
+  const feed = complete || minuteRaw != null || cornersRaw >= 0 || homeGoals + awayGoals > 0;
   return {
     live,
     ended: complete,
+    feed,
     goals: homeGoals + awayGoals,
     homeGoals,
     awayGoals,

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -80,8 +80,9 @@ function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | 
     return { state: 'live', landed, text: `${clock} · ${score}` };
   }
   // Fallback score for leagues API-Football doesn't stream (China, K-League…):
-  // FootyStats carries the running goal count during the match, so show it.
-  if (ip?.live) {
+  // FootyStats carries the running goal count during the match, so show it —
+  // but ONLY when it has a real feed; a placeholder 0-0 is worse than no score.
+  if (ip?.live && ip.feed) {
     const landed = settleLeg(leg, ip) === 'won';
     return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}${cornerNote(leg, ip)}` };
   }

--- a/src/components/homepage/useInPlay.ts
+++ b/src/components/homepage/useInPlay.ts
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 // /api/inplay (which proxies FootyStats server-side). corners/cards are null
 // when the feed hasn't recorded them yet — never a made-up number.
 export type InPlayState = {
+  /** FootyStats has real live numbers (false = placeholder 0-0, hide score). */
+  feed?: boolean;
   live: boolean;
   ended: boolean;
   goals: number;

--- a/src/components/homepage/useLiveScores.ts
+++ b/src/components/homepage/useLiveScores.ts
@@ -28,7 +28,16 @@ const words = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLower
  *  "Daegu FC" (containment) AND short/abbreviated names like "ÍA" vs "ÍA
  *  Akranes" — where one side's whole name is a standalone word of the other,
  *  which the old ≥3-char containment guard wrongly rejected. */
-const sameTeam = (a: string, b: string): boolean => {
+// Club-name furniture that carries no identity — dropped before token matching.
+// (Feeds disagree wildly: our data says "Tallinna FC Flora U21", API-Football
+// says "Flora II" — the only identity in either is "flora".)
+const NOISE = new Set(['fc', 'fk', 'cf', 'sc', 'afc', 'ac', 'ss', 'sv', 'bk', 'if', 'sk', 'nk', 'ks', 'club', 'u21', 'u23', 'u19', 'ii', 'iii', 'b']);
+// Words shared by unrelated clubs — never a basis for identity on their own.
+const GENERIC = new Set(['united', 'city', 'town', 'county', 'athletic', 'atletico', 'sporting', 'racing', 'rovers', 'wanderers', 'dynamo', 'dinamo', 'real', 'inter', 'national', 'olympic', 'olimpik', 'football']);
+const sigTokens = (s: string) => words(s).filter((w) => !NOISE.has(w) && !GENERIC.has(w) && w.length >= 4);
+
+// Strict: exact / containment / whole-word abbreviation — safe on its own.
+const sameTeamStrict = (a: string, b: string): boolean => {
   const ca = compact(a), cb = compact(b);
   if (!ca || !cb) return false;
   if (ca === cb) return true;
@@ -37,12 +46,33 @@ const sameTeam = (a: string, b: string): boolean => {
   return words(a).includes(cb) || words(b).includes(ca);
 };
 
-/** Match a fixture (by team names) to a live score, either way round. */
+// Loose: shared significant token(s) — needed for cross-feed naming like
+// "Tallinna FC Flora U21" v "Flora II". Only used when no strict match exists,
+// and both teams of the fixture must agree, which kills false pairs.
+const sameTeamLoose = (a: string, b: string): boolean => {
+  if (sameTeamStrict(a, b)) return true;
+  const ta = sigTokens(a), tb = sigTokens(b);
+  const shared = ta.filter((t) => tb.includes(t));
+  if (!shared.length) return false;
+  return shared.length >= 2 || ta.length === 1 || tb.length === 1;
+};
+
+/** Match a fixture (by team names) to a live score, either way round.
+ *  Strict name rules win first; the loose token pass only runs when nothing
+ *  strict matched, so a confident hit always beats a fuzzy one. */
 export function matchLive(home: string, away: string, list: LiveScore[] | undefined): LiveScore | undefined {
   if (!list?.length) return undefined;
-  return list.find(
-    (l) =>
-      (sameTeam(l.home, home) && sameTeam(l.away, away)) ||
-      (sameTeam(l.home, away) && sameTeam(l.away, home)),
-  );
+  for (const same of [sameTeamStrict, sameTeamLoose]) {
+    const hits = list.filter(
+      (l) =>
+        (same(l.home, home) && same(l.away, away)) ||
+        (same(l.home, away) && same(l.away, home)),
+    );
+    if (hits.length) {
+      // The live feed sometimes carries duplicate entries for one match at
+      // different minutes — trust the most advanced one.
+      return hits.reduce((best, l) => ((l.elapsed ?? -1) > (best.elapsed ?? -1) ? l : best));
+    }
+  }
+  return undefined;
 };

--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -312,7 +312,7 @@ function valueStatus(sel: ValueSel, ip: InPlayState | undefined, live: LiveScore
   }
   // FootyStats carries a running score + corner count mid-match for leagues
   // API-Football doesn't stream — show it rather than a bare 'In Play'.
-  if (ip?.live) {
+  if (ip?.live && ip.feed) {
     const landed = settleMarket(sel.catKey, sel.line, sel.under, ip) === 'won';
     return { state: 'live', landed, text: `LIVE · ${ip.homeGoals}–${ip.awayGoals}${metricNote(sel.catKey, ip)}` };
   }


### PR DESCRIPTION
Fixed live, during the affected match (site showed 0-0 while the real score was 2-1):

1. **Team-name matching across feeds failed.** Our data says "Maardu Linnameeskond" / "Tallinna FC Flora U21"; API-Football says "Maardu" / "Flora II" — so the real live feed never attached and the site fell back to a dead score. New matcher: strict exact/containment rules first, then a significant-token pass with noise words (FC, FK, U21, II…) and generic words (United, City, Real…) excluded; both teams of a fixture must agree. Duplicate live entries for one match (an API-Football quirk) resolve to the most advanced minute. Unit-tested against 9 cross-feed cases.
2. **FootyStats placeholder 0-0s displayed as real scores.** For leagues without live coverage it returns 0-0 with no minute and -1 corners until full time. `/api/inplay` now exposes a `feed` flag; both score surfaces (homepage board, form tables) show the plain "In Play" badge instead of a fake score when there's no feed.

Verified against the live match after deploy: board shows **"HT · 2–1"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new in-play feed indicator so the app can distinguish real live match data from placeholder live status.
  * Improved live score matching to better handle team-name variations and duplicate live entries.

* **Bug Fixes**
  * Live scores now avoid showing misleading 0-0 placeholders when no real feed data is available.
  * Match results are more likely to use the most up-to-date live entry when multiple matches are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->