### PR TITLE
Abandoned matches: void the leg, settle on the rest

### DIFF
--- a/functions/api/inplay.ts
+++ b/functions/api/inplay.ts
@@ -30,6 +30,7 @@ function shape(m: Json, nowSec: number) {
   const ko = num(m.date_unix);
   const status = String(m.status ?? "");
   const complete = status === "complete";
+  const voided = ["suspended", "canceled", "cancelled", "abandoned", "postponed"].includes(status);
   const started = ko > 0 && nowSec >= ko;
   const live = started && !complete && nowSec < ko + 160 * 60;
   const homeGoals = num(m.homeGoalCount);
@@ -43,8 +44,9 @@ function shape(m: Json, nowSec: number) {
   const minuteRaw = m.game_minute ?? m.minute;
   const feed = complete || minuteRaw != null || cornersRaw >= 0 || homeGoals + awayGoals > 0;
   return {
-    live,
+    live: live && !voided,
     ended: complete,
+    voided,
     feed,
     goals: homeGoals + awayGoals,
     homeGoals,

--- a/scripts/settle.mjs
+++ b/scripts/settle.mjs
@@ -31,6 +31,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const FORM_PATH = join(ROOT, 'src/data/formTablesData.json');
 const LEDGER_PATH = join(ROOT, 'src/data/pnlLedger.json');
+const VOIDS_PATH = join(ROOT, 'src/data/voids.json');
+
+// Abandoned/void handling — bookmaker convention: a void leg's odds become
+// 1.00 and the bet settles on the remaining legs; all legs void = stake back.
+// Sources: FootyStats status (when it's honest) + the voids.json override for
+// days when the feed marks an abandoned game 'complete' with a partial score.
+const VOID_STATUSES = new Set(['suspended', 'canceled', 'cancelled', 'abandoned', 'postponed']);
+let VOIDS = {};
+try { VOIDS = JSON.parse(readFileSync(VOIDS_PATH, 'utf8')); } catch { /* no overrides */ }
 const STAKE = 10;
 const round2 = (n) => Math.round(n * 100) / 100;
 
@@ -82,19 +91,25 @@ function settleLeg(leg, m) {
 function buildBet(kind, legs, resultsById) {
   const settled = legs.map((l) => {
     const m = resultsById.get(String(l.fixtureId));
+    // Void leg: odds collapse to 1.00, result recorded as 'void'.
+    if (VOIDS[String(l.fixtureId)] || (m && VOID_STATUSES.has(String(m.status)))) {
+      return { ...l, ft: 'ABD', result: 'void', odds: 1 };
+    }
     if (!m || m.status !== 'complete') return null; // not finished → can't settle yet
     return settleLeg(l, m);
   });
   if (settled.some((s) => s === null)) return { pending: true };
   // Multiply the exact odds (a bookmaker settles on the real product, not the
   // rounded-for-display figure), then round the money once at the end.
-  const rawOdds = settled.reduce((p, l) => p * l.odds, 1);
+  const rawOdds = settled.reduce((p, l) => p * l.odds, 1); // void legs are 1.00
   const combinedOdds = round2(rawOdds);
-  const allWon = settled.every((l) => l.result === 'won');
-  const returns = allWon ? round2(STAKE * rawOdds) : 0;
+  const anyLost = settled.some((l) => l.result === 'lost');
+  const allVoid = settled.every((l) => l.result === 'void');
+  const status = anyLost ? 'lost' : allVoid ? 'void' : 'won';
+  const returns = status === 'lost' ? 0 : round2(STAKE * rawOdds); // all-void → stake back
   return {
     kind, stake: STAKE, combinedOdds,
-    status: allWon ? 'won' : 'lost',
+    status,
     returns, profit: round2(returns - STAKE),
     legs: settled.map(({ fixtureId, prob, edge, market, ...keep }) => keep),
   };

--- a/src/components/homepage/GafferValueBoardSection.tsx
+++ b/src/components/homepage/GafferValueBoardSection.tsx
@@ -8,6 +8,7 @@ import { useLiveDailyPicks } from './useLiveDailyPicks';
 import { useInPlay, type InPlayState } from './useInPlay';
 import { useLiveScores, matchLive, type LiveScore } from './useLiveScores';
 import rawSnapshot from '@/data/formTablesData.json';
+import rawVoids from '@/data/voids.json';
 import type { FormFixtureRow } from '@/types/footy';
 
 // ── in-play (time-based v1; live counts land once the FootyStats poller ships) ──
@@ -65,7 +66,11 @@ function settleLeg(leg: Leg, ip: InPlayState): 'won' | 'lost' | null {
 const cornerNote = (leg: Leg, ip: InPlayState): string =>
   leg.market === 'Corners' && ip.corners != null ? ` · ${ip.corners} crn` : '';
 
+const VOIDS = rawVoids as Record<string, { date: string; reason: string }>;
+
 function statusInfo(leg: Leg, ip?: InPlayState, live?: LiveScore): StatusInfo | null {
+  // Abandoned — the leg is void (bookie convention), never won or lost.
+  if (VOIDS[leg.fixtureId] || ip?.voided) return { state: 'ft', text: 'Abandoned · leg void' };
   // Finished — FootyStats carries the final numbers → settle Won/Lost.
   if (ip?.ended) return { state: 'ft', result: settleLeg(leg, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}${cornerNote(leg, ip)}` };
   // Live score from API-Football (real in-play, carries the minute).

--- a/src/components/homepage/useInPlay.ts
+++ b/src/components/homepage/useInPlay.ts
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 // /api/inplay (which proxies FootyStats server-side). corners/cards are null
 // when the feed hasn't recorded them yet — never a made-up number.
 export type InPlayState = {
+  /** Match abandoned/suspended/postponed — the leg is void, never won or lost. */
+  voided?: boolean;
   /** FootyStats has real live numbers (false = placeholder 0-0, hide score). */
   feed?: boolean;
   live: boolean;

--- a/src/components/pnl/BetCard.tsx
+++ b/src/components/pnl/BetCard.tsx
@@ -11,6 +11,7 @@ const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
  */
 export function BetCard({ bet }: { bet: LedgerBet }) {
   const won = bet.status === 'won';
+  const voided = bet.status === 'void';
   const d = new Date(bet.date + 'T12:00:00');
   return (
     <div
@@ -19,7 +20,9 @@ export function BetCard({ bet }: { bet: LedgerBet }) {
         : 'shadow-[0_28px_56px_-28px_rgba(0,0,0,1),0_0_40px_-18px_rgba(244,63,94,0.45)]'}`}
       style={{ background: won
         ? 'linear-gradient(155deg,#6ee7b7 0%,#059669 50%,#34d399 100%)'
-        : 'linear-gradient(155deg,rgba(251,113,133,0.75) 0%,rgba(124,58,237,0.5) 48%,rgba(251,113,133,0.6) 100%)' }}
+        : voided
+          ? 'linear-gradient(155deg,rgba(255,255,255,0.35) 0%,rgba(255,255,255,0.1) 50%,rgba(255,255,255,0.22) 100%)'
+          : 'linear-gradient(155deg,rgba(251,113,133,0.75) 0%,rgba(124,58,237,0.5) 48%,rgba(251,113,133,0.6) 100%)' }}
     >
       <div className="card-3d overflow-hidden rounded-[1.05rem] p-3.5 md:p-4">
         {/* header — kind + date + result */}
@@ -28,8 +31,8 @@ export function BetCard({ bet }: { bet: LedgerBet }) {
             <span className="rounded-full border border-violet-400/45 bg-violet-500/15 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-violet-200">{cap(bet.kind)}</span>
             <span className="text-[11px] font-semibold text-white/45">{d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
           </div>
-          <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-black uppercase tracking-wide ${won ? 'border-emerald-400/55 bg-emerald-500/15 text-emerald-200' : 'border-rose-400/55 bg-rose-500/15 text-rose-200'}`}>
-            {won ? 'Won ✓' : 'Lost ✗'}
+          <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-black uppercase tracking-wide ${won ? 'border-emerald-400/55 bg-emerald-500/15 text-emerald-200' : voided ? 'border-white/25 bg-white/[0.08] text-white/70' : 'border-rose-400/55 bg-rose-500/15 text-rose-200'}`}>
+            {won ? 'Won ✓' : voided ? 'Void — stake returned' : 'Lost ✗'}
           </span>
         </div>
 
@@ -37,6 +40,7 @@ export function BetCard({ bet }: { bet: LedgerBet }) {
         <div className="mt-3 space-y-2">
           {bet.legs.map((l, i) => {
             const lw = l.result === 'won';
+            const lv = l.result === 'void';
             return (
               <div key={i} className="inset-3d flex items-center gap-2.5 rounded-xl px-3 py-2">
                 <div className="flex shrink-0 -space-x-1.5">
@@ -46,11 +50,11 @@ export function BetCard({ bet }: { bet: LedgerBet }) {
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-[12.5px] font-bold leading-tight text-white text-emboss">{l.home} <span className="text-white/30">v</span> {l.away}</div>
                   <div className="truncate text-[10px] leading-tight text-white/50">
-                    <span className="text-[#f8e7a1]/80">{l.selection}</span> · {l.odds.toFixed(2)}{l.ft ? ` · FT ${l.ft}` : ''}
+                    <span className="text-[#f8e7a1]/80">{l.selection}</span> · {l.odds.toFixed(2)}{l.ft ? (l.ft === 'ABD' ? ' · Abandoned' : ` · FT ${l.ft}`) : ''}
                   </div>
                 </div>
-                <span className={`shrink-0 rounded-md px-2 py-0.5 text-[9px] font-black uppercase tracking-wide ${lw ? 'bg-emerald-500/20 text-emerald-300 ring-1 ring-inset ring-emerald-400/25' : 'bg-rose-500/20 text-rose-300 ring-1 ring-inset ring-rose-400/25'}`}>
-                  {lw ? 'Won' : 'Lost'}
+                <span className={`shrink-0 rounded-md px-2 py-0.5 text-[9px] font-black uppercase tracking-wide ${lw ? 'bg-emerald-500/20 text-emerald-300 ring-1 ring-inset ring-emerald-400/25' : lv ? 'bg-white/10 text-white/60 ring-1 ring-inset ring-white/20' : 'bg-rose-500/20 text-rose-300 ring-1 ring-inset ring-rose-400/25'}`}>
+                  {lw ? 'Won' : lv ? 'Void' : 'Lost'}
                 </span>
               </div>
             );
@@ -60,7 +64,7 @@ export function BetCard({ bet }: { bet: LedgerBet }) {
         {/* footer — stake, odds, return, profit */}
         <div className="mt-3 flex items-center justify-between gap-2 border-t border-white/10 pt-2.5">
           <span className="text-[12px] text-white/55">
-            {money(bet.stake)} @ <b className="text-white/75">{bet.combinedOdds.toFixed(2)}</b> → <b className={won ? 'text-[#f8e7a1]' : 'text-white/40'}>{won ? money(bet.returns) : '£0'}</b>
+            {money(bet.stake)} @ <b className="text-white/75">{bet.combinedOdds.toFixed(2)}</b> → <b className={won || voided ? 'text-[#f8e7a1]' : 'text-white/40'}>{bet.status === 'lost' ? '£0' : money(bet.returns)}</b>
           </span>
           <span className={`font-display text-xl leading-none text-extrude ${bet.profit >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>
             {bet.profit >= 0 ? '+' : '−'}{money(Math.abs(bet.profit))}

--- a/src/data/pnlLedger.json
+++ b/src/data/pnlLedger.json
@@ -5,10 +5,10 @@
       "date": "2026-07-10",
       "kind": "double",
       "stake": 10,
-      "combinedOdds": 3.11,
-      "status": "lost",
-      "returns": 0,
-      "profit": -10,
+      "combinedOdds": 1.7,
+      "status": "won",
+      "returns": 17,
+      "profit": 7,
       "legs": [
         {
           "home": "Cheonan City",
@@ -16,9 +16,9 @@
           "region": "South Korea",
           "league": "K League 2",
           "selection": "BTTS - Yes",
-          "odds": 1.83,
-          "ft": "0-1",
-          "result": "lost"
+          "odds": 1,
+          "ft": "ABD",
+          "result": "void"
         },
         {
           "home": "Harju Jalgpallikool",
@@ -31,7 +31,7 @@
           "result": "won"
         }
       ],
-      "verdict": "Every morning I mark my own homework in public, which is either brave or daft depending on the scoreline — let’s find out which today. A blank, and it stings — nothing landed, the ledger takes a knock, and I take it on the chin in public, because that’s the deal we have. Our BTTS died in Cheonan City v Gimhae City, where Cheonan City forgot their shooting boots entirely — 0-1 at the whistle, one net untouched, slip down the drain. Same time tomorrow, same honest report — bring your tenner, bring your patience, and let the numbers do their slow, reliable work."
+      "verdict": "Every morning I mark my own homework in public, which is either brave or daft depending on the scoreline — let’s find out which today. Mixed bag, and I’ll give it to you straight: the double banked, the treble came up a leg short, and the ledger still moved the right direction — which is the bit that matters. The pick of the winners was the Harju Jalgpallikool game — 3-0, 3 goals for the greedy, and the sweet feeling of watching a form read play out to the letter. The costly one was Suwon v Jeonnam Dragons at 5-0 — I needed both to score and Jeonnam Dragons never looked like obliging, which is football’s way of keeping a man humble. The card never sleeps and neither does the spreadsheet — see you in the morning with the next round of value."
     },
     {
       "date": "2026-07-10",
@@ -73,7 +73,7 @@
           "result": "won"
         }
       ],
-      "verdict": "Every morning I mark my own homework in public, which is either brave or daft depending on the scoreline — let’s find out which today. A blank, and it stings — nothing landed, the ledger takes a knock, and I take it on the chin in public, because that’s the deal we have. Our BTTS died in Cheonan City v Gimhae City, where Cheonan City forgot their shooting boots entirely — 0-1 at the whistle, one net untouched, slip down the drain. Same time tomorrow, same honest report — bring your tenner, bring your patience, and let the numbers do their slow, reliable work."
+      "verdict": "Every morning I mark my own homework in public, which is either brave or daft depending on the scoreline — let’s find out which today. Mixed bag, and I’ll give it to you straight: the double banked, the treble came up a leg short, and the ledger still moved the right direction — which is the bit that matters. The pick of the winners was the Harju Jalgpallikool game — 3-0, 3 goals for the greedy, and the sweet feeling of watching a form read play out to the letter. The costly one was Suwon v Jeonnam Dragons at 5-0 — I needed both to score and Jeonnam Dragons never looked like obliging, which is football’s way of keeping a man humble. The card never sleeps and neither does the spreadsheet — see you in the morning with the next round of value."
     },
     {
       "date": "2026-07-09",

--- a/src/data/voids.json
+++ b/src/data/voids.json
@@ -1,0 +1,3 @@
+{
+  "8471630": { "date": "2026-07-10", "reason": "Abandoned — leg void, bet settles on the remaining legs" }
+}

--- a/src/pages/FormTables.tsx
+++ b/src/pages/FormTables.tsx
@@ -11,6 +11,7 @@ import { useInPlay, type InPlayState } from '@/components/homepage/useInPlay';
 import { useLiveScores, matchLive, type LiveScore } from '@/components/homepage/useLiveScores';
 import { supabase } from '@/integrations/supabase/client';
 import raw from '@/data/formTablesData.json';
+import rawVoids from '@/data/voids.json';
 import type { FormFixtureRow as Fixture, FormValueCell, FormValueFlag, FormGame } from '@/types/footy';
 
 type ValueCell = FormValueCell | null;
@@ -299,6 +300,7 @@ function metricNote(catKey: CatKey, ip: InPlayState): string {
 
 function valueStatus(sel: ValueSel, ip: InPlayState | undefined, live: LiveScore | undefined, today: string): VStatus | null {
   // Finished — settle Won/Lost from FootyStats final numbers (+ corner/card count).
+  if ((rawVoids as Record<string, unknown>)[sel.f.id] || ip?.voided) return { state: 'ft', text: 'Abandoned · void' };
   if (ip?.ended) return { state: 'ft', result: settleMarket(sel.catKey, sel.line, sel.under, ip) ?? undefined, text: `FT ${ip.homeGoals}–${ip.awayGoals}${metricNote(sel.catKey, ip)}` };
   // Real live score from API-Football.
   if (live) {


### PR DESCRIPTION
Bookmaker convention, enforced end to end: **a void leg's odds collapse to 1.00 and the bet settles on the remaining legs**; all legs void returns the stake (status `void`, profit £0).

**Detection is twofold** because the data source proved unreliable today — FootyStats marked the abandoned Cheonan City v Gimhae City "complete" with the partial 0–1 score:
- automatic: FootyStats void statuses (suspended / canceled / abandoned / postponed)
- manual: a committed `src/data/voids.json` override, read by `settle.mjs` on every run so the cron's idempotent daily re-settle keeps the void forever

**Display:** board and form-table status chips show "Abandoned · leg void" (neutral, never won/lost); BetCard gets a neutral rim, "Void — stake returned" header, per-leg VOID badge and "Abandoned" in place of the FT score.

**Backfill (already live):** 10 Jul double — Cheonan leg void, settles WON **+£7.00** on Harju Jalgpallikool alone (3–0, Over 2.5 ✓); treble lost (Suwon 5–0 killed BTTS). Record **+£16.17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for voided or abandoned match legs across live match displays, form tables, and bet cards.
  - Void bets now show a distinct outcome, return the original stake when applicable, and settle remaining valid legs normally.
  - Added clearer “Abandoned · void” and “Void — stake returned” labels.
- **Bug Fixes**
  - Prevented voided matches from being shown as live or incorrectly settled as wins or losses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->