### PR TITLE
Pick verdicts quote the real numbers, like the results write-up

### DIFF
--- a/src/data/gaffer/phraseLibrary.ts
+++ b/src/data/gaffer/phraseLibrary.ts
@@ -126,6 +126,26 @@ export const MARKET_FLAVOUR: Record<string, string[]> = {
   ],
 };
 
+/* ── Evidence — the actual numbers behind a pick, spoken with team names ──
+ * This is what separates a read from a slogan: the Gaffer quotes the real
+ * hit counts and averages from the form tables, same as he quotes real
+ * scorelines after the games. COMBO entries need avgs + hit rate; HITS
+ * entries need only the hit rate (BTTS, or when averages are missing). */
+export const EVIDENCE_COMBO = [
+  'Let’s talk actual numbers: {team}’s recent games have been running at {homeAvg} {unit} apiece and {opp}’s at {awayAvg}, and this exact line has landed in {hits} of their combined last {total} matches — that’s not a hunch, that’s a habit.',
+  'The tale of the tape reads {homeAvg} {unit} a game around {team} lately and {awayAvg} around {opp} — and sure enough, {hits} of their combined last {total} have cleared this line.',
+  'Between them, {team} and {opp} have cleared this line in {hits} of their last {total}, and the shape behind it is solid — {homeAvg} {unit} per game in one camp, {awayAvg} in the other.',
+  'I counted it twice: {hits} of the last {total} matches involving {team} and {opp} have gone over this line, off the back of {homeAvg} and {awayAvg} {unit} a game respectively — the pattern is doing all the work here.',
+  '{team} have been living at {homeAvg} {unit} a game, {opp} at {awayAvg}, and this line has been beaten in {hits} of their combined last {total} — when both roads point the same way, I stop arguing with the map.',
+] as const;
+
+export const EVIDENCE_HITS = [
+  'The receipts are simple: across {team} and {opp}’s combined last {total} matches, this exact bet has landed {hits} times — I didn’t have to dig for it, it was lying in plain sight.',
+  'Check the recent ledger — {hits} of the last {total} games involving {team} and {opp} have seen this land, and that kind of consistency is exactly what the price is failing to respect.',
+  '{hits} out of the combined last {total} for {team} and {opp} — that’s how often this has been landing lately, and form like that tends to keep its habits longer than the odds admit.',
+  'Strip away the opinions and count: {team} and {opp}’s last {total} between them, {hits} times this came in. I back counts, not vibes.',
+] as const;
+
 /* ── Verdicts — STRONG tier (his bankers) ────────────────────────────────── */
 export const VERDICT_STRONG = [
   'This is the strongest call on the card by a distance, and I don’t say that lightly — I’ve turned down prettier prices this morning because the football didn’t back them up. This one has both.',

--- a/src/lib/gafferSelection.ts
+++ b/src/lib/gafferSelection.ts
@@ -8,9 +8,36 @@
  */
 import raw from '@/data/formTablesData.json';
 import type { FormFixtureRow, FormValueCell } from '@/types/footy';
-import { gafferReason } from '@/lib/gafferVoice';
+import { gafferReason, type PickEvidence } from '@/lib/gafferVoice';
 
 const DATA = raw as unknown as { fixtures: FormFixtureRow[] };
+
+/* ── The concrete facts behind a pick — mined from both teams' recent games
+ *    so the Gaffer's pre-match read quotes real numbers, like his results
+ *    write-up does. ─────────────────────────────────────────────────────── */
+type FG = { gf?: number; ga?: number; corners?: number; cards?: number; btts?: boolean };
+function evidenceFor(f: FormFixtureRow, market: 'Goals' | 'Corners' | 'BTTS' | 'Cards', selection: string): PickEvidence | undefined {
+  const line = Number(/(\d+(?:\.\d+)?)/.exec(selection)?.[1] ?? 0);
+  const homeGames = ((f as unknown as { home_form?: FG[] }).home_form ?? []).slice(0, 8);
+  const awayGames = ((f as unknown as { away_form?: FG[] }).away_form ?? []).slice(0, 8);
+  const metric = (g: FG) =>
+    market === 'Goals' ? (g.gf ?? 0) + (g.ga ?? 0)
+    : market === 'Corners' ? g.corners ?? 0
+    : market === 'Cards' ? g.cards ?? 0
+    : g.btts ? 1 : 0;
+  const hit = (g: FG) => (market === 'BTTS' ? !!g.btts : metric(g) > line);
+  const both = [...homeGames, ...awayGames];
+  if (!both.length) return undefined;
+  const avg = (gs: FG[]) => (gs.length ? Math.round((gs.reduce((p, g) => p + metric(g), 0) / gs.length) * 10) / 10 : null);
+  const unit = market === 'Goals' ? 'goals' : market === 'Corners' ? 'corners' : market === 'Cards' ? 'cards' : undefined;
+  return {
+    hits: both.filter(hit).length,
+    total: both.length,
+    homeAvg: market === 'BTTS' ? null : avg(homeGames),
+    awayAvg: market === 'BTTS' ? null : avg(awayGames),
+    unit,
+  };
+}
 export const STAKE = 10;
 
 /** Today's UK date (YYYY-MM-DD) — the Gaffer only picks from today's card. */
@@ -75,6 +102,7 @@ export function getGafferPicks(): Leg[] {
           team: base.home.name, opp: base.away.name, market: base.market,
           selection: base.selection, odds: base.odds, pct: base.prob,
           edge: base.edge, tier: base.flag,
+          evidence: evidenceFor(f, base.market, base.selection),
         },
         base.fixtureId,
       ),
