### PR TITLE
Add footy-morning-trigger worker (code only, not yet deployed)

### DIFF
--- a/workers/morning-trigger/src/index.js
+++ b/workers/morning-trigger/src/index.js
@@ -1,0 +1,58 @@
+/**
+ * footy-morning-trigger — kicks the GitHub "Daily Board + P&L" workflow on a
+ * punctual Cloudflare cron. If the kick itself fails, it raises the alarm on
+ * Telegram directly (the workflow can't scream if it never starts).
+ *
+ * Secrets: GITHUB_TOKEN (fine-grained PAT, Actions read/write on the repo),
+ * ADMIN_KEY (manual-trigger gate), TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID.
+ */
+const DISPATCH_URL =
+  'https://api.github.com/repos/dannythehat/golden-bet-ai/actions/workflows/daily-update.yml/dispatches';
+
+export default {
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(kick(env));
+  },
+  // Manual trigger for testing: GET /?key=<ADMIN_KEY>
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.searchParams.get('key') !== env.ADMIN_KEY) return new Response('not found', { status: 404 });
+    const result = await kick(env);
+    return new Response(JSON.stringify(result), { headers: { 'content-type': 'application/json' } });
+  },
+};
+
+async function kick(env) {
+  try {
+    const res = await fetch(DISPATCH_URL, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        accept: 'application/vnd.github+json',
+        'user-agent': 'footy-morning-trigger',
+        'x-github-api-version': '2022-11-28',
+      },
+      body: JSON.stringify({ ref: 'main' }),
+    });
+    if (res.status === 204) return { ok: true, kicked: true };
+    const detail = (await res.text()).slice(0, 140);
+    await alarm(env, `🚨 Morning trigger: GitHub refused the dispatch (${res.status}). ${detail}`);
+    return { ok: false, status: res.status };
+  } catch (e) {
+    await alarm(env, `🚨 Morning trigger crashed before reaching GitHub: ${e.message}`);
+    return { ok: false, error: String(e) };
+  }
+}
+
+async function alarm(env, text) {
+  if (!env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text }),
+    });
+  } catch {
+    /* the alarm about the alarm failing goes nowhere — nothing else to do */
+  }
+}

--- a/workers/morning-trigger/wrangler.toml
+++ b/workers/morning-trigger/wrangler.toml
@@ -1,0 +1,11 @@
+# The punctual alarm clock. GitHub's own scheduler fires hours late or not at
+# all; Cloudflare cron fires on the minute. This worker's only job is to kick
+# the Daily Board + P&L workflow every morning.
+name = "footy-morning-trigger"
+main = "src/index.js"
+compatibility_date = "2026-01-01"
+
+[triggers]
+# 03:10 UTC — 06:10 in Sofia, 04:10 in London. One slot is enough here:
+# unlike GitHub, Cloudflare cron actually fires when told.
+crons = ["10 3 * * *"]


### PR DESCRIPTION
A Cloudflare Worker cron that kicks the Daily Board + P&L workflow at 03:10 UTC sharp (06:10 Sofia) — replacing GitHub's unreliable scheduler as the alarm clock. If the dispatch fails, it raises the alarm on Telegram directly (the workflow can't scream if it never starts). Includes a key-gated manual trigger for testing.

**Code only** — contains no secrets and is not yet deployed. The GitHub PAT, admin key and Telegram credentials go into the worker's encrypted secret store at deploy time, pending the owner's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_