### PR TITLE
Settle engine: single-pick days settle as a £10 single

### DIFF
--- a/scripts/settle.mjs
+++ b/scripts/settle.mjs
@@ -174,14 +174,17 @@ async function main() {
   let changed = false;
   for (const date of dates) {
     const { double, treble } = lockedBetFor(fixtures, date);
-    if (double.length < 2) { console.log(`${date}: no bet (only ${double.length} value pick(s)) — skipped.`); continue; }
+    if (double.length === 0) { console.log(`${date}: no picks on the card — nothing to settle.`); continue; }
 
     const needIds = [...double, ...treble].map((l) => String(l.fixtureId));
     const results = await fetchResults(needIds);
 
     const entries = [];
-    const dbl = buildBet('double', double, results);
-    if (dbl.pending) { console.log(`${date}: double not final yet — skipped (will settle once complete).`); continue; }
+    // 1 qualifying pick = the day's bet is a £10 SINGLE (the board shows it as
+    // "Gaffer's Top Pick"). It settles like any other bet — never skipped.
+    const kind = double.length === 1 ? 'single' : 'double';
+    const dbl = buildBet(kind, double, results);
+    if (dbl.pending) { console.log(`${date}: ${kind} not final yet — skipped (will settle once complete).`); continue; }
     entries.push({ date, ...dbl });
 
     if (treble.length === 3) {

--- a/src/data/formTablesData.json
+++ b/src/data/formTablesData.json
@@ -47,6 +47,14 @@
     {
       "name": "Úrvalsdeild",
       "region": "Iceland"
+    },
+    {
+      "name": "MLS",
+      "region": "USA"
+    },
+    {
+      "name": "Serie A",
+      "region": "Brazil"
     }
   ],
   "fixtures": [
@@ -408,81 +416,99 @@
         "5.5": 23.5
       },
       "goals_odds": {
-        "2.5": 1.89,
-        "3.5": 3.42,
-        "4.5": 6.95
+        "2.5": 2.0,
+        "3.5": 3.7,
+        "4.5": 7.0
       },
       "corners_odds": {
-        "8.5": 1.91,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 1.82,
+        "9.5": 2.85,
+        "10.5": 3.17,
+        "11.5": 4.65
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.78,
+      "btts_odds": 1.83,
       "goals_under_odds": {
-        "0.5": 8.75,
+        "0.5": 9.3,
         "1.5": 3.1,
-        "2.5": 1.95,
-        "3.5": 1.29
+        "2.5": 1.73,
+        "3.5": 1.25
       },
       "corners_under_odds": {
-        "8.5": 1.8,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 1.94,
+        "9.5": 1.52,
+        "10.5": 1.27,
+        "11.5": 1.11
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.95,
+      "btts_no_odds": 1.85,
       "value": {
         "goals": {
           "2.5": {
             "prob": 56.5,
-            "odds": 1.89,
-            "implied": 52.9,
-            "edge": 3.6,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": 6.5,
             "flag": null
           },
           "3.5": {
             "prob": 36.5,
-            "odds": 3.42,
-            "implied": 29.2,
-            "edge": 7.3,
+            "odds": 3.7,
+            "implied": 27,
+            "edge": 9.5,
             "flag": null
           },
           "4.5": {
             "prob": 13.5,
-            "odds": 6.95,
-            "implied": 14.4,
-            "edge": -0.9,
+            "odds": 7.0,
+            "implied": 14.3,
+            "edge": -0.8,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 43.5,
-            "odds": 1.91,
-            "implied": 52.4,
-            "edge": -8.9,
+            "odds": 1.82,
+            "implied": 54.9,
+            "edge": -11.4,
             "flag": null
           },
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
+          "9.5": {
+            "prob": 40,
+            "odds": 2.85,
+            "implied": 35.1,
+            "edge": 4.9,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 33,
+            "odds": 3.17,
+            "implied": 31.5,
+            "edge": 1.5,
+            "flag": null
+          },
+          "11.5": {
+            "prob": 30,
+            "odds": 4.65,
+            "implied": 21.5,
+            "edge": 8.5,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 66.5,
-          "odds": 1.78,
-          "implied": 56.2,
-          "edge": 10.3,
+          "odds": 1.83,
+          "implied": 54.6,
+          "edge": 11.9,
           "flag": "value"
         }
       },
@@ -715,82 +741,100 @@
         "5.5": 27
       },
       "goals_odds": {
-        "2.5": 1.8,
-        "3.5": 2.9,
-        "4.5": 5.5
+        "2.5": 1.74,
+        "3.5": 2.85,
+        "4.5": 5.0
       },
       "corners_odds": {
-        "8.5": 1.8,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 1.67,
+        "9.5": 2.36,
+        "10.5": 2.63,
+        "11.5": 3.66
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.65,
+      "btts_odds": 1.67,
       "goals_under_odds": {
-        "0.5": 11.0,
-        "1.5": 3.75,
-        "2.5": 2.0,
-        "3.5": 1.36
+        "0.5": 11.3,
+        "1.5": 4.0,
+        "2.5": 2.12,
+        "3.5": 1.43
       },
       "corners_under_odds": {
-        "8.5": 1.91,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 2.1,
+        "9.5": 1.7,
+        "10.5": 1.4,
+        "11.5": 1.2
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 2.05,
       "value": {
         "goals": {
           "2.5": {
             "prob": 66.5,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 10.9,
-            "flag": "value"
+            "odds": 1.74,
+            "implied": 57.5,
+            "edge": 9,
+            "flag": null
           },
           "3.5": {
             "prob": 50,
-            "odds": 2.9,
-            "implied": 34.5,
-            "edge": 15.5,
+            "odds": 2.85,
+            "implied": 35.1,
+            "edge": 14.9,
             "flag": "value"
           },
           "4.5": {
             "prob": 16.5,
-            "odds": 5.5,
-            "implied": 18.2,
-            "edge": -1.7,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -3.5,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 56.5,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 0.9,
+            "odds": 1.67,
+            "implied": 59.9,
+            "edge": -3.4,
             "flag": null
           },
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
+          "9.5": {
+            "prob": 50,
+            "odds": 2.36,
+            "implied": 42.4,
+            "edge": 7.6,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 40,
+            "odds": 2.63,
+            "implied": 38,
+            "edge": 2,
+            "flag": null
+          },
+          "11.5": {
+            "prob": 30,
+            "odds": 3.66,
+            "implied": 27.3,
+            "edge": 2.7,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 70,
-          "odds": 1.65,
-          "implied": 60.6,
-          "edge": 9.4,
-          "flag": null
+          "odds": 1.67,
+          "implied": 59.9,
+          "edge": 10.1,
+          "flag": "value"
         }
       },
       "home_form": [
@@ -1022,99 +1066,99 @@
         "5.5": 31.5
       },
       "goals_odds": {
-        "2.5": 1.36,
-        "3.5": 1.85,
-        "4.5": 2.9
+        "2.5": 1.33,
+        "3.5": 1.92,
+        "4.5": 3.1
       },
       "corners_odds": {
-        "8.5": 1.29,
-        "9.5": 1.69,
-        "10.5": 1.87,
-        "11.5": 2.41
+        "8.5": 1.38,
+        "9.5": 1.68,
+        "10.5": 2.09,
+        "11.5": 2.7
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.4,
+      "btts_odds": 1.36,
       "goals_under_odds": {
         "0.5": 25.0,
-        "1.5": 6.5,
+        "1.5": 7.0,
         "2.5": 3.1,
-        "3.5": 1.85
+        "3.5": 1.83
       },
       "corners_under_odds": {
-        "8.5": 3.08,
-        "9.5": 2.27,
-        "10.5": 1.77,
-        "11.5": 1.46
+        "8.5": 2.67,
+        "9.5": 2.03,
+        "10.5": 1.66,
+        "11.5": 1.35
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.77,
+      "btts_no_odds": 2.8,
       "value": {
         "goals": {
           "2.5": {
             "prob": 76.5,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": 3,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": 1.3,
             "flag": null
           },
           "3.5": {
             "prob": 41,
-            "odds": 1.85,
-            "implied": 54.1,
-            "edge": -13.1,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": -11.1,
             "flag": null
           },
           "4.5": {
             "prob": 26.5,
-            "odds": 2.9,
-            "implied": 34.5,
-            "edge": -8,
+            "odds": 3.1,
+            "implied": 32.3,
+            "edge": -5.8,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 59,
-            "odds": 1.29,
-            "implied": 77.5,
-            "edge": -18.5,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": -13.5,
             "flag": null
           },
           "9.5": {
             "prob": 41,
-            "odds": 1.69,
-            "implied": 59.2,
-            "edge": -18.2,
+            "odds": 1.68,
+            "implied": 59.5,
+            "edge": -18.5,
             "flag": null
           },
           "10.5": {
             "prob": 29.5,
-            "odds": 1.87,
-            "implied": 53.5,
-            "edge": -24,
+            "odds": 2.09,
+            "implied": 47.8,
+            "edge": -18.3,
             "flag": null
           },
           "11.5": {
             "prob": 26,
-            "odds": 2.41,
-            "implied": 41.5,
-            "edge": -15.5,
+            "odds": 2.7,
+            "implied": 37,
+            "edge": -11,
             "flag": null
           }
         },
         "btts": {
           "prob": 73.5,
-          "odds": 1.4,
-          "implied": 71.4,
-          "edge": 2.1,
+          "odds": 1.36,
+          "implied": 73.5,
+          "edge": 0,
           "flag": null
         }
       },
@@ -1357,75 +1401,99 @@
         "5.5": 8
       },
       "goals_odds": {
-        "2.5": 1.47,
-        "3.5": 2.34,
-        "4.5": 4.0
+        "2.5": 1.6,
+        "3.5": 2.27,
+        "4.5": 3.86
       },
       "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 1.29,
+        "9.5": 1.7,
+        "10.5": 1.91,
+        "11.5": 2.41
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.73,
+      "btts_odds": 1.69,
       "goals_under_odds": {
         "0.5": 12.7,
-        "1.5": 4.8,
-        "2.5": 2.3,
-        "3.5": 1.53
+        "1.5": 4.65,
+        "2.5": 2.38,
+        "3.5": 1.56
       },
       "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 3.05,
+        "9.5": 2.26,
+        "10.5": 1.8,
+        "11.5": 1.48
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.97,
+      "btts_no_odds": 2.0,
       "value": {
         "goals": {
           "2.5": {
             "prob": 42,
-            "odds": 1.47,
-            "implied": 68,
-            "edge": -26,
+            "odds": 1.6,
+            "implied": 62.5,
+            "edge": -20.5,
             "flag": null
           },
           "3.5": {
             "prob": 23,
-            "odds": 2.34,
-            "implied": 42.7,
-            "edge": -19.7,
+            "odds": 2.27,
+            "implied": 44.1,
+            "edge": -21.1,
             "flag": null
           },
           "4.5": {
             "prob": 19,
-            "odds": 4.0,
-            "implied": 25,
-            "edge": -6,
+            "odds": 3.86,
+            "implied": 25.9,
+            "edge": -6.9,
             "flag": null
           }
         },
         "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
+          "8.5": {
+            "prob": 57.5,
+            "odds": 1.29,
+            "implied": 77.5,
+            "edge": -20,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 50,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -8.8,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 34.5,
+            "odds": 1.91,
+            "implied": 52.4,
+            "edge": -17.9,
+            "flag": null
+          },
+          "11.5": {
+            "prob": 27,
+            "odds": 2.41,
+            "implied": 41.5,
+            "edge": -14.5,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 30.5,
-          "odds": 1.73,
-          "implied": 57.8,
-          "edge": -27.3,
+          "odds": 1.69,
+          "implied": 59.2,
+          "edge": -28.7,
           "flag": null
         }
       },
@@ -1668,15 +1736,15 @@
         "5.5": 21
       },
       "goals_odds": {
-        "2.5": 1.63,
-        "3.5": 2.51,
-        "4.5": 4.75
+        "2.5": 1.68,
+        "3.5": 2.7,
+        "4.5": 4.4
       },
       "corners_odds": {
-        "8.5": 1.31,
-        "9.5": 1.57,
-        "10.5": 1.98,
-        "11.5": 2.53
+        "8.5": 1.29,
+        "9.5": 1.79,
+        "10.5": 1.99,
+        "11.5": 2.2
       },
       "cards_odds": {
         "3.5": null,
@@ -1686,73 +1754,73 @@
       "btts_odds": 1.53,
       "goals_under_odds": {
         "0.5": 12.3,
-        "1.5": 4.33,
-        "2.5": 2.15,
+        "1.5": 4.05,
+        "2.5": 2.12,
         "3.5": 1.44
       },
       "corners_under_odds": {
-        "8.5": 2.92,
-        "9.5": 2.38,
-        "10.5": 1.72,
-        "11.5": 1.42
+        "8.5": 3.2,
+        "9.5": 2.17,
+        "10.5": 1.73,
+        "11.5": 1.58
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.28,
+      "btts_no_odds": 2.25,
       "value": {
         "goals": {
           "2.5": {
             "prob": 46.5,
-            "odds": 1.63,
-            "implied": 61.3,
-            "edge": -14.8,
+            "odds": 1.68,
+            "implied": 59.5,
+            "edge": -13,
             "flag": null
           },
           "3.5": {
             "prob": 28.5,
-            "odds": 2.51,
-            "implied": 39.8,
-            "edge": -11.3,
+            "odds": 2.7,
+            "implied": 37,
+            "edge": -8.5,
             "flag": null
           },
           "4.5": {
             "prob": 14,
-            "odds": 4.75,
-            "implied": 21.1,
-            "edge": -7.1,
+            "odds": 4.4,
+            "implied": 22.7,
+            "edge": -8.7,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 63.5,
-            "odds": 1.31,
-            "implied": 76.3,
-            "edge": -12.8,
+            "odds": 1.29,
+            "implied": 77.5,
+            "edge": -14,
             "flag": null
           },
           "9.5": {
             "prob": 53,
-            "odds": 1.57,
-            "implied": 63.7,
-            "edge": -10.7,
+            "odds": 1.79,
+            "implied": 55.9,
+            "edge": -2.9,
             "flag": null
           },
           "10.5": {
             "prob": 43,
-            "odds": 1.98,
-            "implied": 50.5,
-            "edge": -7.5,
+            "odds": 1.99,
+            "implied": 50.3,
+            "edge": -7.3,
             "flag": null
           },
           "11.5": {
             "prob": 36,
-            "odds": 2.53,
-            "implied": 39.5,
-            "edge": -3.5,
+            "odds": 2.2,
+            "implied": 45.5,
+            "edge": -9.5,
             "flag": null
           }
         },
@@ -2004,14 +2072,14 @@
       },
       "goals_odds": {
         "2.5": 1.76,
-        "3.5": 2.85,
-        "4.5": 5.87
+        "3.5": 3.12,
+        "4.5": 5.3
       },
       "corners_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 1.25,
+        "9.5": 1.63,
+        "10.5": 1.83,
+        "11.5": 2.28
       },
       "cards_odds": {
         "3.5": null,
@@ -2022,21 +2090,21 @@
       "goals_under_odds": {
         "0.5": 9.9,
         "1.5": 3.58,
-        "2.5": 1.95,
-        "3.5": 1.34
+        "2.5": 1.93,
+        "3.5": 1.33
       },
       "corners_under_odds": {
-        "8.5": null,
-        "9.5": null,
-        "10.5": null,
-        "11.5": null
+        "8.5": 3.26,
+        "9.5": 2.37,
+        "10.5": 1.87,
+        "11.5": 1.54
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.92,
+      "btts_no_odds": 1.89,
       "value": {
         "goals": {
           "2.5": {
@@ -2048,24 +2116,48 @@
           },
           "3.5": {
             "prob": 24,
-            "odds": 2.85,
-            "implied": 35.1,
-            "edge": -11.1,
+            "odds": 3.12,
+            "implied": 32.1,
+            "edge": -8.1,
             "flag": null
           },
           "4.5": {
             "prob": 7.5,
-            "odds": 5.87,
-            "implied": 17,
-            "edge": -9.5,
+            "odds": 5.3,
+            "implied": 18.9,
+            "edge": -11.4,
             "flag": null
           }
         },
         "corners": {
-          "8.5": null,
-          "9.5": null,
-          "10.5": null,
-          "11.5": null
+          "8.5": {
+            "prob": 63,
+            "odds": 1.25,
+            "implied": 80,
+            "edge": -17,
+            "flag": null
+          },
+          "9.5": {
+            "prob": 52,
+            "odds": 1.63,
+            "implied": 61.3,
+            "edge": -9.3,
+            "flag": null
+          },
+          "10.5": {
+            "prob": 39.5,
+            "odds": 1.83,
+            "implied": 54.6,
+            "edge": -15.1,
+            "flag": null
+          },
+          "11.5": {
+            "prob": 28,
+            "odds": 2.28,
+            "implied": 43.9,
+            "edge": -15.9,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 44.5,
@@ -2314,8 +2406,8 @@
         "5.5": 36
       },
       "goals_odds": {
-        "2.5": 1.67,
-        "3.5": 2.7,
+        "2.5": 1.7,
+        "3.5": 2.62,
         "4.5": 4.95
       },
       "corners_odds": {
@@ -2332,9 +2424,9 @@
       "btts_odds": 1.57,
       "goals_under_odds": {
         "0.5": 13.0,
-        "1.5": 4.05,
-        "2.5": 2.1,
-        "3.5": 1.43
+        "1.5": 4.1,
+        "2.5": 2.12,
+        "3.5": 1.37
       },
       "corners_under_odds": {
         "8.5": 2.55,
@@ -2352,16 +2444,16 @@
         "goals": {
           "2.5": {
             "prob": 69.5,
-            "odds": 1.67,
-            "implied": 59.9,
-            "edge": 9.6,
-            "flag": null
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": 10.7,
+            "flag": "value"
           },
           "3.5": {
             "prob": 27.5,
-            "odds": 2.7,
-            "implied": 37,
-            "edge": -9.5,
+            "odds": 2.62,
+            "implied": 38.2,
+            "edge": -10.7,
             "flag": null
           },
           "4.5": {
@@ -2658,99 +2750,99 @@
         "5.5": 34.5
       },
       "goals_odds": {
-        "2.5": 1.6,
-        "3.5": 2.52,
-        "4.5": 4.33
+        "2.5": 1.59,
+        "3.5": 2.35,
+        "4.5": 4.05
       },
       "corners_odds": {
-        "8.5": 1.38,
-        "9.5": 1.86,
-        "10.5": 2.08,
-        "11.5": 2.7
+        "8.5": 1.39,
+        "9.5": 1.88,
+        "10.5": 2.11,
+        "11.5": 2.78
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.6,
+      "btts_odds": 1.62,
       "goals_under_odds": {
-        "0.5": 15.0,
-        "1.5": 4.35,
-        "2.5": 2.3,
+        "0.5": 13.2,
+        "1.5": 4.33,
+        "2.5": 2.31,
         "3.5": 1.5
       },
       "corners_under_odds": {
-        "8.5": 2.7,
-        "9.5": 2.06,
-        "10.5": 1.66,
-        "11.5": 1.38
+        "8.5": 2.67,
+        "9.5": 2.03,
+        "10.5": 1.6,
+        "11.5": 1.49
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.2,
+      "btts_no_odds": 2.15,
       "value": {
         "goals": {
           "2.5": {
             "prob": 56.5,
-            "odds": 1.6,
-            "implied": 62.5,
-            "edge": -6,
+            "odds": 1.59,
+            "implied": 62.9,
+            "edge": -6.4,
             "flag": null
           },
           "3.5": {
             "prob": 37,
-            "odds": 2.52,
-            "implied": 39.7,
-            "edge": -2.7,
+            "odds": 2.35,
+            "implied": 42.6,
+            "edge": -5.6,
             "flag": null
           },
           "4.5": {
             "prob": 19.5,
-            "odds": 4.33,
-            "implied": 23.1,
-            "edge": -3.6,
+            "odds": 4.05,
+            "implied": 24.7,
+            "edge": -5.2,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 71.5,
-            "odds": 1.38,
-            "implied": 72.5,
-            "edge": -1,
+            "odds": 1.39,
+            "implied": 71.9,
+            "edge": -0.4,
             "flag": null
           },
           "9.5": {
             "prob": 63,
-            "odds": 1.86,
-            "implied": 53.8,
-            "edge": 9.2,
+            "odds": 1.88,
+            "implied": 53.2,
+            "edge": 9.8,
             "flag": null
           },
           "10.5": {
             "prob": 45.5,
-            "odds": 2.08,
-            "implied": 48.1,
-            "edge": -2.6,
+            "odds": 2.11,
+            "implied": 47.4,
+            "edge": -1.9,
             "flag": null
           },
           "11.5": {
             "prob": 32.5,
-            "odds": 2.7,
-            "implied": 37,
-            "edge": -4.5,
+            "odds": 2.78,
+            "implied": 36,
+            "edge": -3.5,
             "flag": null
           }
         },
         "btts": {
           "prob": 65.5,
-          "odds": 1.6,
-          "implied": 62.5,
-          "edge": 3,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": 3.8,
           "flag": null
         }
       },
@@ -3002,32 +3094,32 @@
         "5.5": 19.5
       },
       "goals_odds": {
-        "2.5": 1.8,
-        "3.5": 3.0,
-        "4.5": 5.42
+        "2.5": 1.75,
+        "3.5": 2.85,
+        "4.5": 5.2
       },
       "corners_odds": {
-        "8.5": 1.3,
-        "9.5": 1.65,
-        "10.5": 1.85,
-        "11.5": 2.32
+        "8.5": 1.27,
+        "9.5": 1.66,
+        "10.5": 1.86,
+        "11.5": 2.25
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.75,
+      "btts_odds": 1.8,
       "goals_under_odds": {
-        "0.5": 10.0,
+        "0.5": 9.5,
         "1.5": 3.75,
         "2.5": 1.95,
-        "3.5": 1.36
+        "3.5": 1.39
       },
       "corners_under_odds": {
-        "8.5": 3.18,
-        "9.5": 2.34,
-        "10.5": 1.85,
+        "8.5": 3.1,
+        "9.5": 2.33,
+        "10.5": 1.84,
         "11.5": 1.52
       },
       "cards_under_odds": {
@@ -3040,61 +3132,61 @@
         "goals": {
           "2.5": {
             "prob": 45.5,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": -10.1,
+            "odds": 1.75,
+            "implied": 57.1,
+            "edge": -11.6,
             "flag": null
           },
           "3.5": {
             "prob": 39,
-            "odds": 3.0,
-            "implied": 33.3,
-            "edge": 5.7,
+            "odds": 2.85,
+            "implied": 35.1,
+            "edge": 3.9,
             "flag": null
           },
           "4.5": {
             "prob": 26,
-            "odds": 5.42,
-            "implied": 18.5,
-            "edge": 7.5,
+            "odds": 5.2,
+            "implied": 19.2,
+            "edge": 6.8,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 76,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": -0.9,
+            "odds": 1.27,
+            "implied": 78.7,
+            "edge": -2.7,
             "flag": null
           },
           "9.5": {
             "prob": 61,
-            "odds": 1.65,
-            "implied": 60.6,
-            "edge": 0.4,
+            "odds": 1.66,
+            "implied": 60.2,
+            "edge": 0.8,
             "flag": null
           },
           "10.5": {
             "prob": 52,
-            "odds": 1.85,
-            "implied": 54.1,
-            "edge": -2.1,
+            "odds": 1.86,
+            "implied": 53.8,
+            "edge": -1.8,
             "flag": null
           },
           "11.5": {
             "prob": 41,
-            "odds": 2.32,
-            "implied": 43.1,
-            "edge": -2.1,
+            "odds": 2.25,
+            "implied": 44.4,
+            "edge": -3.4,
             "flag": null
           }
         },
         "btts": {
           "prob": 48,
-          "odds": 1.75,
-          "implied": 57.1,
-          "edge": -9.1,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": -7.6,
           "flag": null
         }
       },
@@ -3346,9 +3438,9 @@
         "5.5": 19
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 2.15,
+        "3.5": 4.0,
+        "4.5": 7.1
       },
       "corners_odds": {
         "8.5": null,
@@ -3361,12 +3453,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 2.12,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 7.0,
+        "1.5": 2.8,
+        "2.5": 1.62,
+        "3.5": 1.2
       },
       "corners_under_odds": {
         "8.5": null,
@@ -3379,12 +3471,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.64,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 42,
+            "odds": 2.15,
+            "implied": 46.5,
+            "edge": -4.5,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 15,
+            "odds": 4.0,
+            "implied": 25,
+            "edge": -10,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 4,
+            "odds": 7.1,
+            "implied": 14.1,
+            "edge": -10.1,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -3392,7 +3502,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 46,
+          "odds": 2.12,
+          "implied": 47.2,
+          "edge": -1.2,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -3624,8 +3740,8 @@
       },
       "goals_odds": {
         "2.5": 2.2,
-        "3.5": 4.25,
-        "4.5": 8.5
+        "3.5": 4.2,
+        "4.5": 8.1
       },
       "corners_odds": {
         "8.5": 1.92,
@@ -3638,11 +3754,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 2.25,
+      "btts_odds": 2.2,
       "goals_under_odds": {
-        "0.5": 8.5,
-        "1.5": 2.72,
-        "2.5": 1.65,
+        "0.5": 7.5,
+        "1.5": 2.7,
+        "2.5": 1.62,
         "3.5": 1.17
       },
       "corners_under_odds": {
@@ -3656,7 +3772,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.57,
+      "btts_no_odds": 1.58,
       "value": {
         "goals": {
           "2.5": {
@@ -3668,17 +3784,17 @@
           },
           "3.5": {
             "prob": 28.5,
-            "odds": 4.25,
-            "implied": 23.5,
-            "edge": 5,
+            "odds": 4.2,
+            "implied": 23.8,
+            "edge": 4.7,
             "flag": null
           },
           "4.5": {
             "prob": 22,
-            "odds": 8.5,
-            "implied": 11.8,
-            "edge": 10.2,
-            "flag": "value"
+            "odds": 8.1,
+            "implied": 12.3,
+            "edge": 9.7,
+            "flag": null
           }
         },
         "corners": {
@@ -3707,9 +3823,9 @@
         },
         "btts": {
           "prob": 31,
-          "odds": 2.25,
-          "implied": 44.4,
-          "edge": -13.4,
+          "odds": 2.2,
+          "implied": 45.5,
+          "edge": -14.5,
           "flag": null
         }
       },
@@ -4245,7 +4361,7 @@
         "5.5": 16
       },
       "goals_odds": {
-        "2.5": 1.95,
+        "2.5": 1.92,
         "3.5": 3.3,
         "4.5": 6.3
       },
@@ -4264,7 +4380,7 @@
       "goals_under_odds": {
         "0.5": 9.5,
         "1.5": 3.4,
-        "2.5": 1.85,
+        "2.5": 1.88,
         "3.5": 1.3
       },
       "corners_under_odds": {
@@ -4283,9 +4399,9 @@
         "goals": {
           "2.5": {
             "prob": 44,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -7.3,
+            "odds": 1.92,
+            "implied": 52.1,
+            "edge": -8.1,
             "flag": null
           },
           "3.5": {
@@ -4580,9 +4696,9 @@
         "5.5": 17
       },
       "goals_odds": {
-        "2.5": 1.99,
-        "3.5": 3.75,
-        "4.5": 6.8
+        "2.5": 2.03,
+        "3.5": 3.42,
+        "4.5": 6.7
       },
       "corners_odds": {
         "8.5": 1.91,
@@ -4595,12 +4711,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.77,
+      "btts_odds": 1.76,
       "goals_under_odds": {
-        "0.5": 8.5,
-        "1.5": 3.04,
-        "2.5": 1.72,
-        "3.5": 1.27
+        "0.5": 8.6,
+        "1.5": 3.05,
+        "2.5": 1.78,
+        "3.5": 1.23
       },
       "corners_under_odds": {
         "8.5": 1.8,
@@ -4613,28 +4729,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.92,
+      "btts_no_odds": 1.91,
       "value": {
         "goals": {
           "2.5": {
             "prob": 60,
-            "odds": 1.99,
-            "implied": 50.3,
-            "edge": 9.7,
-            "flag": null
+            "odds": 2.03,
+            "implied": 49.3,
+            "edge": 10.7,
+            "flag": "value"
           },
           "3.5": {
             "prob": 47,
-            "odds": 3.75,
-            "implied": 26.7,
-            "edge": 20.3,
-            "flag": "strong"
+            "odds": 3.42,
+            "implied": 29.2,
+            "edge": 17.8,
+            "flag": "value"
           },
           "4.5": {
             "prob": 13.5,
-            "odds": 6.8,
-            "implied": 14.7,
-            "edge": -1.2,
+            "odds": 6.7,
+            "implied": 14.9,
+            "edge": -1.4,
             "flag": null
           }
         },
@@ -4652,9 +4768,9 @@
         },
         "btts": {
           "prob": 73.5,
-          "odds": 1.77,
-          "implied": 56.5,
-          "edge": 17,
+          "odds": 1.76,
+          "implied": 56.8,
+          "edge": 16.7,
           "flag": "value"
         }
       },
@@ -4887,8 +5003,8 @@
         "5.5": 17
       },
       "goals_odds": {
-        "2.5": 1.75,
-        "3.5": 2.74,
+        "2.5": 1.69,
+        "3.5": 2.77,
         "4.5": 5.0
       },
       "corners_odds": {
@@ -4902,11 +5018,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.95,
+      "btts_odds": 1.85,
       "goals_under_odds": {
         "0.5": 12.0,
-        "1.5": 3.78,
-        "2.5": 2.05,
+        "1.5": 3.95,
+        "2.5": 2.1,
         "3.5": 1.36
       },
       "corners_under_odds": {
@@ -4925,16 +5041,16 @@
         "goals": {
           "2.5": {
             "prob": 53.5,
-            "odds": 1.75,
-            "implied": 57.1,
-            "edge": -3.6,
+            "odds": 1.69,
+            "implied": 59.2,
+            "edge": -5.7,
             "flag": null
           },
           "3.5": {
             "prob": 26.5,
-            "odds": 2.74,
-            "implied": 36.5,
-            "edge": -10,
+            "odds": 2.77,
+            "implied": 36.1,
+            "edge": -9.6,
             "flag": null
           },
           "4.5": {
@@ -4959,9 +5075,9 @@
         },
         "btts": {
           "prob": 53.5,
-          "odds": 1.95,
-          "implied": 51.3,
-          "edge": 2.2,
+          "odds": 1.85,
+          "implied": 54.1,
+          "edge": -0.6,
           "flag": null
         }
       },
@@ -5194,9 +5310,9 @@
         "5.5": 23.5
       },
       "goals_odds": {
-        "2.5": 2.05,
-        "3.5": 3.8,
-        "4.5": 6.9
+        "2.5": 2.06,
+        "3.5": 3.85,
+        "4.5": 6.85
       },
       "corners_odds": {
         "8.5": 1.85,
@@ -5212,8 +5328,8 @@
       "btts_odds": 1.85,
       "goals_under_odds": {
         "0.5": 8.5,
-        "1.5": 3.0,
-        "2.5": 1.67,
+        "1.5": 2.88,
+        "2.5": 1.7,
         "3.5": 1.22
       },
       "corners_under_odds": {
@@ -5232,23 +5348,23 @@
         "goals": {
           "2.5": {
             "prob": 47,
-            "odds": 2.05,
-            "implied": 48.8,
-            "edge": -1.8,
+            "odds": 2.06,
+            "implied": 48.5,
+            "edge": -1.5,
             "flag": null
           },
           "3.5": {
             "prob": 33,
-            "odds": 3.8,
-            "implied": 26.3,
-            "edge": 6.7,
+            "odds": 3.85,
+            "implied": 26,
+            "edge": 7,
             "flag": null
           },
           "4.5": {
             "prob": 16.5,
-            "odds": 6.9,
-            "implied": 14.5,
-            "edge": 2,
+            "odds": 6.85,
+            "implied": 14.6,
+            "edge": 1.9,
             "flag": null
           }
         },
@@ -5503,7 +5619,7 @@
       "goals_odds": {
         "2.5": 1.95,
         "3.5": 3.5,
-        "4.5": 6.7
+        "4.5": 6.6
       },
       "corners_odds": {
         "8.5": 1.85,
@@ -5516,12 +5632,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.75,
+      "btts_odds": 1.8,
       "goals_under_odds": {
         "0.5": 9.0,
-        "1.5": 3.14,
-        "2.5": 1.8,
-        "3.5": 1.24
+        "1.5": 3.25,
+        "2.5": 1.85,
+        "3.5": 1.29
       },
       "corners_under_odds": {
         "8.5": 1.85,
@@ -5534,7 +5650,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.95,
+      "btts_no_odds": 2.0,
       "value": {
         "goals": {
           "2.5": {
@@ -5553,9 +5669,9 @@
           },
           "4.5": {
             "prob": 16.5,
-            "odds": 6.7,
-            "implied": 14.9,
-            "edge": 1.6,
+            "odds": 6.6,
+            "implied": 15.2,
+            "edge": 1.3,
             "flag": null
           }
         },
@@ -5573,9 +5689,9 @@
         },
         "btts": {
           "prob": 63.5,
-          "odds": 1.75,
-          "implied": 57.1,
-          "edge": 6.4,
+          "odds": 1.8,
+          "implied": 55.6,
+          "edge": 7.9,
           "flag": null
         }
       },
@@ -5808,13 +5924,13 @@
         "5.5": 15
       },
       "goals_odds": {
-        "2.5": 1.73,
-        "3.5": 2.75,
-        "4.5": 5.0
+        "2.5": 1.75,
+        "3.5": 2.7,
+        "4.5": 5.2
       },
       "corners_odds": {
         "8.5": 1.41,
-        "9.5": 1.93,
+        "9.5": 1.67,
         "10.5": 2.15,
         "11.5": 2.82
       },
@@ -5823,12 +5939,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.57,
+      "btts_odds": 1.62,
       "goals_under_odds": {
-        "0.5": 14.7,
-        "1.5": 5.12,
-        "2.5": 2.0,
-        "3.5": 1.4
+        "0.5": 14.3,
+        "1.5": 3.9,
+        "2.5": 2.08,
+        "3.5": 1.36
       },
       "corners_under_odds": {
         "8.5": 2.6,
@@ -5841,28 +5957,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.23,
+      "btts_no_odds": 2.2,
       "value": {
         "goals": {
           "2.5": {
             "prob": 59,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": 1.2,
+            "odds": 1.75,
+            "implied": 57.1,
+            "edge": 1.9,
             "flag": null
           },
           "3.5": {
             "prob": 29.5,
-            "odds": 2.75,
-            "implied": 36.4,
-            "edge": -6.9,
+            "odds": 2.7,
+            "implied": 37,
+            "edge": -7.5,
             "flag": null
           },
           "4.5": {
             "prob": 12,
-            "odds": 5.0,
-            "implied": 20,
-            "edge": -8,
+            "odds": 5.2,
+            "implied": 19.2,
+            "edge": -7.2,
             "flag": null
           }
         },
@@ -5876,9 +5992,9 @@
           },
           "9.5": {
             "prob": 41,
-            "odds": 1.93,
-            "implied": 51.8,
-            "edge": -10.8,
+            "odds": 1.67,
+            "implied": 59.9,
+            "edge": -18.9,
             "flag": null
           },
           "10.5": {
@@ -5898,9 +6014,9 @@
         },
         "btts": {
           "prob": 62,
-          "odds": 1.57,
-          "implied": 63.7,
-          "edge": -1.7,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": 0.3,
           "flag": null
         }
       },
@@ -6143,99 +6259,99 @@
         "5.5": 34.5
       },
       "goals_odds": {
-        "2.5": 1.44,
-        "3.5": 2.15,
-        "4.5": 3.2
+        "2.5": 1.4,
+        "3.5": 2.0,
+        "4.5": 3.34
       },
       "corners_odds": {
-        "8.5": 1.43,
-        "9.5": 1.97,
-        "10.5": 2.2,
-        "11.5": 2.9
+        "8.5": 1.4,
+        "9.5": 2.0,
+        "10.5": 2.23,
+        "11.5": 2.7
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.5,
+      "btts_odds": 1.55,
       "goals_under_odds": {
-        "0.5": 23.0,
+        "0.5": 21.0,
         "1.5": 5.5,
-        "2.5": 2.7,
-        "3.5": 1.74
+        "2.5": 2.85,
+        "3.5": 1.7
       },
       "corners_under_odds": {
-        "8.5": 2.54,
-        "9.5": 1.95,
-        "10.5": 1.58,
-        "11.5": 1.38
+        "8.5": 2.6,
+        "9.5": 1.93,
+        "10.5": 1.63,
+        "11.5": 1.31
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.45,
+      "btts_no_odds": 2.3,
       "value": {
         "goals": {
           "2.5": {
             "prob": 59,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": -10.4,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -12.4,
             "flag": null
           },
           "3.5": {
             "prob": 47,
-            "odds": 2.15,
-            "implied": 46.5,
-            "edge": 0.5,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": -3,
             "flag": null
           },
           "4.5": {
             "prob": 26.5,
-            "odds": 3.2,
-            "implied": 31.2,
-            "edge": -4.7,
+            "odds": 3.34,
+            "implied": 29.9,
+            "edge": -3.4,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 62,
-            "odds": 1.43,
-            "implied": 69.9,
-            "edge": -7.9,
+            "odds": 1.4,
+            "implied": 71.4,
+            "edge": -9.4,
             "flag": null
           },
           "9.5": {
             "prob": 50,
-            "odds": 1.97,
-            "implied": 50.8,
-            "edge": -0.8,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": 0,
             "flag": null
           },
           "10.5": {
             "prob": 44,
-            "odds": 2.2,
-            "implied": 45.5,
-            "edge": -1.5,
+            "odds": 2.23,
+            "implied": 44.8,
+            "edge": -0.8,
             "flag": null
           },
           "11.5": {
             "prob": 41,
-            "odds": 2.9,
-            "implied": 34.5,
-            "edge": 6.5,
+            "odds": 2.7,
+            "implied": 37,
+            "edge": 4,
             "flag": null
           }
         },
         "btts": {
           "prob": 62,
-          "odds": 1.5,
-          "implied": 66.7,
-          "edge": -4.7,
+          "odds": 1.55,
+          "implied": 64.5,
+          "edge": -2.5,
           "flag": null
         }
       },
@@ -6478,9 +6594,9 @@
         "5.5": 19.5
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 2.12,
+        "3.5": 3.9,
+        "4.5": 8.0
       },
       "corners_odds": {
         "8.5": null,
@@ -6493,12 +6609,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.75,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 7.5,
+        "1.5": 2.83,
+        "2.5": 1.62,
+        "3.5": 1.2
       },
       "corners_under_odds": {
         "8.5": null,
@@ -6511,12 +6627,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.85,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 50,
+            "odds": 2.12,
+            "implied": 47.2,
+            "edge": 2.8,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 26.5,
+            "odds": 3.9,
+            "implied": 25.6,
+            "edge": 0.9,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 15.5,
+            "odds": 8.0,
+            "implied": 12.5,
+            "edge": 3,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -6524,7 +6658,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 62,
+          "odds": 1.75,
+          "implied": 57.1,
+          "edge": 4.9,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -6755,9 +6895,9 @@
         "5.5": 19.5
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 2.0,
+        "3.5": 3.5,
+        "4.5": 7.0
       },
       "corners_odds": {
         "8.5": null,
@@ -6770,12 +6910,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.75,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 8.5,
+        "1.5": 3.1,
+        "2.5": 1.7,
+        "3.5": 1.25
       },
       "corners_under_odds": {
         "8.5": null,
@@ -6788,12 +6928,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.91,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 48,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": -2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 24,
+            "odds": 3.5,
+            "implied": 28.6,
+            "edge": -4.6,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 8.5,
+            "odds": 7.0,
+            "implied": 14.3,
+            "edge": -5.8,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -6801,7 +6959,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 64.5,
+          "odds": 1.75,
+          "implied": 57.1,
+          "edge": 7.4,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -7032,9 +7196,9 @@
         "5.5": 16
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 1.62,
+        "3.5": 2.63,
+        "4.5": 3.9
       },
       "corners_odds": {
         "8.5": null,
@@ -7047,12 +7211,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.7,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 11.6,
+        "1.5": 4.0,
+        "2.5": 2.2,
+        "3.5": 1.4
       },
       "corners_under_odds": {
         "8.5": null,
@@ -7065,12 +7229,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 2.0,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 55.5,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": -6.2,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 19.5,
+            "odds": 2.63,
+            "implied": 38,
+            "edge": -18.5,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 8,
+            "odds": 3.9,
+            "implied": 25.6,
+            "edge": -17.6,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -7078,7 +7260,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 48,
+          "odds": 1.7,
+          "implied": 58.8,
+          "edge": -10.8,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -7309,9 +7497,9 @@
         "5.5": 37.5
       },
       "goals_odds": {
-        "2.5": 1.65,
+        "2.5": 1.7,
         "3.5": 2.49,
-        "4.5": 4.4
+        "4.5": 5.0
       },
       "corners_odds": {
         "8.5": null,
@@ -7324,11 +7512,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.52,
+      "btts_odds": 1.48,
       "goals_under_odds": {
         "0.5": 11.5,
-        "1.5": 4.05,
-        "2.5": 2.14,
+        "1.5": 4.25,
+        "2.5": 2.1,
         "3.5": 1.42
       },
       "corners_under_odds": {
@@ -7342,14 +7530,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.34,
+      "btts_no_odds": 2.38,
       "value": {
         "goals": {
           "2.5": {
             "prob": 57,
-            "odds": 1.65,
-            "implied": 60.6,
-            "edge": -3.6,
+            "odds": 1.7,
+            "implied": 58.8,
+            "edge": -1.8,
             "flag": null
           },
           "3.5": {
@@ -7361,9 +7549,9 @@
           },
           "4.5": {
             "prob": 20,
-            "odds": 4.4,
-            "implied": 22.7,
-            "edge": -2.7,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": 0,
             "flag": null
           }
         },
@@ -7393,9 +7581,9 @@
         },
         "btts": {
           "prob": 54,
-          "odds": 1.52,
-          "implied": 65.8,
-          "edge": -11.8,
+          "odds": 1.48,
+          "implied": 67.6,
+          "edge": -13.6,
           "flag": null
         }
       },
@@ -7647,9 +7835,9 @@
         "5.5": 19
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 1.73,
+        "3.5": 2.88,
+        "4.5": 5.0
       },
       "corners_odds": {
         "8.5": null,
@@ -7662,12 +7850,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 2.05,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 11.0,
+        "1.5": 3.75,
+        "2.5": 1.95,
+        "3.5": 1.33
       },
       "corners_under_odds": {
         "8.5": null,
@@ -7680,12 +7868,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.67,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 50,
+            "odds": 1.73,
+            "implied": 57.8,
+            "edge": -7.8,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 19,
+            "odds": 2.88,
+            "implied": 34.7,
+            "edge": -15.7,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 7.5,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -12.5,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -7693,7 +7899,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 50,
+          "odds": 2.05,
+          "implied": 48.8,
+          "edge": 1.2,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -7924,32 +8136,32 @@
         "5.5": 21
       },
       "goals_odds": {
-        "2.5": 1.82,
-        "3.5": 2.88,
-        "4.5": 6.0
+        "2.5": 1.8,
+        "3.5": 3.0,
+        "4.5": 7.8
       },
       "corners_odds": {
-        "8.5": 1.36,
+        "8.5": 1.38,
         "9.5": 1.87,
         "10.5": 2.09,
-        "11.5": 2.72
+        "11.5": 2.56
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.61,
+      "btts_odds": 1.62,
       "goals_under_odds": {
-        "0.5": 10.5,
-        "1.5": 3.94,
-        "2.5": 2.01,
+        "0.5": 28.0,
+        "1.5": 4.54,
+        "2.5": 2.0,
         "3.5": 1.38
       },
       "corners_under_odds": {
-        "8.5": 2.85,
-        "9.5": 2.15,
-        "10.5": 1.73,
+        "8.5": 2.69,
+        "9.5": 2.05,
+        "10.5": 1.65,
         "11.5": 1.37
       },
       "cards_under_odds": {
@@ -7962,32 +8174,32 @@
         "goals": {
           "2.5": {
             "prob": 47,
-            "odds": 1.82,
-            "implied": 54.9,
-            "edge": -7.9,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": -8.6,
             "flag": null
           },
           "3.5": {
             "prob": 32,
-            "odds": 2.88,
-            "implied": 34.7,
-            "edge": -2.7,
+            "odds": 3.0,
+            "implied": 33.3,
+            "edge": -1.3,
             "flag": null
           },
           "4.5": {
             "prob": 26.5,
-            "odds": 6.0,
-            "implied": 16.7,
-            "edge": 9.8,
-            "flag": null
+            "odds": 7.8,
+            "implied": 12.8,
+            "edge": 13.7,
+            "flag": "value"
           }
         },
         "corners": {
           "8.5": {
             "prob": 76.5,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": 3,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": 4,
             "flag": null
           },
           "9.5": {
@@ -8006,17 +8218,17 @@
           },
           "11.5": {
             "prob": 43.5,
-            "odds": 2.72,
-            "implied": 36.8,
-            "edge": 6.7,
+            "odds": 2.56,
+            "implied": 39.1,
+            "edge": 4.4,
             "flag": null
           }
         },
         "btts": {
           "prob": 67.5,
-          "odds": 1.61,
-          "implied": 62.1,
-          "edge": 5.4,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": 5.8,
           "flag": null
         }
       },
@@ -8260,12 +8472,12 @@
       },
       "goals_odds": {
         "2.5": 1.4,
-        "3.5": 1.95,
-        "4.5": 3.14
+        "3.5": 1.96,
+        "4.5": 3.05
       },
       "corners_odds": {
-        "8.5": 1.29,
-        "9.5": 1.64,
+        "8.5": 1.26,
+        "9.5": 1.48,
         "10.5": 1.84,
         "11.5": 2.3
       },
@@ -8274,16 +8486,16 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.33,
+      "btts_odds": 1.36,
       "goals_under_odds": {
-        "0.5": 26.0,
+        "0.5": 21.0,
         "1.5": 6.0,
-        "2.5": 2.87,
-        "3.5": 1.75
+        "2.5": 2.9,
+        "3.5": 1.76
       },
       "corners_under_odds": {
-        "8.5": 3.2,
-        "9.5": 2.43,
+        "8.5": 3.23,
+        "9.5": 2.36,
         "10.5": 1.86,
         "11.5": 1.53
       },
@@ -8292,7 +8504,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.9,
+      "btts_no_odds": 2.98,
       "value": {
         "goals": {
           "2.5": {
@@ -8304,32 +8516,32 @@
           },
           "3.5": {
             "prob": 44,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -7.3,
+            "odds": 1.96,
+            "implied": 51,
+            "edge": -7,
             "flag": null
           },
           "4.5": {
             "prob": 29.5,
-            "odds": 3.14,
-            "implied": 31.8,
-            "edge": -2.3,
+            "odds": 3.05,
+            "implied": 32.8,
+            "edge": -3.3,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 79,
-            "odds": 1.29,
-            "implied": 77.5,
-            "edge": 1.5,
+            "odds": 1.26,
+            "implied": 79.4,
+            "edge": -0.4,
             "flag": null
           },
           "9.5": {
             "prob": 65,
-            "odds": 1.64,
-            "implied": 61,
-            "edge": 4,
+            "odds": 1.48,
+            "implied": 67.6,
+            "edge": -2.6,
             "flag": null
           },
           "10.5": {
@@ -8349,9 +8561,9 @@
         },
         "btts": {
           "prob": 70.5,
-          "odds": 1.33,
-          "implied": 75.2,
-          "edge": -4.7,
+          "odds": 1.36,
+          "implied": 73.5,
+          "edge": -3,
           "flag": null
         }
       },
@@ -8594,9 +8806,9 @@
         "5.5": 22.5
       },
       "goals_odds": {
-        "2.5": 1.8,
+        "2.5": 1.76,
         "3.5": 2.88,
-        "4.5": 5.3
+        "4.5": 5.0
       },
       "corners_odds": {
         "8.5": 1.38,
@@ -8609,12 +8821,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.62,
+      "btts_odds": 1.58,
       "goals_under_odds": {
-        "0.5": 11.0,
-        "1.5": 3.8,
-        "2.5": 2.0,
-        "3.5": 1.36
+        "0.5": 10.6,
+        "1.5": 3.76,
+        "2.5": 2.08,
+        "3.5": 1.35
       },
       "corners_under_odds": {
         "8.5": 2.75,
@@ -8627,14 +8839,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.2,
+      "btts_no_odds": 2.21,
       "value": {
         "goals": {
           "2.5": {
             "prob": 59,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 3.4,
+            "odds": 1.76,
+            "implied": 56.8,
+            "edge": 2.2,
             "flag": null
           },
           "3.5": {
@@ -8646,9 +8858,9 @@
           },
           "4.5": {
             "prob": 4.5,
-            "odds": 5.3,
-            "implied": 18.9,
-            "edge": -14.4,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -15.5,
             "flag": null
           }
         },
@@ -8684,9 +8896,9 @@
         },
         "btts": {
           "prob": 59,
-          "odds": 1.62,
-          "implied": 61.7,
-          "edge": -2.7,
+          "odds": 1.58,
+          "implied": 63.3,
+          "edge": -4.3,
           "flag": null
         }
       },
@@ -8919,14 +9131,14 @@
         "5.5": 24.5
       },
       "goals_odds": {
-        "2.5": 1.66,
-        "3.5": 2.72,
+        "2.5": 1.65,
+        "3.5": 2.6,
         "4.5": 4.8
       },
       "corners_odds": {
-        "8.5": 1.36,
-        "9.5": 1.66,
-        "10.5": 2.08,
+        "8.5": 1.38,
+        "9.5": 1.64,
+        "10.5": 2.02,
         "11.5": 2.7
       },
       "cards_odds": {
@@ -8934,17 +9146,17 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.57,
+      "btts_odds": 1.6,
       "goals_under_odds": {
         "0.5": 13.0,
         "1.5": 4.2,
         "2.5": 2.15,
-        "3.5": 1.46
+        "3.5": 1.44
       },
       "corners_under_odds": {
-        "8.5": 2.75,
-        "9.5": 2.06,
-        "10.5": 1.62,
+        "8.5": 2.7,
+        "9.5": 2.08,
+        "10.5": 1.7,
         "11.5": 1.36
       },
       "cards_under_odds": {
@@ -8952,21 +9164,21 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 2.26,
       "value": {
         "goals": {
           "2.5": {
             "prob": 46.5,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -13.7,
+            "odds": 1.65,
+            "implied": 60.6,
+            "edge": -14.1,
             "flag": null
           },
           "3.5": {
             "prob": 25,
-            "odds": 2.72,
-            "implied": 36.8,
-            "edge": -11.8,
+            "odds": 2.6,
+            "implied": 38.5,
+            "edge": -13.5,
             "flag": null
           },
           "4.5": {
@@ -8980,23 +9192,23 @@
         "corners": {
           "8.5": {
             "prob": 63.5,
-            "odds": 1.36,
-            "implied": 73.5,
-            "edge": -10,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": -9,
             "flag": null
           },
           "9.5": {
             "prob": 50,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -10.2,
+            "odds": 1.64,
+            "implied": 61,
+            "edge": -11,
             "flag": null
           },
           "10.5": {
             "prob": 46.5,
-            "odds": 2.08,
-            "implied": 48.1,
-            "edge": -1.6,
+            "odds": 2.02,
+            "implied": 49.5,
+            "edge": -3,
             "flag": null
           },
           "11.5": {
@@ -9009,9 +9221,9 @@
         },
         "btts": {
           "prob": 46.5,
-          "odds": 1.57,
-          "implied": 63.7,
-          "edge": -17.2,
+          "odds": 1.6,
+          "implied": 62.5,
+          "edge": -16,
           "flag": null
         }
       },
@@ -9254,33 +9466,33 @@
         "5.5": 32.5
       },
       "goals_odds": {
-        "2.5": 1.65,
+        "2.5": 1.62,
         "3.5": 2.63,
-        "4.5": 6.12
+        "4.5": 4.5
       },
       "corners_odds": {
-        "8.5": 1.41,
-        "9.5": 1.96,
-        "10.5": 2.19,
-        "11.5": 2.88
+        "8.5": 1.43,
+        "9.5": 1.97,
+        "10.5": 2.18,
+        "11.5": 2.9
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.85,
+      "btts_odds": 1.94,
       "goals_under_odds": {
-        "0.5": 9.0,
-        "1.5": 4.33,
-        "2.5": 2.2,
+        "0.5": 13.0,
+        "1.5": 4.0,
+        "2.5": 2.23,
         "3.5": 1.44
       },
       "corners_under_odds": {
-        "8.5": 2.56,
-        "9.5": 1.96,
-        "10.5": 1.59,
-        "11.5": 1.42
+        "8.5": 2.54,
+        "9.5": 1.95,
+        "10.5": 1.56,
+        "11.5": 1.32
       },
       "cards_under_odds": {
         "2.5": null,
@@ -9292,9 +9504,9 @@
         "goals": {
           "2.5": {
             "prob": 50,
-            "odds": 1.65,
-            "implied": 60.6,
-            "edge": -10.6,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": -11.7,
             "flag": null
           },
           "3.5": {
@@ -9306,47 +9518,47 @@
           },
           "4.5": {
             "prob": 20.5,
-            "odds": 6.12,
-            "implied": 16.3,
-            "edge": 4.2,
+            "odds": 4.5,
+            "implied": 22.2,
+            "edge": -1.7,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 65,
-            "odds": 1.41,
-            "implied": 70.9,
-            "edge": -5.9,
+            "odds": 1.43,
+            "implied": 69.9,
+            "edge": -4.9,
             "flag": null
           },
           "9.5": {
             "prob": 50,
-            "odds": 1.96,
-            "implied": 51,
-            "edge": -1,
+            "odds": 1.97,
+            "implied": 50.8,
+            "edge": -0.8,
             "flag": null
           },
           "10.5": {
             "prob": 47,
-            "odds": 2.19,
-            "implied": 45.7,
-            "edge": 1.3,
+            "odds": 2.18,
+            "implied": 45.9,
+            "edge": 1.1,
             "flag": null
           },
           "11.5": {
             "prob": 41,
-            "odds": 2.88,
-            "implied": 34.7,
-            "edge": 6.3,
+            "odds": 2.9,
+            "implied": 34.5,
+            "edge": 6.5,
             "flag": null
           }
         },
         "btts": {
           "prob": 53,
-          "odds": 1.85,
-          "implied": 54.1,
-          "edge": -1.1,
+          "odds": 1.94,
+          "implied": 51.5,
+          "edge": 1.5,
           "flag": null
         }
       },
@@ -9589,13 +9801,13 @@
         "5.5": 27
       },
       "goals_odds": {
-        "2.5": 1.73,
-        "3.5": 2.8,
-        "4.5": 4.95
+        "2.5": 1.76,
+        "3.5": 2.76,
+        "4.5": 5.25
       },
       "corners_odds": {
         "8.5": 1.38,
-        "9.5": 1.63,
+        "9.5": 1.62,
         "10.5": 1.98,
         "11.5": 2.5
       },
@@ -9606,14 +9818,14 @@
       },
       "btts_odds": 1.62,
       "goals_under_odds": {
-        "0.5": 10.0,
-        "1.5": 4.0,
-        "2.5": 2.05,
-        "3.5": 1.36
+        "0.5": 12.0,
+        "1.5": 3.62,
+        "2.5": 2.08,
+        "3.5": 1.35
       },
       "corners_under_odds": {
         "8.5": 2.75,
-        "9.5": 2.1,
+        "9.5": 2.12,
         "10.5": 1.71,
         "11.5": 1.45
       },
@@ -9627,23 +9839,23 @@
         "goals": {
           "2.5": {
             "prob": 54.5,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": -3.3,
+            "odds": 1.76,
+            "implied": 56.8,
+            "edge": -2.3,
             "flag": null
           },
           "3.5": {
             "prob": 22.5,
-            "odds": 2.8,
-            "implied": 35.7,
-            "edge": -13.2,
+            "odds": 2.76,
+            "implied": 36.2,
+            "edge": -13.7,
             "flag": null
           },
           "4.5": {
             "prob": 18,
-            "odds": 4.95,
-            "implied": 20.2,
-            "edge": -2.2,
+            "odds": 5.25,
+            "implied": 19,
+            "edge": -1,
             "flag": null
           }
         },
@@ -9657,9 +9869,9 @@
           },
           "9.5": {
             "prob": 50,
-            "odds": 1.63,
-            "implied": 61.3,
-            "edge": -11.3,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": -11.7,
             "flag": null
           },
           "10.5": {
@@ -9929,11 +10141,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.62,
+      "btts_odds": 1.63,
       "goals_under_odds": {
         "0.5": 11.0,
-        "1.5": 3.54,
-        "2.5": 1.95,
+        "1.5": 3.5,
+        "2.5": 1.89,
         "3.5": 1.32
       },
       "corners_under_odds": {
@@ -9947,7 +10159,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.14,
+      "btts_no_odds": 2.12,
       "value": {
         "goals": {
           "2.5": {
@@ -9980,9 +10192,9 @@
         },
         "btts": {
           "prob": 26.5,
-          "odds": 1.62,
-          "implied": 61.7,
-          "edge": -35.2,
+          "odds": 1.63,
+          "implied": 61.3,
+          "edge": -34.8,
           "flag": null
         }
       },
@@ -10225,7 +10437,7 @@
         "5.5": 19.5
       },
       "goals_odds": {
-        "2.5": 1.48,
+        "2.5": 1.5,
         "3.5": 2.23,
         "4.5": 4.35
       },
@@ -10240,12 +10452,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.59,
+      "btts_odds": 1.65,
       "goals_under_odds": {
         "0.5": 13.3,
         "1.5": 4.65,
-        "2.5": 2.35,
-        "3.5": 1.52
+        "2.5": 2.3,
+        "3.5": 1.53
       },
       "corners_under_odds": {
         "8.5": null,
@@ -10258,14 +10470,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.19,
+      "btts_no_odds": 2.1,
       "value": {
         "goals": {
           "2.5": {
             "prob": 57.5,
-            "odds": 1.48,
-            "implied": 67.6,
-            "edge": -10.1,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": -9.2,
             "flag": null
           },
           "3.5": {
@@ -10291,9 +10503,9 @@
         },
         "btts": {
           "prob": 50,
-          "odds": 1.59,
-          "implied": 62.9,
-          "edge": -12.9,
+          "odds": 1.65,
+          "implied": 60.6,
+          "edge": -10.6,
           "flag": null
         }
       },
@@ -10536,14 +10748,14 @@
         "5.5": 13.5
       },
       "goals_odds": {
-        "2.5": 1.54,
-        "3.5": 2.33,
-        "4.5": 3.9
+        "2.5": 1.55,
+        "3.5": 2.32,
+        "4.5": 4.2
       },
       "corners_odds": {
         "8.5": 1.28,
         "9.5": 1.47,
-        "10.5": 1.76,
+        "10.5": 1.8,
         "11.5": 2.16
       },
       "cards_odds": {
@@ -10551,17 +10763,17 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.44,
+      "btts_odds": 1.45,
       "goals_under_odds": {
-        "0.5": 15.0,
+        "0.5": 13.7,
         "1.5": 5.0,
-        "2.5": 2.4,
-        "3.5": 1.57
+        "2.5": 2.38,
+        "3.5": 1.61
       },
       "corners_under_odds": {
         "8.5": 3.3,
         "9.5": 2.45,
-        "10.5": 1.93,
+        "10.5": 1.91,
         "11.5": 1.6
       },
       "cards_under_odds": {
@@ -10569,28 +10781,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.63,
+      "btts_no_odds": 2.5,
       "value": {
         "goals": {
           "2.5": {
             "prob": 54.5,
-            "odds": 1.54,
-            "implied": 64.9,
-            "edge": -10.4,
+            "odds": 1.55,
+            "implied": 64.5,
+            "edge": -10,
             "flag": null
           },
           "3.5": {
             "prob": 36,
-            "odds": 2.33,
-            "implied": 42.9,
-            "edge": -6.9,
+            "odds": 2.32,
+            "implied": 43.1,
+            "edge": -7.1,
             "flag": null
           },
           "4.5": {
             "prob": 22.5,
-            "odds": 3.9,
-            "implied": 25.6,
-            "edge": -3.1,
+            "odds": 4.2,
+            "implied": 23.8,
+            "edge": -1.3,
             "flag": null
           }
         },
@@ -10611,9 +10823,9 @@
           },
           "10.5": {
             "prob": 50,
-            "odds": 1.76,
-            "implied": 56.8,
-            "edge": -6.8,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": -5.6,
             "flag": null
           },
           "11.5": {
@@ -10626,9 +10838,9 @@
         },
         "btts": {
           "prob": 68.5,
-          "odds": 1.44,
-          "implied": 69.4,
-          "edge": -0.9,
+          "odds": 1.45,
+          "implied": 69,
+          "edge": -0.5,
           "flag": null
         }
       },
@@ -10861,7 +11073,7 @@
         "5.5": 25
       },
       "goals_odds": {
-        "2.5": 1.9,
+        "2.5": 1.93,
         "3.5": 3.2,
         "4.5": 6.0
       },
@@ -10876,11 +11088,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.6,
+      "btts_odds": 1.67,
       "goals_under_odds": {
-        "0.5": 10.0,
-        "1.5": 3.5,
-        "2.5": 1.9,
+        "0.5": 8.5,
+        "1.5": 3.69,
+        "2.5": 1.91,
         "3.5": 1.3
       },
       "corners_under_odds": {
@@ -10899,9 +11111,9 @@
         "goals": {
           "2.5": {
             "prob": 43,
-            "odds": 1.9,
-            "implied": 52.6,
-            "edge": -9.6,
+            "odds": 1.93,
+            "implied": 51.8,
+            "edge": -8.8,
             "flag": null
           },
           "3.5": {
@@ -10951,9 +11163,9 @@
         },
         "btts": {
           "prob": 53.5,
-          "odds": 1.6,
-          "implied": 62.5,
-          "edge": -9,
+          "odds": 1.67,
+          "implied": 59.9,
+          "edge": -6.4,
           "flag": null
         }
       },
@@ -11196,14 +11408,14 @@
         "5.5": 14
       },
       "goals_odds": {
-        "2.5": 1.53,
-        "3.5": 2.21,
+        "2.5": 1.5,
+        "3.5": 2.31,
         "4.5": 3.85
       },
       "corners_odds": {
-        "8.5": 1.32,
-        "9.5": 1.57,
-        "10.5": 1.98,
+        "8.5": 1.35,
+        "9.5": 1.58,
+        "10.5": 1.91,
         "11.5": 2.53
       },
       "cards_odds": {
@@ -11214,14 +11426,14 @@
       "btts_odds": 1.79,
       "goals_under_odds": {
         "0.5": 14.4,
-        "1.5": 5.2,
-        "2.5": 2.4,
-        "3.5": 1.59
+        "1.5": 5.0,
+        "2.5": 2.38,
+        "3.5": 1.55
       },
       "corners_under_odds": {
         "8.5": 2.88,
-        "9.5": 2.16,
-        "10.5": 1.72,
+        "9.5": 2.2,
+        "10.5": 1.77,
         "11.5": 1.42
       },
       "cards_under_odds": {
@@ -11229,21 +11441,21 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.95,
+      "btts_no_odds": 1.92,
       "value": {
         "goals": {
           "2.5": {
             "prob": 43,
-            "odds": 1.53,
-            "implied": 65.4,
-            "edge": -22.4,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": -23.7,
             "flag": null
           },
           "3.5": {
             "prob": 21,
-            "odds": 2.21,
-            "implied": 45.2,
-            "edge": -24.2,
+            "odds": 2.31,
+            "implied": 43.3,
+            "edge": -22.3,
             "flag": null
           },
           "4.5": {
@@ -11257,23 +11469,23 @@
         "corners": {
           "8.5": {
             "prob": 71,
-            "odds": 1.32,
-            "implied": 75.8,
-            "edge": -4.8,
+            "odds": 1.35,
+            "implied": 74.1,
+            "edge": -3.1,
             "flag": null
           },
           "9.5": {
             "prob": 56,
-            "odds": 1.57,
-            "implied": 63.7,
-            "edge": -7.7,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": -7.3,
             "flag": null
           },
           "10.5": {
             "prob": 46.5,
-            "odds": 1.98,
-            "implied": 50.5,
-            "edge": -4,
+            "odds": 1.91,
+            "implied": 52.4,
+            "edge": -5.9,
             "flag": null
           },
           "11.5": {
@@ -11531,33 +11743,33 @@
         "5.5": 19.5
       },
       "goals_odds": {
-        "2.5": 1.42,
-        "3.5": 2.14,
-        "4.5": 3.35
+        "2.5": 1.57,
+        "3.5": 2.32,
+        "4.5": 3.6
       },
       "corners_odds": {
         "8.5": null,
-        "9.5": 1.46,
-        "10.5": 1.73,
-        "11.5": 2.14
+        "9.5": 1.49,
+        "10.5": 1.78,
+        "11.5": 2.2
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.44,
+      "btts_odds": 1.5,
       "goals_under_odds": {
-        "0.5": 14.5,
-        "1.5": 5.3,
-        "2.5": 2.5,
-        "3.5": 1.63
+        "0.5": 17.0,
+        "1.5": 4.8,
+        "2.5": 2.35,
+        "3.5": 1.53
       },
       "corners_under_odds": {
         "8.5": null,
-        "9.5": 2.45,
-        "10.5": 1.94,
-        "11.5": 1.6
+        "9.5": 2.38,
+        "10.5": 1.88,
+        "11.5": 1.56
       },
       "cards_under_odds": {
         "2.5": null,
@@ -11569,23 +11781,23 @@
         "goals": {
           "2.5": {
             "prob": 75,
-            "odds": 1.42,
-            "implied": 70.4,
-            "edge": 4.6,
-            "flag": null
+            "odds": 1.57,
+            "implied": 63.7,
+            "edge": 11.3,
+            "flag": "value"
           },
           "3.5": {
             "prob": 41.5,
-            "odds": 2.14,
-            "implied": 46.7,
-            "edge": -5.2,
+            "odds": 2.32,
+            "implied": 43.1,
+            "edge": -1.6,
             "flag": null
           },
           "4.5": {
             "prob": 25,
-            "odds": 3.35,
-            "implied": 29.9,
-            "edge": -4.9,
+            "odds": 3.6,
+            "implied": 27.8,
+            "edge": -2.8,
             "flag": null
           }
         },
@@ -11593,31 +11805,31 @@
           "8.5": null,
           "9.5": {
             "prob": 66.5,
-            "odds": 1.46,
-            "implied": 68.5,
-            "edge": -2,
+            "odds": 1.49,
+            "implied": 67.1,
+            "edge": -0.6,
             "flag": null
           },
           "10.5": {
             "prob": 58.5,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": 0.7,
+            "odds": 1.78,
+            "implied": 56.2,
+            "edge": 2.3,
             "flag": null
           },
           "11.5": {
             "prob": 47,
-            "odds": 2.14,
-            "implied": 46.7,
-            "edge": 0.3,
+            "odds": 2.2,
+            "implied": 45.5,
+            "edge": 1.5,
             "flag": null
           }
         },
         "btts": {
           "prob": 69.5,
-          "odds": 1.44,
-          "implied": 69.4,
-          "edge": 0.1,
+          "odds": 1.5,
+          "implied": 66.7,
+          "edge": 2.8,
           "flag": null
         }
       },
@@ -11869,9 +12081,9 @@
         "5.5": 13.5
       },
       "goals_odds": {
-        "2.5": 1.47,
+        "2.5": 1.41,
         "3.5": 2.18,
-        "4.5": 3.54
+        "4.5": 3.5
       },
       "corners_odds": {
         "8.5": 1.34,
@@ -11887,9 +12099,9 @@
       "btts_odds": 1.53,
       "goals_under_odds": {
         "0.5": 14.9,
-        "1.5": 5.4,
-        "2.5": 2.6,
-        "3.5": 1.63
+        "1.5": 5.51,
+        "2.5": 2.54,
+        "3.5": 1.67
       },
       "corners_under_odds": {
         "8.5": 2.9,
@@ -11902,14 +12114,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.35,
+      "btts_no_odds": 2.25,
       "value": {
         "goals": {
           "2.5": {
             "prob": 59.5,
-            "odds": 1.47,
-            "implied": 68,
-            "edge": -8.5,
+            "odds": 1.41,
+            "implied": 70.9,
+            "edge": -11.4,
             "flag": null
           },
           "3.5": {
@@ -11921,9 +12133,9 @@
           },
           "4.5": {
             "prob": 27,
-            "odds": 3.54,
-            "implied": 28.2,
-            "edge": -1.2,
+            "odds": 3.5,
+            "implied": 28.6,
+            "edge": -1.6,
             "flag": null
           }
         },
@@ -12195,14 +12407,14 @@
       },
       "goals_odds": {
         "2.5": 1.67,
-        "3.5": 2.61,
+        "3.5": 2.82,
         "4.5": 5.0
       },
       "corners_odds": {
-        "8.5": 1.28,
-        "9.5": 1.49,
-        "10.5": 1.8,
-        "11.5": 2.36
+        "8.5": 1.29,
+        "9.5": 1.5,
+        "10.5": 1.85,
+        "11.5": 2.34
       },
       "cards_odds": {
         "3.5": null,
@@ -12213,14 +12425,14 @@
       "goals_under_odds": {
         "0.5": 11.8,
         "1.5": 4.0,
-        "2.5": 2.2,
+        "2.5": 2.16,
         "3.5": 1.39
       },
       "corners_under_odds": {
-        "8.5": 3.12,
+        "8.5": 3.15,
         "9.5": 2.35,
         "10.5": 1.83,
-        "11.5": 1.5
+        "11.5": 1.49
       },
       "cards_under_odds": {
         "2.5": null,
@@ -12239,9 +12451,9 @@
           },
           "3.5": {
             "prob": 31,
-            "odds": 2.61,
-            "implied": 38.3,
-            "edge": -7.3,
+            "odds": 2.82,
+            "implied": 35.5,
+            "edge": -4.5,
             "flag": null
           },
           "4.5": {
@@ -12255,30 +12467,30 @@
         "corners": {
           "8.5": {
             "prob": 71,
-            "odds": 1.28,
-            "implied": 78.1,
-            "edge": -7.1,
+            "odds": 1.29,
+            "implied": 77.5,
+            "edge": -6.5,
             "flag": null
           },
           "9.5": {
             "prob": 57.5,
-            "odds": 1.49,
-            "implied": 67.1,
-            "edge": -9.6,
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": -9.2,
             "flag": null
           },
           "10.5": {
             "prob": 49,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": -6.6,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -5.1,
             "flag": null
           },
           "11.5": {
             "prob": 39.5,
-            "odds": 2.36,
-            "implied": 42.4,
-            "edge": -2.9,
+            "odds": 2.34,
+            "implied": 42.7,
+            "edge": -3.2,
             "flag": null
           }
         },
@@ -12538,9 +12750,9 @@
         "5.5": 13.5
       },
       "goals_odds": {
-        "2.5": 1.73,
-        "3.5": 2.8,
-        "4.5": 5.0
+        "2.5": 1.77,
+        "3.5": 2.76,
+        "4.5": 5.15
       },
       "corners_odds": {
         "8.5": 1.36,
@@ -12553,17 +12765,17 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.67,
+      "btts_odds": 1.66,
       "goals_under_odds": {
         "0.5": 11.3,
         "1.5": 3.9,
-        "2.5": 2.07,
-        "3.5": 1.36
+        "2.5": 1.98,
+        "3.5": 1.42
       },
       "corners_under_odds": {
         "8.5": 2.85,
         "9.5": 2.16,
-        "10.5": 1.75,
+        "10.5": 1.77,
         "11.5": 1.48
       },
       "cards_under_odds": {
@@ -12571,28 +12783,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.05,
+      "btts_no_odds": 2.1,
       "value": {
         "goals": {
           "2.5": {
             "prob": 37,
-            "odds": 1.73,
-            "implied": 57.8,
-            "edge": -20.8,
+            "odds": 1.77,
+            "implied": 56.5,
+            "edge": -19.5,
             "flag": null
           },
           "3.5": {
             "prob": 33.5,
-            "odds": 2.8,
-            "implied": 35.7,
-            "edge": -2.2,
+            "odds": 2.76,
+            "implied": 36.2,
+            "edge": -2.7,
             "flag": null
           },
           "4.5": {
             "prob": 16.5,
-            "odds": 5.0,
-            "implied": 20,
-            "edge": -3.5,
+            "odds": 5.15,
+            "implied": 19.4,
+            "edge": -2.9,
             "flag": null
           }
         },
@@ -12628,9 +12840,9 @@
         },
         "btts": {
           "prob": 38,
-          "odds": 1.67,
-          "implied": 59.9,
-          "edge": -21.9,
+          "odds": 1.66,
+          "implied": 60.2,
+          "edge": -22.2,
           "flag": null
         }
       },
@@ -12863,9 +13075,9 @@
         "5.5": 24
       },
       "goals_odds": {
-        "2.5": 1.81,
-        "3.5": 2.92,
-        "4.5": 5.35
+        "2.5": 1.85,
+        "3.5": 3.04,
+        "4.5": 5.6
       },
       "corners_odds": {
         "8.5": null,
@@ -12878,12 +13090,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.74,
+      "btts_odds": 1.83,
       "goals_under_odds": {
-        "0.5": 9.1,
+        "0.5": 8.9,
         "1.5": 3.42,
-        "2.5": 1.89,
-        "3.5": 1.31
+        "2.5": 1.85,
+        "3.5": 1.32
       },
       "corners_under_odds": {
         "8.5": null,
@@ -12896,28 +13108,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.96,
+      "btts_no_odds": 2.04,
       "value": {
         "goals": {
           "2.5": {
             "prob": 31.5,
-            "odds": 1.81,
-            "implied": 55.2,
-            "edge": -23.7,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -22.6,
             "flag": null
           },
           "3.5": {
             "prob": 11.5,
-            "odds": 2.92,
-            "implied": 34.2,
-            "edge": -22.7,
+            "odds": 3.04,
+            "implied": 32.9,
+            "edge": -21.4,
             "flag": null
           },
           "4.5": {
             "prob": 4,
-            "odds": 5.35,
-            "implied": 18.7,
-            "edge": -14.7,
+            "odds": 5.6,
+            "implied": 17.9,
+            "edge": -13.9,
             "flag": null
           }
         },
@@ -12929,9 +13141,9 @@
         },
         "btts": {
           "prob": 52,
-          "odds": 1.74,
-          "implied": 57.5,
-          "edge": -5.5,
+          "odds": 1.83,
+          "implied": 54.6,
+          "edge": -2.6,
           "flag": null
         }
       },
@@ -13174,9 +13386,9 @@
         "5.5": 3
       },
       "goals_odds": {
-        "2.5": 1.14,
-        "3.5": 1.46,
-        "4.5": 2.12
+        "2.5": 1.22,
+        "3.5": 1.53,
+        "4.5": 2.2
       },
       "corners_odds": {
         "8.5": null,
@@ -13189,12 +13401,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.22,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": 3.8,
-        "3.5": 2.2
+        "0.5": 41.0,
+        "1.5": 10.0,
+        "2.5": 4.0,
+        "3.5": 2.45
       },
       "corners_under_odds": {
         "8.5": null,
@@ -13207,28 +13419,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 3.89,
       "value": {
         "goals": {
           "2.5": {
             "prob": 78,
-            "odds": 1.14,
-            "implied": 87.7,
-            "edge": -9.7,
+            "odds": 1.22,
+            "implied": 82,
+            "edge": -4,
             "flag": null
           },
           "3.5": {
             "prob": 55.5,
-            "odds": 1.46,
-            "implied": 68.5,
-            "edge": -13,
+            "odds": 1.53,
+            "implied": 65.4,
+            "edge": -9.9,
             "flag": null
           },
           "4.5": {
             "prob": 33,
-            "odds": 2.12,
-            "implied": 47.2,
-            "edge": -14.2,
+            "odds": 2.2,
+            "implied": 45.5,
+            "edge": -12.5,
             "flag": null
           }
         },
@@ -13238,7 +13450,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 69.5,
+          "odds": 1.22,
+          "implied": 82,
+          "edge": -12.5,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -13799,10 +14017,10 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.36,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": 5.75,
+        "0.5": 26.0,
+        "1.5": 7.0,
         "2.5": 2.8,
         "3.5": 1.72
       },
@@ -13817,7 +14035,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 2.88,
       "value": {
         "goals": {
           "2.5": {
@@ -13848,7 +14066,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 61,
+          "odds": 1.36,
+          "implied": 73.5,
+          "edge": -12.5,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -14098,15 +14322,15 @@
         "5.5": 28.5
       },
       "goals_odds": {
-        "2.5": 2.2,
-        "3.5": 4.33,
+        "2.5": 2.14,
+        "3.5": 3.75,
         "4.5": 8.5
       },
       "corners_odds": {
-        "8.5": 1.8,
+        "8.5": 1.85,
         "9.5": 2.28,
         "10.5": 2.95,
-        "11.5": null
+        "11.5": 5.04
       },
       "cards_odds": {
         "3.5": null,
@@ -14115,37 +14339,37 @@
       },
       "btts_odds": 1.91,
       "goals_under_odds": {
-        "0.5": 8.0,
-        "1.5": 2.86,
-        "2.5": 1.65,
-        "3.5": 1.2
+        "0.5": 7.5,
+        "1.5": 2.88,
+        "2.5": 1.61,
+        "3.5": 1.17
       },
       "corners_under_odds": {
         "8.5": 1.89,
-        "9.5": 1.55,
-        "10.5": 1.34,
-        "11.5": null
+        "9.5": 1.47,
+        "10.5": 1.23,
+        "11.5": 1.09
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.76,
+      "btts_no_odds": 1.77,
       "value": {
         "goals": {
           "2.5": {
             "prob": 47,
-            "odds": 2.2,
-            "implied": 45.5,
-            "edge": 1.5,
+            "odds": 2.14,
+            "implied": 46.7,
+            "edge": 0.3,
             "flag": null
           },
           "3.5": {
             "prob": 22,
-            "odds": 4.33,
-            "implied": 23.1,
-            "edge": -1.1,
+            "odds": 3.75,
+            "implied": 26.7,
+            "edge": -4.7,
             "flag": null
           },
           "4.5": {
@@ -14159,9 +14383,9 @@
         "corners": {
           "8.5": {
             "prob": 47,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": -8.6,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -7.1,
             "flag": null
           },
           "9.5": {
@@ -14178,7 +14402,13 @@
             "edge": -14.9,
             "flag": null
           },
-          "11.5": null
+          "11.5": {
+            "prob": 12.5,
+            "odds": 5.04,
+            "implied": 19.8,
+            "edge": -7.3,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 62.5,
@@ -14427,15 +14657,15 @@
         "5.5": 16
       },
       "goals_odds": {
-        "2.5": 2.07,
-        "3.5": 3.8,
-        "4.5": 7.4
+        "2.5": 2.1,
+        "3.5": 3.62,
+        "4.5": 8.0
       },
       "corners_odds": {
         "8.5": 1.77,
         "9.5": 2.18,
-        "10.5": 2.85,
-        "11.5": null
+        "10.5": 2.96,
+        "11.5": 4.26
       },
       "cards_odds": {
         "3.5": null,
@@ -14444,44 +14674,44 @@
       },
       "btts_odds": 1.8,
       "goals_under_odds": {
-        "0.5": 9.1,
-        "1.5": 3.0,
+        "0.5": 8.5,
+        "1.5": 3.05,
         "2.5": 1.72,
-        "3.5": 1.22
+        "3.5": 1.21
       },
       "corners_under_odds": {
         "8.5": 1.95,
         "9.5": 1.58,
-        "10.5": 1.36,
-        "11.5": null
+        "10.5": 1.31,
+        "11.5": 1.14
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.95,
+      "btts_no_odds": 1.85,
       "value": {
         "goals": {
           "2.5": {
             "prob": 31,
-            "odds": 2.07,
-            "implied": 48.3,
-            "edge": -17.3,
+            "odds": 2.1,
+            "implied": 47.6,
+            "edge": -16.6,
             "flag": null
           },
           "3.5": {
             "prob": 12.5,
-            "odds": 3.8,
-            "implied": 26.3,
-            "edge": -13.8,
+            "odds": 3.62,
+            "implied": 27.6,
+            "edge": -15.1,
             "flag": null
           },
           "4.5": {
             "prob": 6.5,
-            "odds": 7.4,
-            "implied": 13.5,
-            "edge": -7,
+            "odds": 8.0,
+            "implied": 12.5,
+            "edge": -6,
             "flag": null
           }
         },
@@ -14502,12 +14732,18 @@
           },
           "10.5": {
             "prob": 28,
-            "odds": 2.85,
-            "implied": 35.1,
-            "edge": -7.1,
+            "odds": 2.96,
+            "implied": 33.8,
+            "edge": -5.8,
             "flag": null
           },
-          "11.5": null
+          "11.5": {
+            "prob": 22,
+            "odds": 4.26,
+            "implied": 23.5,
+            "edge": -1.5,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 47,
@@ -14756,70 +14992,70 @@
         "5.5": 37.5
       },
       "goals_odds": {
-        "2.5": 2.4,
-        "3.5": 4.8,
-        "4.5": 8.3
+        "2.5": 2.35,
+        "3.5": 4.25,
+        "4.5": 10.0
       },
       "corners_odds": {
-        "8.5": 1.8,
+        "8.5": 1.87,
         "9.5": 2.38,
         "10.5": 3.15,
-        "11.5": null
+        "11.5": 5.51
       },
       "cards_odds": {
         "3.5": null,
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 2.0,
+      "btts_odds": 1.95,
       "goals_under_odds": {
-        "0.5": 6.4,
-        "1.5": 2.54,
-        "2.5": 1.53,
-        "3.5": 1.15
+        "0.5": 6.5,
+        "1.5": 2.63,
+        "2.5": 1.56,
+        "3.5": 1.18
       },
       "corners_under_odds": {
-        "8.5": 1.91,
+        "8.5": 1.8,
         "9.5": 1.49,
         "10.5": 1.3,
-        "11.5": null
+        "11.5": 1.06
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.7,
+      "btts_no_odds": 1.73,
       "value": {
         "goals": {
           "2.5": {
             "prob": 43.5,
-            "odds": 2.4,
-            "implied": 41.7,
-            "edge": 1.8,
+            "odds": 2.35,
+            "implied": 42.6,
+            "edge": 0.9,
             "flag": null
           },
           "3.5": {
             "prob": 12.5,
-            "odds": 4.8,
-            "implied": 20.8,
-            "edge": -8.3,
+            "odds": 4.25,
+            "implied": 23.5,
+            "edge": -11,
             "flag": null
           },
           "4.5": {
             "prob": 9.5,
-            "odds": 8.3,
-            "implied": 12,
-            "edge": -2.5,
+            "odds": 10.0,
+            "implied": 10,
+            "edge": -0.5,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 56.5,
-            "odds": 1.8,
-            "implied": 55.6,
-            "edge": 0.9,
+            "odds": 1.87,
+            "implied": 53.5,
+            "edge": 3,
             "flag": null
           },
           "9.5": {
@@ -14836,13 +15072,19 @@
             "edge": -3.7,
             "flag": null
           },
-          "11.5": null
+          "11.5": {
+            "prob": 19,
+            "odds": 5.51,
+            "implied": 18.1,
+            "edge": 0.9,
+            "flag": null
+          }
         },
         "btts": {
           "prob": 47,
-          "odds": 2.0,
-          "implied": 50,
-          "edge": -3,
+          "odds": 1.95,
+          "implied": 51.3,
+          "edge": -4.3,
           "flag": null
         }
       },
@@ -15651,14 +15893,14 @@
         "5.5": 24
       },
       "goals_odds": {
-        "2.5": 1.92,
+        "2.5": 1.91,
         "3.5": 3.21,
         "4.5": 6.05
       },
       "corners_odds": {
-        "8.5": 1.49,
-        "9.5": 1.81,
-        "10.5": 2.28,
+        "8.5": 1.59,
+        "9.5": 2.29,
+        "10.5": 2.56,
         "11.5": 3.54
       },
       "cards_odds": {
@@ -15669,14 +15911,14 @@
       "btts_odds": 1.67,
       "goals_under_odds": {
         "0.5": 10.0,
-        "1.5": 3.58,
-        "2.5": 1.9,
+        "1.5": 3.4,
+        "2.5": 1.83,
         "3.5": 1.33
       },
       "corners_under_odds": {
-        "8.5": 2.38,
-        "9.5": 1.87,
-        "10.5": 1.54,
+        "8.5": 2.27,
+        "9.5": 1.74,
+        "10.5": 1.42,
         "11.5": 1.21
       },
       "cards_under_odds": {
@@ -15689,9 +15931,9 @@
         "goals": {
           "2.5": {
             "prob": 62,
-            "odds": 1.92,
-            "implied": 52.1,
-            "edge": 9.9,
+            "odds": 1.91,
+            "implied": 52.4,
+            "edge": 9.6,
             "flag": null
           },
           "3.5": {
@@ -15712,23 +15954,23 @@
         "corners": {
           "8.5": {
             "prob": 56,
-            "odds": 1.49,
-            "implied": 67.1,
-            "edge": -11.1,
+            "odds": 1.59,
+            "implied": 62.9,
+            "edge": -6.9,
             "flag": null
           },
           "9.5": {
             "prob": 35,
-            "odds": 1.81,
-            "implied": 55.2,
-            "edge": -20.2,
+            "odds": 2.29,
+            "implied": 43.7,
+            "edge": -8.7,
             "flag": null
           },
           "10.5": {
             "prob": 26,
-            "odds": 2.28,
-            "implied": 43.9,
-            "edge": -17.9,
+            "odds": 2.56,
+            "implied": 39.1,
+            "edge": -13.1,
             "flag": null
           },
           "11.5": {
@@ -16263,9 +16505,9 @@
         "5.5": 8
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 1.85,
+        "3.5": 3.1,
+        "4.5": 6.0
       },
       "corners_odds": {
         "8.5": null,
@@ -16278,12 +16520,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.75,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 9.5,
+        "1.5": 3.4,
+        "2.5": 1.83,
+        "3.5": 1.3
       },
       "corners_under_odds": {
         "8.5": null,
@@ -16296,12 +16538,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.91,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 54,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -0.1,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 34.5,
+            "odds": 3.1,
+            "implied": 32.3,
+            "edge": 2.2,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 15,
+            "odds": 6.0,
+            "implied": 16.7,
+            "edge": -1.7,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -16309,7 +16569,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 58,
+          "odds": 1.75,
+          "implied": 57.1,
+          "edge": 0.9,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -16540,9 +16806,9 @@
         "5.5": 15
       },
       "goals_odds": {
-        "2.5": null,
-        "3.5": null,
-        "4.5": null
+        "2.5": 2.0,
+        "3.5": 3.5,
+        "4.5": 7.0
       },
       "corners_odds": {
         "8.5": null,
@@ -16555,12 +16821,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": null,
+      "btts_odds": 1.75,
       "goals_under_odds": {
-        "0.5": null,
-        "1.5": null,
-        "2.5": null,
-        "3.5": null
+        "0.5": 8.0,
+        "1.5": 3.1,
+        "2.5": 1.75,
+        "3.5": 1.25
       },
       "corners_under_odds": {
         "8.5": null,
@@ -16573,12 +16839,30 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": null,
+      "btts_no_odds": 1.91,
       "value": {
         "goals": {
-          "2.5": null,
-          "3.5": null,
-          "4.5": null
+          "2.5": {
+            "prob": 54,
+            "odds": 2.0,
+            "implied": 50,
+            "edge": 4,
+            "flag": null
+          },
+          "3.5": {
+            "prob": 30.5,
+            "odds": 3.5,
+            "implied": 28.6,
+            "edge": 1.9,
+            "flag": null
+          },
+          "4.5": {
+            "prob": 4,
+            "odds": 7.0,
+            "implied": 14.3,
+            "edge": -10.3,
+            "flag": null
+          }
         },
         "corners": {
           "8.5": null,
@@ -16586,7 +16870,13 @@
           "10.5": null,
           "11.5": null
         },
-        "btts": null
+        "btts": {
+          "prob": 57.5,
+          "odds": 1.75,
+          "implied": 57.1,
+          "edge": 0.4,
+          "flag": null
+        }
       },
       "home_form": [
         {
@@ -16817,14 +17107,14 @@
         "5.5": 26
       },
       "goals_odds": {
-        "2.5": 1.53,
+        "2.5": 1.49,
         "3.5": 2.38,
-        "4.5": 3.96
+        "4.5": 4.0
       },
       "corners_odds": {
-        "8.5": 1.4,
-        "9.5": 1.72,
-        "10.5": 2.04,
+        "8.5": 1.34,
+        "9.5": 1.62,
+        "10.5": 2.14,
         "11.5": 2.8
       },
       "cards_odds": {
@@ -16832,16 +17122,16 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.48,
+      "btts_odds": 1.53,
       "goals_under_odds": {
-        "0.5": 16.5,
-        "1.5": 4.8,
-        "2.5": 2.3,
-        "3.5": 1.53
+        "0.5": 10.0,
+        "1.5": 4.9,
+        "2.5": 2.39,
+        "3.5": 1.5
       },
       "corners_under_odds": {
-        "8.5": 2.62,
-        "9.5": 2.06,
+        "8.5": 2.78,
+        "9.5": 2.08,
         "10.5": 1.62,
         "11.5": 1.35
       },
@@ -16850,14 +17140,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.33,
+      "btts_no_odds": 2.38,
       "value": {
         "goals": {
           "2.5": {
             "prob": 65,
-            "odds": 1.53,
-            "implied": 65.4,
-            "edge": -0.4,
+            "odds": 1.49,
+            "implied": 67.1,
+            "edge": -2.1,
             "flag": null
           },
           "3.5": {
@@ -16869,32 +17159,32 @@
           },
           "4.5": {
             "prob": 20.5,
-            "odds": 3.96,
-            "implied": 25.3,
-            "edge": -4.8,
+            "odds": 4.0,
+            "implied": 25,
+            "edge": -4.5,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 62,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": -9.4,
+            "odds": 1.34,
+            "implied": 74.6,
+            "edge": -12.6,
             "flag": null
           },
           "9.5": {
             "prob": 53,
-            "odds": 1.72,
-            "implied": 58.1,
-            "edge": -5.1,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": -8.7,
             "flag": null
           },
           "10.5": {
             "prob": 41,
-            "odds": 2.04,
-            "implied": 49,
-            "edge": -8,
+            "odds": 2.14,
+            "implied": 46.7,
+            "edge": -5.7,
             "flag": null
           },
           "11.5": {
@@ -16907,9 +17197,9 @@
         },
         "btts": {
           "prob": 67.5,
-          "odds": 1.48,
-          "implied": 67.6,
-          "edge": -0.1,
+          "odds": 1.53,
+          "implied": 65.4,
+          "edge": 2.1,
           "flag": null
         }
       },
@@ -17153,8 +17443,8 @@
       },
       "goals_odds": {
         "2.5": 2.0,
-        "3.5": 3.5,
-        "4.5": 7.0
+        "3.5": 3.55,
+        "4.5": 6.6
       },
       "corners_odds": {
         "8.5": 1.32,
@@ -17185,7 +17475,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 1.95,
+      "btts_no_odds": 1.91,
       "value": {
         "goals": {
           "2.5": {
@@ -17197,16 +17487,16 @@
           },
           "3.5": {
             "prob": 36.5,
-            "odds": 3.5,
-            "implied": 28.6,
-            "edge": 7.9,
+            "odds": 3.55,
+            "implied": 28.2,
+            "edge": 8.3,
             "flag": null
           },
           "4.5": {
             "prob": 22.5,
-            "odds": 7.0,
-            "implied": 14.3,
-            "edge": 8.2,
+            "odds": 6.6,
+            "implied": 15.2,
+            "edge": 7.3,
             "flag": null
           }
         },
@@ -17477,8 +17767,8 @@
         "5.5": 8.5
       },
       "goals_odds": {
-        "2.5": 1.5,
-        "3.5": 2.21,
+        "2.5": 1.43,
+        "3.5": 2.12,
         "4.5": 3.6
       },
       "corners_odds": {
@@ -17492,12 +17782,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.66,
+      "btts_odds": 1.67,
       "goals_under_odds": {
-        "0.5": 14.9,
-        "1.5": 4.9,
-        "2.5": 2.5,
-        "3.5": 1.64
+        "0.5": 17.0,
+        "1.5": 5.0,
+        "2.5": 2.48,
+        "3.5": 1.62
       },
       "corners_under_odds": {
         "8.5": 2.65,
@@ -17515,16 +17805,16 @@
         "goals": {
           "2.5": {
             "prob": 56.5,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": -10.2,
+            "odds": 1.43,
+            "implied": 69.9,
+            "edge": -13.4,
             "flag": null
           },
           "3.5": {
             "prob": 21.5,
-            "odds": 2.21,
-            "implied": 45.2,
-            "edge": -23.7,
+            "odds": 2.12,
+            "implied": 47.2,
+            "edge": -25.7,
             "flag": null
           },
           "4.5": {
@@ -17567,9 +17857,9 @@
         },
         "btts": {
           "prob": 51.5,
-          "odds": 1.66,
-          "implied": 60.2,
-          "edge": -8.7,
+          "odds": 1.67,
+          "implied": 59.9,
+          "edge": -8.4,
           "flag": null
         }
       },
@@ -17802,13 +18092,13 @@
         "5.5": 13.5
       },
       "goals_odds": {
-        "2.5": 1.65,
+        "2.5": 1.62,
         "3.5": 2.6,
         "4.5": 4.6
       },
       "corners_odds": {
         "8.5": 1.36,
-        "9.5": 1.58,
+        "9.5": 1.6,
         "10.5": 1.85,
         "11.5": 2.43
       },
@@ -17817,32 +18107,32 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.57,
+      "btts_odds": 1.6,
       "goals_under_odds": {
-        "0.5": 12.3,
+        "0.5": 13.0,
         "1.5": 4.33,
-        "2.5": 2.2,
-        "3.5": 1.43
+        "2.5": 2.3,
+        "3.5": 1.44
       },
       "corners_under_odds": {
         "8.5": 2.85,
-        "9.5": 2.18,
+        "9.5": 2.17,
         "10.5": 1.85,
-        "11.5": 1.49
+        "11.5": 1.48
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.25,
+      "btts_no_odds": 2.1,
       "value": {
         "goals": {
           "2.5": {
             "prob": 54.5,
-            "odds": 1.65,
-            "implied": 60.6,
-            "edge": -6.1,
+            "odds": 1.62,
+            "implied": 61.7,
+            "edge": -7.2,
             "flag": null
           },
           "3.5": {
@@ -17870,9 +18160,9 @@
           },
           "9.5": {
             "prob": 59.5,
-            "odds": 1.58,
-            "implied": 63.3,
-            "edge": -3.8,
+            "odds": 1.6,
+            "implied": 62.5,
+            "edge": -3,
             "flag": null
           },
           "10.5": {
@@ -17892,9 +18182,9 @@
         },
         "btts": {
           "prob": 68.5,
-          "odds": 1.57,
-          "implied": 63.7,
-          "edge": 4.8,
+          "odds": 1.6,
+          "implied": 62.5,
+          "edge": 6,
           "flag": null
         }
       },
@@ -18128,8 +18418,8 @@
       },
       "goals_odds": {
         "2.5": 1.47,
-        "3.5": 2.17,
-        "4.5": 3.5
+        "3.5": 2.16,
+        "4.5": 3.7
       },
       "corners_odds": {
         "8.5": 1.38,
@@ -18142,12 +18432,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.57,
+      "btts_odds": 1.54,
       "goals_under_odds": {
-        "0.5": 19.0,
+        "0.5": 17.0,
         "1.5": 5.5,
         "2.5": 2.6,
-        "3.5": 1.67
+        "3.5": 1.71
       },
       "corners_under_odds": {
         "8.5": 2.7,
@@ -18160,7 +18450,7 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 2.2,
       "value": {
         "goals": {
           "2.5": {
@@ -18172,16 +18462,16 @@
           },
           "3.5": {
             "prob": 45.5,
-            "odds": 2.17,
-            "implied": 46.1,
-            "edge": -0.6,
+            "odds": 2.16,
+            "implied": 46.3,
+            "edge": -0.8,
             "flag": null
           },
           "4.5": {
             "prob": 18,
-            "odds": 3.5,
-            "implied": 28.6,
-            "edge": -10.6,
+            "odds": 3.7,
+            "implied": 27,
+            "edge": -9,
             "flag": null
           }
         },
@@ -18217,9 +18507,9 @@
         },
         "btts": {
           "prob": 40.5,
-          "odds": 1.57,
-          "implied": 63.7,
-          "edge": -23.2,
+          "odds": 1.54,
+          "implied": 64.9,
+          "edge": -24.4,
           "flag": null
         }
       },
@@ -18452,9 +18742,9 @@
         "5.5": 9
       },
       "goals_odds": {
-        "2.5": 1.53,
-        "3.5": 2.33,
-        "4.5": 4.0
+        "2.5": 1.57,
+        "3.5": 2.3,
+        "4.5": 3.85
       },
       "corners_odds": {
         "8.5": 1.32,
@@ -18467,17 +18757,17 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.53,
+      "btts_odds": 1.55,
       "goals_under_odds": {
         "0.5": 15.0,
-        "1.5": 4.8,
-        "2.5": 2.4,
-        "3.5": 1.53
+        "1.5": 5.0,
+        "2.5": 2.35,
+        "3.5": 1.54
       },
       "corners_under_odds": {
         "8.5": 3.05,
         "9.5": 2.3,
-        "10.5": 1.85,
+        "10.5": 1.84,
         "11.5": 1.54
       },
       "cards_under_odds": {
@@ -18485,28 +18775,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 2.28,
       "value": {
         "goals": {
           "2.5": {
             "prob": 77.5,
-            "odds": 1.53,
-            "implied": 65.4,
-            "edge": 12.1,
+            "odds": 1.57,
+            "implied": 63.7,
+            "edge": 13.8,
             "flag": "value"
           },
           "3.5": {
             "prob": 45.5,
-            "odds": 2.33,
-            "implied": 42.9,
-            "edge": 2.6,
+            "odds": 2.3,
+            "implied": 43.5,
+            "edge": 2,
             "flag": null
           },
           "4.5": {
             "prob": 22.5,
-            "odds": 4.0,
-            "implied": 25,
-            "edge": -2.5,
+            "odds": 3.85,
+            "implied": 26,
+            "edge": -3.5,
             "flag": null
           }
         },
@@ -18542,9 +18832,9 @@
         },
         "btts": {
           "prob": 68.5,
-          "odds": 1.53,
-          "implied": 65.4,
-          "edge": 3.1,
+          "odds": 1.55,
+          "implied": 64.5,
+          "edge": 4,
           "flag": null
         }
       },
@@ -18777,14 +19067,14 @@
         "5.5": 12.5
       },
       "goals_odds": {
-        "2.5": 1.95,
-        "3.5": 3.12,
-        "4.5": 5.95
+        "2.5": 1.85,
+        "3.5": 3.3,
+        "4.5": 6.5
       },
       "corners_odds": {
         "8.5": 1.43,
         "9.5": 1.7,
-        "10.5": 2.05,
+        "10.5": 2.1,
         "11.5": 2.7
       },
       "cards_odds": {
@@ -18794,15 +19084,15 @@
       },
       "btts_odds": 1.75,
       "goals_under_odds": {
-        "0.5": 9.5,
+        "0.5": 9.1,
         "1.5": 3.4,
-        "2.5": 1.85,
-        "3.5": 1.33
+        "2.5": 1.86,
+        "3.5": 1.29
       },
       "corners_under_odds": {
         "8.5": 2.6,
         "9.5": 2.0,
-        "10.5": 1.7,
+        "10.5": 1.64,
         "11.5": 1.4
       },
       "cards_under_odds": {
@@ -18815,23 +19105,23 @@
         "goals": {
           "2.5": {
             "prob": 46,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -5.3,
+            "odds": 1.85,
+            "implied": 54.1,
+            "edge": -8.1,
             "flag": null
           },
           "3.5": {
             "prob": 21,
-            "odds": 3.12,
-            "implied": 32.1,
-            "edge": -11.1,
+            "odds": 3.3,
+            "implied": 30.3,
+            "edge": -9.3,
             "flag": null
           },
           "4.5": {
             "prob": 0,
-            "odds": 5.95,
-            "implied": 16.8,
-            "edge": -16.8,
+            "odds": 6.5,
+            "implied": 15.4,
+            "edge": -15.4,
             "flag": null
           }
         },
@@ -18852,9 +19142,9 @@
           },
           "10.5": {
             "prob": 37.5,
-            "odds": 2.05,
-            "implied": 48.8,
-            "edge": -11.3,
+            "odds": 2.1,
+            "implied": 47.6,
+            "edge": -10.1,
             "flag": null
           },
           "11.5": {
@@ -19102,9 +19392,9 @@
         "5.5": 18
       },
       "goals_odds": {
-        "2.5": 1.66,
-        "3.5": 2.63,
-        "4.5": 4.45
+        "2.5": 1.67,
+        "3.5": 2.62,
+        "4.5": 4.75
       },
       "corners_odds": {
         "8.5": null,
@@ -19117,17 +19407,17 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.7,
+      "btts_odds": 1.68,
       "goals_under_odds": {
         "0.5": 12.1,
-        "1.5": 4.0,
-        "2.5": 2.15,
-        "3.5": 1.42
+        "1.5": 4.33,
+        "2.5": 2.1,
+        "3.5": 1.4
       },
       "corners_under_odds": {
         "8.5": null,
         "9.5": 2.35,
-        "10.5": 1.91,
+        "10.5": 1.87,
         "11.5": 1.56
       },
       "cards_under_odds": {
@@ -19140,23 +19430,23 @@
         "goals": {
           "2.5": {
             "prob": 40.5,
-            "odds": 1.66,
-            "implied": 60.2,
-            "edge": -19.7,
+            "odds": 1.67,
+            "implied": 59.9,
+            "edge": -19.4,
             "flag": null
           },
           "3.5": {
             "prob": 18,
-            "odds": 2.63,
-            "implied": 38,
-            "edge": -20,
+            "odds": 2.62,
+            "implied": 38.2,
+            "edge": -20.2,
             "flag": null
           },
           "4.5": {
             "prob": 9,
-            "odds": 4.45,
-            "implied": 22.5,
-            "edge": -13.5,
+            "odds": 4.75,
+            "implied": 21.1,
+            "edge": -12.1,
             "flag": null
           }
         },
@@ -19186,9 +19476,9 @@
         },
         "btts": {
           "prob": 45.5,
-          "odds": 1.7,
-          "implied": 58.8,
-          "edge": -13.3,
+          "odds": 1.68,
+          "implied": 59.5,
+          "edge": -14,
           "flag": null
         }
       },
@@ -19421,14 +19711,14 @@
         "5.5": 12.5
       },
       "goals_odds": {
-        "2.5": 1.47,
-        "3.5": 2.21,
-        "4.5": 3.6
+        "2.5": 1.41,
+        "3.5": 2.2,
+        "4.5": 3.8
       },
       "corners_odds": {
         "8.5": 1.36,
         "9.5": 1.58,
-        "10.5": 1.95,
+        "10.5": 1.93,
         "11.5": 2.43
       },
       "cards_odds": {
@@ -19436,12 +19726,12 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.65,
+      "btts_odds": 1.62,
       "goals_under_odds": {
-        "0.5": 19.0,
-        "1.5": 5.05,
-        "2.5": 2.6,
-        "3.5": 1.63
+        "0.5": 15.5,
+        "1.5": 5.1,
+        "2.5": 2.65,
+        "3.5": 1.68
       },
       "corners_under_odds": {
         "8.5": 2.85,
@@ -19454,28 +19744,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.15,
+      "btts_no_odds": 2.11,
       "value": {
         "goals": {
           "2.5": {
             "prob": 66.5,
-            "odds": 1.47,
-            "implied": 68,
-            "edge": -1.5,
+            "odds": 1.41,
+            "implied": 70.9,
+            "edge": -4.4,
             "flag": null
           },
           "3.5": {
             "prob": 41.5,
-            "odds": 2.21,
-            "implied": 45.2,
-            "edge": -3.7,
+            "odds": 2.2,
+            "implied": 45.5,
+            "edge": -4,
             "flag": null
           },
           "4.5": {
             "prob": 29,
-            "odds": 3.6,
-            "implied": 27.8,
-            "edge": 1.2,
+            "odds": 3.8,
+            "implied": 26.3,
+            "edge": 2.7,
             "flag": null
           }
         },
@@ -19496,9 +19786,9 @@
           },
           "10.5": {
             "prob": 50,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -1.3,
+            "odds": 1.93,
+            "implied": 51.8,
+            "edge": -1.8,
             "flag": null
           },
           "11.5": {
@@ -19511,9 +19801,9 @@
         },
         "btts": {
           "prob": 79,
-          "odds": 1.65,
-          "implied": 60.6,
-          "edge": 18.4,
+          "odds": 1.62,
+          "implied": 61.7,
+          "edge": 17.3,
           "flag": "value"
         }
       },
@@ -19746,14 +20036,14 @@
         "5.5": 5
       },
       "goals_odds": {
-        "2.5": 1.67,
-        "3.5": 2.72,
-        "4.5": 4.8
+        "2.5": 1.69,
+        "3.5": 2.63,
+        "4.5": 5.0
       },
       "corners_odds": {
         "8.5": null,
         "9.5": 1.49,
-        "10.5": 1.77,
+        "10.5": 1.8,
         "11.5": 2.17
       },
       "cards_odds": {
@@ -19761,11 +20051,11 @@
         "4.5": null,
         "5.5": null
       },
-      "btts_odds": 1.57,
+      "btts_odds": 1.55,
       "goals_under_odds": {
-        "0.5": 12.0,
-        "1.5": 4.0,
-        "2.5": 2.1,
+        "0.5": 12.2,
+        "1.5": 4.15,
+        "2.5": 2.13,
         "3.5": 1.4
       },
       "corners_under_odds": {
@@ -19779,28 +20069,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.3,
+      "btts_no_odds": 2.2,
       "value": {
         "goals": {
           "2.5": {
             "prob": 53,
-            "odds": 1.67,
-            "implied": 59.9,
-            "edge": -6.9,
+            "odds": 1.69,
+            "implied": 59.2,
+            "edge": -6.2,
             "flag": null
           },
           "3.5": {
             "prob": 29,
-            "odds": 2.72,
-            "implied": 36.8,
-            "edge": -7.8,
+            "odds": 2.63,
+            "implied": 38,
+            "edge": -9,
             "flag": null
           },
           "4.5": {
             "prob": 10,
-            "odds": 4.8,
-            "implied": 20.8,
-            "edge": -10.8,
+            "odds": 5.0,
+            "implied": 20,
+            "edge": -10,
             "flag": null
           }
         },
@@ -19815,9 +20105,9 @@
           },
           "10.5": {
             "prob": 61.5,
-            "odds": 1.77,
-            "implied": 56.5,
-            "edge": 5,
+            "odds": 1.8,
+            "implied": 55.6,
+            "edge": 5.9,
             "flag": null
           },
           "11.5": {
@@ -19830,9 +20120,9 @@
         },
         "btts": {
           "prob": 57.5,
-          "odds": 1.57,
-          "implied": 63.7,
-          "edge": -6.2,
+          "odds": 1.55,
+          "implied": 64.5,
+          "edge": -7,
           "flag": null
         }
       },
@@ -20043,26 +20333,26 @@
       },
       "goals_avg": 4.5,
       "corners_avg": 10.6,
-      "cards_avg": 2.7,
-      "btts_pct": 75.5,
+      "cards_avg": 2.5,
+      "btts_pct": 76.5,
       "goals_over": {
         "0.5": 100,
         "1.5": 94,
         "2.5": 94,
         "3.5": 79.5,
-        "4.5": 42.5
+        "4.5": 44
       },
       "corners_over": {
-        "8.5": 63.5,
-        "9.5": 48.5,
-        "10.5": 45.5,
-        "11.5": 39.5
+        "8.5": 65,
+        "9.5": 50,
+        "10.5": 44,
+        "11.5": 38
       },
       "cards_over": {
-        "2.5": 53,
-        "3.5": 32.5,
-        "4.5": 23,
-        "5.5": 13.5
+        "2.5": 51.5,
+        "3.5": 32,
+        "4.5": 22.5,
+        "5.5": 13
       },
       "goals_odds": {
         "2.5": null,
@@ -20205,6 +20495,17 @@
       ],
       "away_form": [
         {
+          "date": "2026-07-09",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
           "date": "2026-07-05",
           "opp": "Tallinna FC Levadia U21",
           "ha": "H",
@@ -20280,17 +20581,6 @@
           "corners": 15,
           "cards": 1,
           "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Viimsi",
-          "ha": "H",
-          "gf": 0,
-          "ga": 4,
-          "res": "L",
-          "corners": 5,
-          "cards": 2,
-          "btts": false
         }
       ],
       "h2h": [
@@ -20361,9 +20651,9 @@
         "5.5": 19
       },
       "goals_odds": {
-        "2.5": 1.5,
-        "3.5": 2.08,
-        "4.5": 3.75
+        "2.5": 1.42,
+        "3.5": 2.26,
+        "4.5": 3.52
       },
       "corners_odds": {
         "8.5": 1.29,
@@ -20378,10 +20668,10 @@
       },
       "btts_odds": 1.45,
       "goals_under_odds": {
-        "0.5": 17.0,
-        "1.5": 4.85,
-        "2.5": 2.5,
-        "3.5": 1.66
+        "0.5": 15.0,
+        "1.5": 5.0,
+        "2.5": 2.42,
+        "3.5": 1.61
       },
       "corners_under_odds": {
         "8.5": 3.2,
@@ -20399,23 +20689,23 @@
         "goals": {
           "2.5": {
             "prob": 67.5,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": 0.8,
+            "odds": 1.42,
+            "implied": 70.4,
+            "edge": -2.9,
             "flag": null
           },
           "3.5": {
             "prob": 29,
-            "odds": 2.08,
-            "implied": 48.1,
-            "edge": -19.1,
+            "odds": 2.26,
+            "implied": 44.2,
+            "edge": -15.2,
             "flag": null
           },
           "4.5": {
             "prob": 24.5,
-            "odds": 3.75,
-            "implied": 26.7,
-            "edge": -2.2,
+            "odds": 3.52,
+            "implied": 28.4,
+            "edge": -3.9,
             "flag": null
           }
         },
@@ -20686,13 +20976,13 @@
         "5.5": 37
       },
       "goals_odds": {
-        "2.5": 1.18,
-        "3.5": 1.5,
-        "4.5": 2.2
+        "2.5": 1.16,
+        "3.5": 1.53,
+        "4.5": 2.08
       },
       "corners_odds": {
         "8.5": 1.07,
-        "9.5": 1.21,
+        "9.5": 1.26,
         "10.5": 1.41,
         "11.5": 1.7
       },
@@ -20705,8 +20995,8 @@
       "goals_under_odds": {
         "0.5": 25.0,
         "1.5": 10.0,
-        "2.5": 4.0,
-        "3.5": 2.4
+        "2.5": 4.25,
+        "3.5": 2.45
       },
       "corners_under_odds": {
         "8.5": 5.42,
@@ -20719,28 +21009,28 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 3.0,
+      "btts_no_odds": 3.04,
       "value": {
         "goals": {
           "2.5": {
             "prob": 77.5,
-            "odds": 1.18,
-            "implied": 84.7,
-            "edge": -7.2,
+            "odds": 1.16,
+            "implied": 86.2,
+            "edge": -8.7,
             "flag": null
           },
           "3.5": {
             "prob": 65.5,
-            "odds": 1.5,
-            "implied": 66.7,
-            "edge": -1.2,
+            "odds": 1.53,
+            "implied": 65.4,
+            "edge": 0.1,
             "flag": null
           },
           "4.5": {
             "prob": 55,
-            "odds": 2.2,
-            "implied": 45.5,
-            "edge": 9.5,
+            "odds": 2.08,
+            "implied": 48.1,
+            "edge": 6.9,
             "flag": null
           }
         },
@@ -20754,9 +21044,9 @@
           },
           "9.5": {
             "prob": 66,
-            "odds": 1.21,
-            "implied": 82.6,
-            "edge": -16.6,
+            "odds": 1.26,
+            "implied": 79.4,
+            "edge": -13.4,
             "flag": null
           },
           "10.5": {
@@ -21021,14 +21311,14 @@
         "5.5": 23
       },
       "goals_odds": {
-        "2.5": 1.22,
-        "3.5": 1.53,
+        "2.5": 1.17,
+        "3.5": 1.47,
         "4.5": 2.3
       },
       "corners_odds": {
         "8.5": 1.11,
-        "9.5": 1.27,
-        "10.5": 1.49,
+        "9.5": 1.34,
+        "10.5": 1.51,
         "11.5": 1.82
       },
       "cards_odds": {
@@ -21040,8 +21330,8 @@
       "goals_under_odds": {
         "0.5": 24.0,
         "1.5": 8.8,
-        "2.5": 3.9,
-        "3.5": 2.2
+        "2.5": 4.0,
+        "3.5": 2.38
       },
       "corners_under_odds": {
         "8.5": 4.62,
@@ -21054,21 +21344,21 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.53,
+      "btts_no_odds": 2.49,
       "value": {
         "goals": {
           "2.5": {
             "prob": 69,
-            "odds": 1.22,
-            "implied": 82,
-            "edge": -13,
+            "odds": 1.17,
+            "implied": 85.5,
+            "edge": -16.5,
             "flag": null
           },
           "3.5": {
             "prob": 61.5,
-            "odds": 1.53,
-            "implied": 65.4,
-            "edge": -3.9,
+            "odds": 1.47,
+            "implied": 68,
+            "edge": -6.5,
             "flag": null
           },
           "4.5": {
@@ -21089,17 +21379,17 @@
           },
           "9.5": {
             "prob": 81,
-            "odds": 1.27,
-            "implied": 78.7,
-            "edge": 2.3,
+            "odds": 1.34,
+            "implied": 74.6,
+            "edge": 6.4,
             "flag": null
           },
           "10.5": {
             "prob": 81,
-            "odds": 1.49,
-            "implied": 67.1,
-            "edge": 13.9,
-            "flag": null
+            "odds": 1.51,
+            "implied": 66.2,
+            "edge": 14.8,
+            "flag": "value"
           },
           "11.5": {
             "prob": 65.5,
@@ -21356,9 +21646,9 @@
         "5.5": 31
       },
       "goals_odds": {
-        "2.5": 1.44,
+        "2.5": 1.38,
         "3.5": 2.01,
-        "4.5": 3.2
+        "4.5": 3.18
       },
       "corners_odds": {
         "8.5": 1.12,
@@ -21373,10 +21663,10 @@
       },
       "btts_odds": 1.34,
       "goals_under_odds": {
-        "0.5": 19.0,
-        "1.5": 6.05,
-        "2.5": 2.62,
-        "3.5": 1.78
+        "0.5": 17.0,
+        "1.5": 6.22,
+        "2.5": 2.63,
+        "3.5": 1.7
       },
       "corners_under_odds": {
         "8.5": 4.51,
@@ -21389,14 +21679,14 @@
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.7,
+      "btts_no_odds": 2.99,
       "value": {
         "goals": {
           "2.5": {
             "prob": 62,
-            "odds": 1.44,
-            "implied": 69.4,
-            "edge": -7.4,
+            "odds": 1.38,
+            "implied": 72.5,
+            "edge": -10.5,
             "flag": null
           },
           "3.5": {
@@ -21408,9 +21698,9 @@
           },
           "4.5": {
             "prob": 23,
-            "odds": 3.2,
-            "implied": 31.2,
-            "edge": -8.2,
+            "odds": 3.18,
+            "implied": 31.4,
+            "edge": -8.4,
             "flag": null
           }
         },
@@ -21691,15 +21981,15 @@
         "5.5": 29.5
       },
       "goals_odds": {
-        "2.5": 1.4,
-        "3.5": 1.95,
-        "4.5": 3.2
+        "2.5": 1.35,
+        "3.5": 1.98,
+        "4.5": 3.04
       },
       "corners_odds": {
-        "8.5": 1.09,
-        "9.5": 1.3,
-        "10.5": 1.47,
-        "11.5": 1.77
+        "8.5": 1.1,
+        "9.5": 1.33,
+        "10.5": 1.5,
+        "11.5": 1.81
       },
       "cards_odds": {
         "3.5": null,
@@ -21709,73 +21999,73 @@
       "btts_odds": 1.36,
       "goals_under_odds": {
         "0.5": 17.0,
-        "1.5": 6.07,
-        "2.5": 2.75,
-        "3.5": 1.75
+        "1.5": 5.65,
+        "2.5": 2.74,
+        "3.5": 1.78
       },
       "corners_under_odds": {
-        "8.5": 4.94,
-        "9.5": 3.31,
-        "10.5": 2.44,
-        "11.5": 1.93
+        "8.5": 4.72,
+        "9.5": 3.19,
+        "10.5": 2.37,
+        "11.5": 1.89
       },
       "cards_under_odds": {
         "2.5": null,
         "3.5": null,
         "4.5": null
       },
-      "btts_no_odds": 2.9,
+      "btts_no_odds": 2.5,
       "value": {
         "goals": {
           "2.5": {
             "prob": 70,
-            "odds": 1.4,
-            "implied": 71.4,
-            "edge": -1.4,
+            "odds": 1.35,
+            "implied": 74.1,
+            "edge": -4.1,
             "flag": null
           },
           "3.5": {
             "prob": 48,
-            "odds": 1.95,
-            "implied": 51.3,
-            "edge": -3.3,
+            "odds": 1.98,
+            "implied": 50.5,
+            "edge": -2.5,
             "flag": null
           },
           "4.5": {
             "prob": 40.5,
-            "odds": 3.2,
-            "implied": 31.2,
-            "edge": 9.3,
+            "odds": 3.04,
+            "implied": 32.9,
+            "edge": 7.6,
             "flag": null
           }
         },
         "corners": {
           "8.5": {
             "prob": 82,
-            "odds": 1.09,
-            "implied": 91.7,
-            "edge": -9.7,
+            "odds": 1.1,
+            "implied": 90.9,
+            "edge": -8.9,
             "flag": null
           },
           "9.5": {
             "prob": 82,
-            "odds": 1.3,
-            "implied": 76.9,
-            "edge": 5.1,
+            "odds": 1.33,
+            "implied": 75.2,
+            "edge": 6.8,
             "flag": null
           },
           "10.5": {
             "prob": 82,
-            "odds": 1.47,
-            "implied": 68,
-            "edge": 14,
-            "flag": null
+            "odds": 1.5,
+            "implied": 66.7,
+            "edge": 15.3,
+            "flag": "value"
           },
           "11.5": {
             "prob": 70,
-            "odds": 1.77,
-            "implied": 56.5,
-            "edge": 13.5,
+            "odds": 1.81,
+            "implied": 55.2,
+            "edge": 14.8,
             "flag": "value"
           }
         },
@@ -22004,26 +22294,26 @@
       },
       "goals_avg": 3.9,
       "corners_avg": 10.1,
-      "cards_avg": 3.6,
-      "btts_pct": 66,
+      "cards_avg": 3.3,
+      "btts_pct": 66.5,
       "goals_over": {
         "0.5": 97,
-        "1.5": 88,
-        "2.5": 68.5,
-        "3.5": 54,
-        "4.5": 42.5
+        "1.5": 88.5,
+        "2.5": 69.5,
+        "3.5": 55.5,
+        "4.5": 44
       },
       "corners_over": {
-        "8.5": 60,
-        "9.5": 45.5,
-        "10.5": 40,
-        "11.5": 34.5
+        "8.5": 61,
+        "9.5": 47,
+        "10.5": 38.5,
+        "11.5": 33.5
       },
       "cards_over": {
-        "2.5": 73.5,
-        "3.5": 50,
-        "4.5": 23.5,
-        "5.5": 20
+        "2.5": 71.5,
+        "3.5": 48.5,
+        "4.5": 23,
+        "5.5": 19.5
       },
       "goals_odds": {
         "2.5": null,
@@ -22075,6 +22365,17 @@
         "btts": null
       },
       "home_form": [
+        {
+          "date": "2026-07-09",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
         {
           "date": "2026-07-03",
           "opp": "Tallinna Kalev",
@@ -22149,17 +22450,6 @@
           "ga": 1,
           "res": "W",
           "corners": 12,
-          "cards": 4,
-          "btts": true
-        },
-        {
-          "date": "2026-05-09",
-          "opp": "Nõmme United II",
-          "ha": "H",
-          "gf": 2,
-          "ga": 1,
-          "res": "W",
-          "corners": 9,
           "cards": 4,
           "btts": true
         }
@@ -23221,6 +23511,1428 @@
           "cards": 1
         }
       ]
+    },
+    {
+      "id": "8391026",
+      "league": "MLS",
+      "region": "USA",
+      "date": "2026-07-16",
+      "time": "00:30",
+      "home": {
+        "name": "Montreal Impact",
+        "short": "MON",
+        "logo": "https://cdn.footystats.org/img/teams/canada-montreal-impact.png"
+      },
+      "away": {
+        "name": "Toronto",
+        "short": "TOR",
+        "logo": "https://cdn.footystats.org/img/teams/canada-toronto-fc.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.7,
+      "corners_avg": 10.6,
+      "cards_avg": 5.7,
+      "btts_pct": 68,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 93,
+        "2.5": 75,
+        "3.5": 43,
+        "4.5": 32.5
+      },
+      "corners_over": {
+        "8.5": 63.5,
+        "9.5": 60.5,
+        "10.5": 49.5,
+        "11.5": 39.5
+      },
+      "cards_over": {
+        "2.5": 82.5,
+        "3.5": 71.5,
+        "4.5": 53.5,
+        "5.5": 35.5
+      },
+      "goals_odds": {
+        "2.5": 1.58,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 2.2,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 75,
+            "odds": 1.58,
+            "implied": 63.3,
+            "edge": 11.7,
+            "flag": "value"
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-23",
+          "opp": "DC United",
+          "ha": "A",
+          "gf": 4,
+          "ga": 4,
+          "res": "D",
+          "corners": 10,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Chicago Fire",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 19,
+          "cards": 7,
+          "btts": false
+        },
+        {
+          "date": "2026-05-13",
+          "opp": "Portland Timbers",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 15,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Orlando City",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 14,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Atlanta United FC",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 5,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "New York City",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 4,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "New York RB",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Philadelphia Union",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-24",
+          "opp": "Chicago Fire",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 7,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Charlotte",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Inter Miami",
+          "ha": "H",
+          "gf": 2,
+          "ga": 4,
+          "res": "L",
+          "corners": 8,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "SJ Earthquakes",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 17,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Atlanta United FC",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-22",
+          "opp": "Philadelphia Union",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 4,
+          "cards": 9,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Austin",
+          "ha": "H",
+          "gf": 3,
+          "ga": 3,
+          "res": "D",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "FC Cincinnati",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 11,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8464293",
+      "league": "Esiliiga",
+      "region": "Estonia",
+      "date": "2026-07-16",
+      "time": "17:00",
+      "home": {
+        "name": "Viimsi",
+        "short": "VII",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-viimsi-jk.png"
+      },
+      "away": {
+        "name": "Elva",
+        "short": "ELV",
+        "logo": "https://cdn.footystats.org/img/teams/estonia-fc-elva.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 10.1,
+      "cards_avg": 3.2,
+      "btts_pct": 51,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 79.5,
+        "2.5": 54,
+        "3.5": 37,
+        "4.5": 17
+      },
+      "corners_over": {
+        "8.5": 56.5,
+        "9.5": 47.5,
+        "10.5": 37,
+        "11.5": 28
+      },
+      "cards_over": {
+        "2.5": 59.5,
+        "3.5": 41,
+        "4.5": 25,
+        "5.5": 19
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-07-02",
+          "opp": "Tartu JK Welco",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Maardu Linnameeskond",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 8,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Elva",
+          "ha": "A",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 17,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-14",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 8,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-27",
+          "opp": "Tallinna Kalev",
+          "ha": "A",
+          "gf": 3,
+          "ga": 0,
+          "res": "W",
+          "corners": 8,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "FC Tallinn",
+          "ha": "A",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 14,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "A",
+          "gf": 4,
+          "ga": 0,
+          "res": "W",
+          "corners": 5,
+          "cards": 2,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-07-05",
+          "opp": "Nõmme Kalju FC U21",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 10,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-06-22",
+          "opp": "Tallinna FC Flora U21",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 17,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-06-18",
+          "opp": "Viimsi",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 17,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-06-11",
+          "opp": "Maardu Linnameeskond",
+          "ha": "H",
+          "gf": 4,
+          "ga": 3,
+          "res": "W",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-06-01",
+          "opp": "Tartu JK Welco",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 9,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-05-28",
+          "opp": "Tallinna FC Levadia U21",
+          "ha": "A",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Tallinna Kalev",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Nõmme United II",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 13,
+          "cards": 0,
+          "btts": false
+        }
+      ],
+      "h2h": [
+        {
+          "date": "2026-06-18",
+          "home": "Elva",
+          "away": "Viimsi",
+          "hg": 0,
+          "ag": 1,
+          "corners": 17,
+          "cards": 8
+        },
+        {
+          "date": "2026-04-03",
+          "home": "Elva",
+          "away": "Viimsi",
+          "hg": 1,
+          "ag": 0,
+          "corners": 7,
+          "cards": 3
+        }
+      ]
+    },
+    {
+      "id": "8411734",
+      "league": "Eliteserien",
+      "region": "Norway",
+      "date": "2026-07-16",
+      "time": "18:00",
+      "home": {
+        "name": "Vålerenga",
+        "short": "VÅL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-valerenga-fotball.png"
+      },
+      "away": {
+        "name": "Aalesund",
+        "short": "AAL",
+        "logo": "https://cdn.footystats.org/img/teams/norway-aalesunds-fk.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3,
+      "corners_avg": 12.2,
+      "cards_avg": 3.8,
+      "btts_pct": 63.5,
+      "goals_over": {
+        "0.5": 100,
+        "1.5": 82,
+        "2.5": 50,
+        "3.5": 40.5,
+        "4.5": 18
+      },
+      "corners_over": {
+        "8.5": 82,
+        "9.5": 77.5,
+        "10.5": 68.5,
+        "11.5": 50
+      },
+      "cards_over": {
+        "2.5": 64,
+        "3.5": 50,
+        "4.5": 31.5,
+        "5.5": 22.5
+      },
+      "goals_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": null,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": null,
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Start",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Sarpsborg 08",
+          "ha": "H",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 7,
+          "cards": 1,
+          "btts": true
+        },
+        {
+          "date": "2026-05-08",
+          "opp": "HamKam",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Molde",
+          "ha": "A",
+          "gf": 1,
+          "ga": 5,
+          "res": "L",
+          "corners": 7,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Lillestrøm",
+          "ha": "H",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 19,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Fredrikstad",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 5,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-29",
+          "opp": "HamKam",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 12,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-25",
+          "opp": "Tromsø",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 15,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-05-20",
+          "opp": "Brann",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Rosenborg",
+          "ha": "A",
+          "gf": 3,
+          "ga": 2,
+          "res": "W",
+          "corners": 11,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Sandefjord",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 10,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Kristiansund",
+          "ha": "H",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 18,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "FK Bodo - Glimt",
+          "ha": "A",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 1,
+          "btts": false
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "KFUM",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 4,
+          "btts": true
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8409705",
+      "league": "Serie A",
+      "region": "Brazil",
+      "date": "2026-07-16",
+      "time": "23:30",
+      "home": {
+        "name": "Botafogo",
+        "short": "BOT",
+        "logo": "https://cdn.footystats.org/img/teams/brazil-botafogo-fr.png"
+      },
+      "away": {
+        "name": "Santos",
+        "short": "SAN",
+        "logo": "https://cdn.footystats.org/img/teams/brazil-santos-fc-sao-paulo.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 3.3,
+      "corners_avg": 9.5,
+      "cards_avg": 5.3,
+      "btts_pct": 77,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 91.5,
+        "2.5": 71.5,
+        "3.5": 43,
+        "4.5": 20.5
+      },
+      "corners_over": {
+        "8.5": 59.5,
+        "9.5": 54,
+        "10.5": 34,
+        "11.5": 23
+      },
+      "cards_over": {
+        "2.5": 85.5,
+        "3.5": 74.5,
+        "4.5": 60.5,
+        "5.5": 45.5
+      },
+      "goals_odds": {
+        "2.5": 1.84,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.9,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 71.5,
+            "odds": 1.84,
+            "implied": 54.3,
+            "edge": 17.2,
+            "flag": "value"
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Bahia",
+          "ha": "A",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 14,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "São Paulo",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 7,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Corinthians",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 5,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Atlético Mineiro",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 10,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Remo",
+          "ha": "H",
+          "gf": 1,
+          "ga": 2,
+          "res": "L",
+          "corners": 15,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Internacional",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 5,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Chapecoense",
+          "ha": "A",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 8,
+          "cards": 0,
+          "btts": true
+        },
+        {
+          "date": "2026-04-12",
+          "opp": "Coritiba",
+          "ha": "H",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Vitória",
+          "ha": "H",
+          "gf": 3,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Grêmio",
+          "ha": "A",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 13,
+          "cards": 4,
+          "btts": true
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Coritiba",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": false
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Bragantino",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Palmeiras",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 13,
+          "cards": 2,
+          "btts": true
+        },
+        {
+          "date": "2026-04-25",
+          "opp": "Bahia",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 8,
+          "cards": 7,
+          "btts": true
+        },
+        {
+          "date": "2026-04-19",
+          "opp": "Fluminense",
+          "ha": "H",
+          "gf": 2,
+          "ga": 3,
+          "res": "L",
+          "corners": 10,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Atlético Mineiro",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        }
+      ],
+      "h2h": []
+    },
+    {
+      "id": "8409713",
+      "league": "Serie A",
+      "region": "Brazil",
+      "date": "2026-07-16",
+      "time": "23:30",
+      "home": {
+        "name": "Vitória",
+        "short": "VIT",
+        "logo": "https://cdn.footystats.org/img/teams/brazil-ec-vitoria.png"
+      },
+      "away": {
+        "name": "Vasco da Gama",
+        "short": "VAS",
+        "logo": "https://cdn.footystats.org/img/teams/brazil-cr-vasco-da-gama.png"
+      },
+      "result": {
+        "hg": 0,
+        "ag": 0,
+        "corners": 0,
+        "cards": 0,
+        "btts": false
+      },
+      "goals_avg": 2.8,
+      "corners_avg": 9.1,
+      "cards_avg": 5.5,
+      "btts_pct": 59.5,
+      "goals_over": {
+        "0.5": 97,
+        "1.5": 83,
+        "2.5": 51,
+        "3.5": 25.5,
+        "4.5": 14.5
+      },
+      "corners_over": {
+        "8.5": 63,
+        "9.5": 45.5,
+        "10.5": 28.5,
+        "11.5": 20
+      },
+      "cards_over": {
+        "2.5": 86,
+        "3.5": 69,
+        "4.5": 54.5,
+        "5.5": 43.5
+      },
+      "goals_odds": {
+        "2.5": 2.05,
+        "3.5": null,
+        "4.5": null
+      },
+      "corners_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_odds": {
+        "3.5": null,
+        "4.5": null,
+        "5.5": null
+      },
+      "btts_odds": null,
+      "goals_under_odds": {
+        "0.5": null,
+        "1.5": null,
+        "2.5": 1.68,
+        "3.5": null
+      },
+      "corners_under_odds": {
+        "8.5": null,
+        "9.5": null,
+        "10.5": null,
+        "11.5": null
+      },
+      "cards_under_odds": {
+        "2.5": null,
+        "3.5": null,
+        "4.5": null
+      },
+      "btts_no_odds": null,
+      "value": {
+        "goals": {
+          "2.5": {
+            "prob": 51,
+            "odds": 2.05,
+            "implied": 48.8,
+            "edge": 2.2,
+            "flag": null
+          },
+          "3.5": null,
+          "4.5": null
+        },
+        "corners": {
+          "8.5": null,
+          "9.5": null,
+          "10.5": null,
+          "11.5": null
+        },
+        "btts": null
+      },
+      "home_form": [
+        {
+          "date": "2026-05-30",
+          "opp": "Santos",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 6,
+          "cards": 8,
+          "btts": true
+        },
+        {
+          "date": "2026-05-23",
+          "opp": "Internacional",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 10,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-17",
+          "opp": "Bragantino",
+          "ha": "A",
+          "gf": 0,
+          "ga": 2,
+          "res": "L",
+          "corners": 13,
+          "cards": 6,
+          "btts": false
+        },
+        {
+          "date": "2026-05-09",
+          "opp": "Fluminense",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 9,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-02",
+          "opp": "Coritiba",
+          "ha": "H",
+          "gf": 4,
+          "ga": 1,
+          "res": "W",
+          "corners": 6,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Atlético PR",
+          "ha": "A",
+          "gf": 1,
+          "ga": 3,
+          "res": "L",
+          "corners": 8,
+          "cards": 10,
+          "btts": true
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "Corinthians",
+          "ha": "H",
+          "gf": 0,
+          "ga": 0,
+          "res": "D",
+          "corners": 6,
+          "cards": 3,
+          "btts": false
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "São Paulo",
+          "ha": "H",
+          "gf": 2,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 7,
+          "btts": false
+        }
+      ],
+      "away_form": [
+        {
+          "date": "2026-05-31",
+          "opp": "Atlético Mineiro",
+          "ha": "H",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 7,
+          "cards": 2,
+          "btts": false
+        },
+        {
+          "date": "2026-05-24",
+          "opp": "Bragantino",
+          "ha": "H",
+          "gf": 0,
+          "ga": 3,
+          "res": "L",
+          "corners": 12,
+          "cards": 4,
+          "btts": false
+        },
+        {
+          "date": "2026-05-16",
+          "opp": "Internacional",
+          "ha": "A",
+          "gf": 1,
+          "ga": 4,
+          "res": "L",
+          "corners": 7,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-05-10",
+          "opp": "Atlético PR",
+          "ha": "H",
+          "gf": 1,
+          "ga": 0,
+          "res": "W",
+          "corners": 7,
+          "cards": 5,
+          "btts": false
+        },
+        {
+          "date": "2026-05-03",
+          "opp": "Flamengo",
+          "ha": "A",
+          "gf": 2,
+          "ga": 2,
+          "res": "D",
+          "corners": 11,
+          "cards": 6,
+          "btts": true
+        },
+        {
+          "date": "2026-04-26",
+          "opp": "Corinthians",
+          "ha": "A",
+          "gf": 0,
+          "ga": 1,
+          "res": "L",
+          "corners": 12,
+          "cards": 9,
+          "btts": false
+        },
+        {
+          "date": "2026-04-18",
+          "opp": "São Paulo",
+          "ha": "H",
+          "gf": 2,
+          "ga": 1,
+          "res": "W",
+          "corners": 11,
+          "cards": 3,
+          "btts": true
+        },
+        {
+          "date": "2026-04-11",
+          "opp": "Remo",
+          "ha": "A",
+          "gf": 1,
+          "ga": 1,
+          "res": "D",
+          "corners": 9,
+          "cards": 2,
+          "btts": true
+        }
+      ],
+      "h2h": []
     }
   ]
 }

--- a/src/data/pnlLedger.json
+++ b/src/data/pnlLedger.json
@@ -2,6 +2,28 @@
   "note": "Settled bet ledger — the tracked record. Each entry is a locked pre-match bet (double = 2 best value picks, treble = next 3) with its real result. Append new days here; never edit a settled result.",
   "bets": [
     {
+      "date": "2026-07-09",
+      "kind": "single",
+      "stake": 10,
+      "combinedOdds": 1.47,
+      "status": "won",
+      "returns": 14.7,
+      "profit": 4.7,
+      "legs": [
+        {
+          "home": "Maardu Linnameeskond",
+          "away": "Tallinna FC Flora U21",
+          "region": "Estonia",
+          "league": "Esiliiga",
+          "selection": "Over 3.5 Goals",
+          "odds": 1.47,
+          "ft": "3-2",
+          "result": "won"
+        }
+      ],
+      "verdict": "Results are in, and you know the house rule by now: I read them out whether they flatter me or not. And it’s a green one — the slip did exactly what the numbers said it would, which is the most satisfying sentence in this whole trade. I told you the Maardu Linnameeskond v Tallinna FC Flora U21 defences were held together with tape, and 5 goals later the scoreboard read 3-2 — that’s the form table talking, not luck. On we go — the season is a marathon of small edges, and yesterday, whatever it was, is now just one more data point behind us."
+    },
+    {
       "date": "2026-07-06",
       "kind": "double",
       "stake": 10,


### PR DESCRIPTION
Root cause of "yesterday's result never updated": 9 Jul had exactly one qualifying game, the board showed it as the Gaffer's Top Pick (a £10 single) — but `settle.mjs` only knew doubles and trebles and skipped the day with "no bet (only 1 value pick)". Singles could never reach the ledger.

- A lone qualifying pick now settles as `kind: 'single'` through the same `buildBet` path (which is leg-count agnostic).
- Backfills 9 Jul: **single WON +£4.70** (record → +£19.17).
- Includes this morning's board data (already live in production).

Settling and board-building remain one job — results land in the same pass that adds the new day's games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settlement now processes days with a single qualifying pick instead of skipping them.
  * Pending results continue to be excluded until final outcomes are available.

* **Data Updates**
  * Added a settled single-bet record with its outcome, score, odds, returns, and profit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->