@@ -105,7 +133,7 @@ export function getValueFixtures(): Leg[] {
     fixtureId: f.id, home: f.home, away: f.away, region: f.region, league: f.league, time: f.time,
     market, selection, odds: cell.odds!, prob: cell.prob, edge: cell.edge, flag: cell.flag ?? 'value',
     placeholderReason: gafferReason(
-      { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value' },
+      { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value', evidence: evidenceFor(f, market, selection) },
       f.id,
     ),
   });
@@ -137,7 +165,7 @@ export function getValueCandidates(): Leg[] {
       time: localKO(koMs, f.time), kickoffMs: koMs,
       market, selection, odds: cell.odds!, prob: cell.prob, edge: cell.edge, flag: cell.flag ?? 'value',
       placeholderReason: gafferReason(
-        { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value' },
+        { team: f.home.name, opp: f.away.name, market, selection, odds: cell.odds!, pct: cell.prob, edge: cell.edge, tier: cell.flag ?? 'value', evidence: evidenceFor(f, market, selection) },
         f.id,
       ),
     };

--- a/src/lib/gafferVoice.ts
+++ b/src/lib/gafferVoice.ts
@@ -13,6 +13,7 @@
 import {
   OPENERS, MARKET_FLAVOUR, VERDICT_STRONG, VERDICT_VALUE, EDGE_PHRASES,
   HEDGES, SIGN_OFFS, ASIDES, NO_BET, DONKEY_ROASTS, nickname,
+  EVIDENCE_COMBO, EVIDENCE_HITS,
 } from '../data/gaffer/phraseLibrary';
 import {
   DAY_OPENERS, DAY_PERFECT, DAY_WIN, DAY_MIXED, DAY_ALL_LOST,
@@ -20,6 +21,15 @@ import {
 } from '../data/gaffer/dayVerdict';
 
 export type Market = 'Corners' | 'Goals' | 'Cards' | 'BTTS';
+
+/** The concrete facts behind a pick — same fuel the results write-up runs on. */
+export interface PickEvidence {
+  hits: number;           // times the exact line landed across both teams' recent games
+  total: number;          // games counted
+  homeAvg?: number | null; // per-game metric average in the home side's recent games
+  awayAvg?: number | null;
+  unit?: string;           // 'goals' | 'corners' | 'cards'
+}
 
 export interface PickSignals {
   team: string;
@@ -32,6 +42,7 @@ export interface PickSignals {
   edge: number;
   streak?: number;       // current run in the market (optional)
   tier: 'strong' | 'value';
+  evidence?: PickEvidence; // when present, the read quotes the real numbers
 }
 
 /* ── Deterministic-but-varied RNG (so a given seed is reproducible) ───────── */
@@ -111,18 +122,26 @@ export function gafferPickLine(s: PickSignals, seed = '', flavourful = true): st
  */
 export function gafferReason(s: PickSignals, seed = ''): string {
   const rng = mulberry32(seedOf(`${s.team}|${s.opp}|${s.market}|reason|${seed}`));
-  const vars = varsFor(s, rng);
-  // Read → value → PUNCHLINE. He lands on a bit of wit or a confident verdict —
-  // never a limp "bet responsibly" hedge (that belongs on the small print, not
-  // in his mouth). Keeps every pick fun, funny and sharp.
+  const vars: Record<string, string | number> = varsFor(s, rng);
+  // Read → EVIDENCE (the real numbers, with team names — what makes it a read
+  // about THIS game and not any game) → value → PUNCHLINE. He lands on wit or
+  // a confident verdict, never a limp hedge.
   const closer = rng() > 0.38
     ? pick(ASIDES, 'aside', rng)
     : pick(verdictBankFor(s), `verdict:${s.tier}`, rng);
-  const parts = [
-    pick(MARKET_FLAVOUR[s.market] ?? MARKET_FLAVOUR.Goals, `flavour:${s.market}`, rng),
-    pick(edgeBankFor(s), 'edge', rng),
-    closer,
-  ];
+  const parts = [pick(MARKET_FLAVOUR[s.market] ?? MARKET_FLAVOUR.Goals, `flavour:${s.market}`, rng)];
+  const ev = s.evidence;
+  if (ev && ev.total > 0) {
+    vars.hits = ev.hits; vars.total = ev.total;
+    const combo = ev.homeAvg != null && ev.awayAvg != null && ev.unit;
+    if (combo) {
+      vars.homeAvg = ev.homeAvg!.toFixed(1); vars.awayAvg = ev.awayAvg!.toFixed(1); vars.unit = ev.unit!;
+      parts.push(pick(EVIDENCE_COMBO as unknown as string[], 'evidence:combo', rng));
+    } else {
+      parts.push(pick(EVIDENCE_HITS as unknown as string[], 'evidence:hits', rng));
+    }
+  }
+  parts.push(pick(edgeBankFor(s), 'edge', rng), closer);
   return parts.map((p) => fill(p, vars)).join(' ');
 }
 

--- a/src/lib/valueBoard.ts
+++ b/src/lib/valueBoard.ts
@@ -464,6 +464,12 @@ export function getFixtureValueBreakdown(fixtureId: string, marketKey: ValueMark
     selection: m.label, mark: m.line ?? undefined,
     odds: row.oddsSnapshot ?? 0, pct: row.modelProbability, edge: row.valueGap,
     tier: row.confidence === 'high' ? 'strong' : 'value',
+    evidence: hits ? {
+      hits: hits.hits, total: hits.total,
+      homeAvg: m.family === 'btts' ? null : homeAvg,
+      awayAvg: m.family === 'btts' ? null : awayAvg,
+      unit: m.family === 'btts' ? undefined : m.family,
+    } : undefined,
   };
 
   const { gafferNote: _drop, ...rest } = row;


### PR DESCRIPTION
The pre-match reads were generic market patter ("both these teams attack like the game owes them something…") while the settled-day verdicts named teams and quoted scorelines. The difference was fuel, not voice — the results engine gets real facts, the picks engine didn't.

- `PickSignals` gains an **evidence** payload: exact-line hit count across both teams' recent games, plus per-side metric averages (goals/corners/cards per game) — mined from the same form-table data the tables already show.
- Two new phrase banks (`EVIDENCE_COMBO`, `EVIDENCE_HITS`) weave those facts into flowing sentences **with team names**, anti-repeat as ever.
- Wired at every read: selection-engine legs (double/treble/top pick), value-watch fallbacks, and Value Board fixture breakdowns.

Sample output (today's real card):
> "Neither side can keep a clean sheet to save their lives, but both have forwards in genuine form… **The receipts are simple: across Cheonan City and Gimhae City's combined last 16 matches, this exact bet has landed 11 times — I didn't have to dig for it, it was lying in plain sight.** The form says 67%, the price says 1.83…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_