### PR TITLE
Value Board: real match state, not a wall clock

### DIFF
--- a/src/components/valueboard/GafferDailyCardSection.tsx
+++ b/src/components/valueboard/GafferDailyCardSection.tsx
@@ -1,11 +1,28 @@
 import { Star, Layers, Bell, Clock, Trophy, ShieldAlert } from 'lucide-react';
 import { TeamAvatar } from '@/components/TeamAvatar';
 import { BoardSection } from './BoardSection';
-import type { GafferDailyCardData, DailyCardSelection } from '@/lib/valueBoard';
+import { settleMarketKey, VOIDS, type GafferDailyCardData, type DailyCardSelection, type InPlayLite } from '@/lib/valueBoard';
 
 /** One selection — the homepage leg-card language: crests, gold odds,
  *  confidence bar, emerald edge chip, one short line from the Gaffer. */
-function SelectionCard({ s }: { s: DailyCardSelection }) {
+function SelectionCard({ s, ip }: { s: DailyCardSelection; ip?: InPlayLite }) {
+  // Real match state beats the clock: FT with result, live score, or KO time.
+  const voided = !!VOIDS[s.fixtureId] || !!ip?.voided;
+  const result = ip?.ended && s.marketKey ? settleMarketKey(s.marketKey, ip) : null;
+  const isCorners = s.marketKey?.includes('corners');
+  const crn = isCorners && ip?.corners != null ? ` · ${ip.corners} crn` : '';
+  const statusChip = voided ? (
+    <span className="inline-flex shrink-0 items-center rounded-full border border-white/25 bg-white/[0.08] px-2.5 py-1 text-[10px] font-black uppercase tracking-wide text-white/70">Abandoned · void</span>
+  ) : ip?.ended ? (
+    <span className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-[10px] font-black uppercase tracking-wide [font-variant-numeric:tabular-nums] ${result === 'won' ? 'border-emerald-400/55 bg-emerald-500/15 text-emerald-200' : result === 'lost' ? 'border-rose-400/55 bg-rose-500/15 text-rose-200' : 'border-white/20 bg-white/[0.06] text-white/70'}`}>
+      FT {ip.homeGoals}–{ip.awayGoals}{crn}{result === 'won' ? ' · Won ✓' : result === 'lost' ? ' · Lost' : ''}
+    </span>
+  ) : ip?.live && ip.feed ? (
+    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-400/55 bg-emerald-500/15 px-2.5 py-1 text-[10px] font-black uppercase tracking-wide text-emerald-200 [font-variant-numeric:tabular-nums]">
+      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 [animation:pulse_1.4s_ease-in-out_infinite]" />
+      LIVE · {ip.homeGoals}–{ip.awayGoals}{crn}
+    </span>
+  ) : null;
   return (
     <div
       className="relative rounded-[15px] p-px shadow-[0_2px_4px_-1px_rgba(0,0,0,0.7),0_24px_44px_-20px_rgba(0,0,0,0.95)]"
@@ -33,9 +50,11 @@ function SelectionCard({ s }: { s: DailyCardSelection }) {
             <Trophy className="h-2.5 w-2.5 shrink-0 text-[#f5c542]/70" />
             <span className="truncate text-[9px] font-black uppercase tracking-[0.16em] text-[#f8e7a1]/70">{s.league}</span>
           </span>
-          <span className="inline-flex shrink-0 items-center gap-1 text-[12px] font-black text-[#f8e7a1] [font-variant-numeric:tabular-nums]">
-            <Clock className="h-3 w-3 text-[#f5c542]/80" /> {s.kickoffLabel} <span className="text-[8px] font-black uppercase tracking-[0.18em] text-white/35">KO</span>
-          </span>
+          {statusChip ?? (
+            <span className="inline-flex shrink-0 items-center gap-1 text-[12px] font-black text-[#f8e7a1] [font-variant-numeric:tabular-nums]">
+              <Clock className="h-3 w-3 text-[#f5c542]/80" /> {s.kickoffLabel} <span className="text-[8px] font-black uppercase tracking-[0.18em] text-white/35">KO</span>
+            </span>
+          )}
         </div>
 
         {/* the pick */}
@@ -80,7 +99,7 @@ function SelectionCard({ s }: { s: DailyCardSelection }) {
 
 /** The Gaffer's Daily Card — surfaces the tipping engine's locked double and
  *  treble (this page never re-picks). Honest quiet-day state when thin. */
-export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDailyCardData; onEmailCard: () => void }) {
+export function GafferDailyCardSection({ card, inplay, onEmailCard }: { card: GafferDailyCardData; inplay?: Record<string, InPlayLite>; onEmailCard: () => void }) {
   return (
     <BoardSection id="gaffer-daily-card" tone="gold">
       {/* the Gaffer keeps an eye on his card */}
@@ -111,7 +130,7 @@ export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDail
                 <Star className="h-3.5 w-3.5" /> Daily Double
               </div>
               <div className="space-y-3">
-                {card.double.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} />)}
+                {card.double.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} ip={inplay?.[s.fixtureId]} />)}
               </div>
             </div>
             <div>
@@ -120,7 +139,7 @@ export function GafferDailyCardSection({ card, onEmailCard }: { card: GafferDail
               </div>
               {card.treble.available ? (
                 <div className="space-y-3">
-                  {card.treble.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} />)}
+                  {card.treble.selections.map((s) => <SelectionCard key={s.fixtureId} s={s} ip={inplay?.[s.fixtureId]} />)}
                 </div>
               ) : (
                 <div className="rounded-[13px] border border-white/10 bg-black/25 p-5 text-sm text-white/55">

--- a/src/components/valueboard/MarketBoard.tsx
+++ b/src/components/valueboard/MarketBoard.tsx
@@ -3,8 +3,8 @@ import { X, BellPlus, Swords, TrendingUp, Activity, Search } from 'lucide-react'
 import { TeamAvatar } from '@/components/TeamAvatar';
 import { BoardSection } from './BoardSection';
 import {
-  FAMILIES, VALUE_MARKETS, type HubSummary, type MarketSummary,
-  type ValueMarketFamily, type ValueMarketKey, type Confidence, type FixtureStatus,
+  FAMILIES, VALUE_MARKETS, settleMarketKey, VOIDS, type HubSummary, type MarketSummary,
+  type ValueMarketFamily, type ValueMarketKey, type Confidence, type FixtureStatus, type InPlayLite,
 } from '@/lib/valueBoard';
 import { useValueMarketFixtures, useFixtureValueBreakdown, useValueBoardLeagues } from '@/hooks/useValueBoard';
 
@@ -74,7 +74,7 @@ function ValueMarketCard({ s, active, onOpen }: { s: MarketSummary; active: bool
 }
 
 /* ── Ranked fixtures for the selected market ────────────────────────────── */
-function MarketFixtureTable({ marketKey, onRowClick }: { marketKey: ValueMarketKey; onRowClick: (fixtureId: string) => void }) {
+function MarketFixtureTable({ marketKey, onRowClick, inplay }: { marketKey: ValueMarketKey; onRowClick: (fixtureId: string) => void; inplay?: Record<string, InPlayLite> }) {
   const [league, setLeague] = useState('all');
   const leagues = useValueBoardLeagues();
   const res = useValueMarketFixtures({ marketKey, league });
@@ -114,7 +114,17 @@ function MarketFixtureTable({ marketKey, onRowClick }: { marketKey: ValueMarketK
                 <div className="truncate text-[13.5px] font-semibold text-white">{r.fixture}</div>
                 <div className="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[10.5px] text-white/45 [font-variant-numeric:tabular-nums]">
                   <span className="truncate">{r.league}</span>
-                  <span className={statusTone[r.status]}>{r.status === 'scheduled' ? `${r.kickoffLabel} KO` : r.status.toUpperCase()}</span>
+                  {(() => {
+                    const ip = inplay?.[r.id];
+                    if (VOIDS[r.id] || ip?.voided) return <span className="text-white/50">ABANDONED · VOID</span>;
+                    if (ip?.ended) {
+                      const res = settleMarketKey(r.marketKey, ip);
+                      return <span className={res === 'won' ? 'text-emerald-300' : res === 'lost' ? 'text-rose-300' : 'text-white/50'}>FT {ip.homeGoals}–{ip.awayGoals}{res === 'won' ? ' ✓' : res === 'lost' ? ' ✗' : ''}</span>;
+                    }
+                    if (ip?.live && ip.feed) return <span className="text-emerald-300">LIVE {ip.homeGoals}–{ip.awayGoals}</span>;
+                    if (r.status === 'scheduled') return <span className="text-white/50">{r.kickoffLabel} KO</span>;
+                    return <span className="text-white/40">result soon…</span>;
+                  })()}
                   <span>Form <b className="text-white/80">{Math.round(r.formScore)}%</b> · price says <b className="text-white/80">{Math.round(r.impliedProbability)}%</b></span>
                 </div>
               </div>
@@ -240,7 +250,7 @@ function FixtureBreakdownPanel({ fixtureId, marketKey, onClose, onAddAlert }: {
 }
 
 /* ── The board: tabs → value cards → quiet chips → table → breakdown ────── */
-export function MarketBoard({ summary, onAddAlert }: { summary: HubSummary; onAddAlert: (k: ValueMarketKey) => void }) {
+export function MarketBoard({ summary, inplay, onAddAlert }: { summary: HubSummary; inplay?: Record<string, InPlayLite>; onAddAlert: (k: ValueMarketKey) => void }) {
   const [family, setFamily] = useState<ValueMarketFamily>('goals');
   const [marketKey, setMarketKey] = useState<ValueMarketKey | null>(null);
   const [breakdown, setBreakdown] = useState<{ fixtureId: string; marketKey: ValueMarketKey } | null>(null);
@@ -283,7 +293,7 @@ export function MarketBoard({ summary, onAddAlert }: { summary: HubSummary; onAd
           </div>
         )}
 
-        {activeKey && <MarketFixtureTable marketKey={activeKey} onRowClick={(fixtureId) => setBreakdown({ fixtureId, marketKey: activeKey })} />}
+        {activeKey && <MarketFixtureTable marketKey={activeKey} inplay={inplay} onRowClick={(fixtureId) => setBreakdown({ fixtureId, marketKey: activeKey })} />}
       </div>
 
       {breakdown && (

--- a/src/hooks/useValueBoard.ts
+++ b/src/hooks/useValueBoard.ts
@@ -7,6 +7,7 @@
  * these later move behind server functions.
  */
 import { useEffect, useMemo, useState } from 'react';
+import { getTodayInPlayIds, type InPlayLite } from '@/lib/valueBoard';
 import {
   getValueHubSummary, getValueMarketFamilies, getValueMarketFixtures,
   getGafferDailyCard, getFixtureValueBreakdown, getLeaguesOn, todayUK,
@@ -36,6 +37,27 @@ export function useFixtureValueBreakdown(fixtureId: string | null, marketKey: Va
 }
 export function useValueBoardLeagues(date?: string) {
   return useMemo(() => getLeaguesOn(date ?? todayUK()), [date]);
+}
+
+/** In-play state for the day's card — explicit ids (the bulk FootyStats feed
+ *  omits whole leagues, so per-id is the only reliable route). One poll serves
+ *  every widget on the page. */
+export function useInPlayAll(enabled = true) {
+  const ids = useMemo(() => getTodayInPlayIds().join(','), []);
+  const [data, setData] = useState<Record<string, InPlayLite>>({});
+  useEffect(() => {
+    if (!enabled || !ids) return;
+    let dead = false;
+    const load = () =>
+      fetch(`/api/inplay?ids=${encodeURIComponent(ids)}`)
+        .then((r) => r.json())
+        .then((j) => { if (!dead && j?.ok && j.data) setData(j.data as Record<string, InPlayLite>); })
+        .catch(() => {});
+    load();
+    const id = setInterval(load, 60_000);
+    return () => { dead = true; clearInterval(id); };
+  }, [enabled, ids]);
+  return data;
 }
 
 /* ── Subscriber state ──────────────────────────────────────────────────────

--- a/src/lib/valueBoard.ts
+++ b/src/lib/valueBoard.ts
@@ -15,6 +15,7 @@
  * quiet days report as quiet, and nothing here ever invents a fixture.
  */
 import rawSnapshot from '@/data/formTablesData.json';
+import rawVoids from '@/data/voids.json';
 import type { FormFixtureRow } from '@/types/footy';
 import { getValueCandidates, type Leg } from '@/lib/gafferSelection';
 import { gafferReason, type PickSignals } from '@/lib/gafferVoice';
@@ -148,6 +149,30 @@ export interface MarketStats {
   hitRate: { hits: number; total: number } | null; // exact line, last-8 both teams
   averages: { label: string; home: number | null; away: number | null; combined: number | null };
   series: number[]; // per-game metric across recent games (chronological-ish)
+}
+
+export const VOIDS = rawVoids as Record<string, { date: string; reason: string }>;
+
+/** Live/final match numbers (shape of /api/inplay entries). */
+export interface InPlayLite {
+  live: boolean; ended: boolean; voided?: boolean; feed?: boolean;
+  goals: number; homeGoals: number; awayGoals: number;
+  corners: number | null; cards: number | null;
+}
+
+/** Settle a market key against real match numbers: 'won' | 'lost' | null. */
+export function settleMarketKey(key: ValueMarketKey, ip: InPlayLite): 'won' | 'lost' | null {
+  const m = MARKET_BY_KEY[key];
+  if (!m) return null;
+  if (m.family === 'btts') {
+    const both = ip.homeGoals > 0 && ip.awayGoals > 0;
+    return (m.side === 'yes' ? both : !both) ? 'won' : 'lost';
+  }
+  const metric = m.family === 'goals' ? ip.goals : m.family === 'corners' ? ip.corners : ip.cards;
+  if (metric == null) return null;
+  const line = Number(m.line);
+  const over = metric > line;
+  return (m.side === 'over' ? over : !over) ? 'won' : 'lost';
 }
 
 /* ── Market definitions (fixed by contract — the ONLY hard-coded part) ──── */
@@ -487,6 +512,21 @@ export function getFixtureValueBreakdown(fixtureId: string, marketKey: ValueMark
     gafferVerdict: gafferReason(signals, `${fixtureId}|${marketKey}|breakdown`),
     riskNote: riskNote(`${fixtureId}|${marketKey}`),
   });
+}
+
+/** Today's fixture ids for live polling — daily-card legs first (they matter
+ *  most), then the rest of the card by kickoff, capped to the API limit. */
+export function getTodayInPlayIds(limit = 20): string[] {
+  const cardIds: string[] = [];
+  {
+    const best = new Map<string, Leg>();
+    for (const l of getValueCandidates()) if (!best.has(l.fixtureId)) best.set(l.fixtureId, l);
+    for (const l of [...best.values()].slice(0, 5)) cardIds.push(l.fixtureId);
+  }
+  const rest = fixturesOn(todayUK())
+    .map((f) => f.id)
+    .filter((id) => !cardIds.includes(id));
+  return [...cardIds, ...rest].slice(0, limit);
 }
 
 /** Leagues present on a date — for table filters. */

--- a/src/pages/ValueBoard.tsx
+++ b/src/pages/ValueBoard.tsx
@@ -7,7 +7,7 @@ import { GafferDailyCardSection } from '@/components/valueboard/GafferDailyCardS
 import { MarketBoard } from '@/components/valueboard/MarketBoard';
 import { EmailAlertPreferences } from '@/components/valueboard/EmailAlertPreferences';
 import { SEOValueExplainer, ResponsibleFooterNote } from '@/components/valueboard/SEOValueExplainer';
-import { useValueHubSummary, useGafferDailyCard, useSubscriberState, useValueBoardRealtime } from '@/hooks/useValueBoard';
+import { useValueHubSummary, useGafferDailyCard, useSubscriberState, useValueBoardRealtime, useInPlayAll } from '@/hooks/useValueBoard';
 import { gafferBoardPrompt, type HubSummary, type ValueMarketKey } from '@/lib/valueBoard';
 
 /** The Gaffer sets the scene on the day's slate — quiet Monday or bumper Saturday. */
@@ -92,6 +92,7 @@ export default function ValueBoard() {
   const card = useGafferDailyCard();
   useValueBoardRealtime(); // contract seat for value-board-updates (no push channel yet)
   const [pendingMarket, setPendingMarket] = useState<ValueMarketKey | null>(null);
+  const inplay = useInPlayAll();
 
   // SEO title + meta description (restored on unmount).
   useEffect(() => {
@@ -128,8 +129,8 @@ export default function ValueBoard() {
             <GafferSlatePrompt summary={summary.data} />
             <SubscriberLockPanel state={subscriberState}>
               <div className="space-y-4 md:space-y-5">
-                <GafferDailyCardSection card={card.data} onEmailCard={() => goToAlerts(null)} />
-                <MarketBoard summary={summary.data} onAddAlert={(k) => goToAlerts(k)} />
+                <GafferDailyCardSection card={card.data} inplay={inplay} onEmailCard={() => goToAlerts(null)} />
+                <MarketBoard summary={summary.data} inplay={inplay} onAddAlert={(k) => goToAlerts(k)} />
                 <EmailAlertPreferences pendingMarket={pendingMarket} onConsumedPending={() => setPendingMarket(null)} />
               </div>
             </SubscriberLockPanel>


### PR DESCRIPTION
The Value Board's statuses were purely time-based (KO + 130 min ⇒ "finished"), so a finished game sat "in play" for up to 40 minutes after the whistle — while the homepage, wired to the live feed, was already showing FT. The board now polls `/api/inplay` with **explicit fixture ids** (the bulk FootyStats feed omits whole leagues — Brann's Eliteserien among them), daily-card legs prioritised, one poll serving every widget on the page.

- **Daily-card selections**: FT score + settled Won ✓ / Lost (corner counts on corners picks), pulsing live score during play, abandoned-void chips, KO time before kickoff
- **Market table rows**: same treatment via a shared `settleMarketKey()` that scores any of the 22 market keys — overs, unders, both BTTS sides — against real match numbers
- Verified against today's card: Brann v Start shows **FT 2–1 · WON ✓** the moment the feed confirms it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3MgUksCLMnJKVmreKAuYo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live match updates across the Value Board, including live scores, full-time results, and abandoned or voided match statuses.
  * Market and selection cards now display outcomes such as won or lost when results are available.
  * Added automatic polling to keep in-play fixture information refreshed.
  * Scheduled fixtures continue to show kickoff details until live data or results become available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->